### PR TITLE
Production reliability: systemd watchdog, self-healing, deploy safeguards

### DIFF
--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -37,3 +37,75 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: node cli/dist/index.js feed health --direct --json
+
+      - name: Check public endpoint
+        run: |
+          if curl -sf --max-time 10 https://feed.corgi.network/health/live > /dev/null 2>&1; then
+            echo "Public health endpoint OK"
+          else
+            echo "Public health endpoint unreachable"
+            exit 1
+          fi
+
+      - name: Ping health monitor on success
+        if: success()
+        env:
+          HC_URL: ${{ secrets.HEALTHCHECK_PING_URL }}
+        run: |
+          if [ -n "${HC_URL:-}" ]; then
+            curl -fsS "${HC_URL}" || true
+          fi
+
+      - name: Alert health monitor on failure
+        if: failure()
+        env:
+          HC_URL: ${{ secrets.HEALTHCHECK_PING_URL }}
+        run: |
+          if [ -n "${HC_URL:-}" ]; then
+            curl -fsS "${HC_URL}/fail" || true
+          fi
+
+      - name: Create GitHub issue on failure
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const today = new Date().toISOString().split('T')[0];
+            const title = 'Feed Health Alert - ' + today;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'incident',
+              per_page: 10,
+            });
+
+            const alreadyOpen = existing.data.some(i => i.title === title);
+            if (alreadyOpen) {
+              console.log('Issue already exists for today, skipping');
+              return;
+            }
+
+            const runUrl = [
+              context.serverUrl,
+              context.repo.owner,
+              context.repo.repo,
+              'actions/runs',
+              context.runId,
+            ].join('/');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: [
+                'The daily health check workflow failed.',
+                '',
+                '**Run:** ' + runUrl,
+                '**Time:** ' + new Date().toISOString(),
+                '',
+                'Check the workflow logs for details.',
+              ].join('\n'),
+              labels: ['incident'],
+            });

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,15 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          script_stop: true
+          command_timeout: 10m
           script: |
+            set -euo pipefail
             cd /opt/bluesky-feed
+
+            # Save current commit for rollback
+            PREV_COMMIT=$(git rev-parse HEAD)
+
             git pull origin main
             npm ci --ignore-scripts
             npm audit --audit-level=high
@@ -29,3 +36,49 @@ jobs:
             cd cli && npm ci && npx tsc
             cd ..
             sudo systemctl restart bluesky-feed
+
+            # Post-deploy health verification (3 retries, 10s apart)
+            echo "Waiting 10s for startup..."
+            sleep 10
+            HEALTHY=false
+            for i in 1 2 3; do
+              if curl -sf --max-time 5 http://localhost:3001/health/ready > /dev/null 2>&1; then
+                echo "Health check passed (attempt $i/3)"
+                HEALTHY=true
+                break
+              fi
+              echo "Health check failed (attempt $i/3)"
+              sleep 10
+            done
+
+            if [ "$HEALTHY" = "false" ]; then
+              echo "DEPLOY FAILED: service unhealthy after restart"
+              echo "Rolling back to $PREV_COMMIT..."
+              git checkout "$PREV_COMMIT"
+              npm run build
+              sudo systemctl restart bluesky-feed
+              sleep 5
+              echo "Rollback complete. Current health:"
+              curl -s http://localhost:3001/health || echo "Still unhealthy after rollback"
+              exit 1
+            fi
+
+            echo "Deploy successful"
+
+      - name: Ping health monitor on success
+        if: success()
+        env:
+          HC_URL: ${{ secrets.HEALTHCHECK_PING_URL }}
+        run: |
+          if [ -n "${HC_URL:-}" ]; then
+            curl -fsS "${HC_URL}" || true
+          fi
+
+      - name: Alert on deploy failure
+        if: failure()
+        env:
+          HC_URL: ${{ secrets.HEALTHCHECK_PING_URL }}
+        run: |
+          if [ -n "${HC_URL:-}" ]; then
+            curl -fsS "${HC_URL}/fail" || true
+          fi

--- a/ops/bluesky-feed.service
+++ b/ops/bluesky-feed.service
@@ -1,0 +1,71 @@
+# Community Feed Generator — systemd unit file
+#
+# Install: cp ops/bluesky-feed.service /etc/systemd/system/ && systemctl daemon-reload
+# Enable:  systemctl enable bluesky-feed
+# Start:   systemctl start bluesky-feed
+# Logs:    journalctl -u bluesky-feed -f
+
+[Unit]
+Description=Community Feed Generator (Bluesky)
+Documentation=https://github.com/corgi-network/bluesky-feed
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=notify
+NotifyAccess=main
+
+# Working directory and environment
+WorkingDirectory=/opt/bluesky-feed
+EnvironmentFile=/opt/bluesky-feed/.env
+Environment=NODE_ENV=production
+Environment=NODE_OPTIONS=--max-old-space-size=896
+
+# Start the application (sends READY=1 via sd_notify after listen())
+ExecStart=/usr/bin/node dist/index.js
+
+# Watchdog: process must send WATCHDOG=1 every 60s or systemd kills it.
+# The app sends heartbeats every 30s (half of WatchdogSec) only when
+# database AND Redis health checks pass. If dependencies are down for
+# >60s the process is killed and restarted automatically.
+WatchdogSec=60
+
+# Restart policy: auto-restart on crash or watchdog timeout.
+# RestartSec adds a 5s delay to avoid rapid restart loops.
+Restart=on-failure
+RestartSec=5
+
+# Crash loop protection: if the service fails 5 times in 5 minutes,
+# stop trying. Manual intervention is needed at that point.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+# Memory limits (cgroup v2): cap before OOM killer strikes.
+# MemoryHigh is a soft limit that triggers throttling.
+# MemoryMax is a hard limit that triggers OOM kill.
+# NODE_OPTIONS --max-old-space-size=896 keeps V8 heap below MemoryMax.
+MemoryHigh=768M
+MemoryMax=1G
+
+# Graceful shutdown: SIGTERM triggers the app's shutdown handler,
+# which drains HTTP, saves Jetstream cursor, closes DB/Redis.
+# 30s matches the app's SHUTDOWN_TIMEOUT_MS.
+TimeoutStopSec=35
+KillSignal=SIGTERM
+KillMode=mixed
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/bluesky-feed
+PrivateTmp=true
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bluesky-feed
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/health-watchdog
+++ b/ops/health-watchdog
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# External health watchdog — belt-and-suspenders alongside in-process watchdog.
+#
+# Checks /health/ready up to 3 times with 10s gaps.
+# If all 3 fail, restarts bluesky-feed via systemctl.
+#
+# Intended to run as a systemd timer (health-watchdog.timer) every 5 minutes.
+# Logs all actions to syslog via logger(1).
+#
+# Usage: ops/health-watchdog
+set -euo pipefail
+
+SERVICE="bluesky-feed"
+HEALTH_URL="http://localhost:3001/health/ready"
+MAX_RETRIES=3
+RETRY_DELAY=10
+TAG="health-watchdog"
+
+log_info()  { logger -t "$TAG" -p user.info  "$1"; }
+log_warn()  { logger -t "$TAG" -p user.warning "$1"; }
+log_err()   { logger -t "$TAG" -p user.err "$1"; }
+
+# Check if the service is even running
+if ! systemctl is-active --quiet "$SERVICE"; then
+  log_warn "$SERVICE is not active — skipping health check (systemd will handle restart)"
+  exit 0
+fi
+
+# Try health check with retries
+failures=0
+for attempt in $(seq 1 "$MAX_RETRIES"); do
+  if curl -sf --max-time 5 "$HEALTH_URL" > /dev/null 2>&1; then
+    log_info "Health check passed (attempt $attempt/$MAX_RETRIES)"
+    exit 0
+  fi
+  failures=$((failures + 1))
+  log_warn "Health check failed (attempt $attempt/$MAX_RETRIES)"
+  if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+    sleep "$RETRY_DELAY"
+  fi
+done
+
+# All retries exhausted — restart the service
+log_err "Health check failed $failures/$MAX_RETRIES times — restarting $SERVICE"
+systemctl restart "$SERVICE"
+log_info "$SERVICE restarted by health watchdog"

--- a/ops/health-watchdog.service
+++ b/ops/health-watchdog.service
@@ -1,0 +1,13 @@
+# Health watchdog oneshot service — runs the health check script.
+# Triggered by health-watchdog.timer every 5 minutes.
+#
+# Install: cp ops/health-watchdog.service /etc/systemd/system/
+
+[Unit]
+Description=Bluesky Feed Health Watchdog
+After=bluesky-feed.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bluesky-feed/ops/health-watchdog
+TimeoutStartSec=120

--- a/ops/health-watchdog.timer
+++ b/ops/health-watchdog.timer
@@ -1,0 +1,21 @@
+# Health watchdog timer — runs the health check every 5 minutes.
+#
+# Install:
+#   cp ops/health-watchdog.timer /etc/systemd/system/
+#   systemctl daemon-reload
+#   systemctl enable --now health-watchdog.timer
+#
+# Verify:
+#   systemctl list-timers health-watchdog.timer
+#   journalctl -t health-watchdog --since "1 hour ago"
+
+[Unit]
+Description=Bluesky Feed Health Watchdog Timer
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/ops/install.sh
+++ b/ops/install.sh
@@ -1,20 +1,62 @@
 #!/usr/bin/env bash
-# Install ops scripts on the VPS
+# Install ops scripts and systemd units on the VPS.
 # Run from local: ssh root@64.23.239.212 'bash -s' < ops/install.sh
 # Or from VPS:    cd /opt/bluesky-feed && bash ops/install.sh
 set -euo pipefail
 
-SCRIPTS="db redis logs deploy feed-check status"
+APP_DIR="/opt/bluesky-feed"
+
+# ── Make ops scripts executable ──────────────────────────────────
+SCRIPTS="db redis logs deploy feed-check status health-watchdog"
 for script in $SCRIPTS; do
-  chmod +x "/opt/bluesky-feed/ops/$script"
-  echo "✓ ops/$script"
+  if [ -f "$APP_DIR/ops/$script" ]; then
+    chmod +x "$APP_DIR/ops/$script"
+    echo "✓ ops/$script"
+  fi
 done
 
+# ── Install systemd service file ─────────────────────────────────
 echo ""
-echo "Ops scripts installed. Usage from VPS:"
+echo "=== Installing systemd units ==="
+
+# Main application service
+if [ -f "$APP_DIR/ops/bluesky-feed.service" ]; then
+  cp "$APP_DIR/ops/bluesky-feed.service" /etc/systemd/system/bluesky-feed.service
+  echo "✓ bluesky-feed.service"
+fi
+
+# Health watchdog timer
+if [ -f "$APP_DIR/ops/health-watchdog.service" ]; then
+  cp "$APP_DIR/ops/health-watchdog.service" /etc/systemd/system/health-watchdog.service
+  echo "✓ health-watchdog.service"
+fi
+
+if [ -f "$APP_DIR/ops/health-watchdog.timer" ]; then
+  cp "$APP_DIR/ops/health-watchdog.timer" /etc/systemd/system/health-watchdog.timer
+  echo "✓ health-watchdog.timer"
+fi
+
+# Reload systemd and enable units
+systemctl daemon-reload
+echo "✓ systemctl daemon-reload"
+
+systemctl enable bluesky-feed 2>/dev/null || true
+echo "✓ bluesky-feed enabled"
+
+systemctl enable --now health-watchdog.timer 2>/dev/null || true
+echo "✓ health-watchdog.timer enabled"
+
+# ── Summary ──────────────────────────────────────────────────────
+echo ""
+echo "Installation complete. Usage:"
 echo "  ops/db \"SELECT COUNT(*) FROM posts\""
 echo "  ops/redis GET feed:count"
 echo "  ops/logs -f"
 echo "  ops/deploy"
 echo "  ops/feed-check 50"
 echo "  ops/status"
+echo ""
+echo "Systemd units:"
+echo "  systemctl status bluesky-feed"
+echo "  systemctl list-timers health-watchdog.timer"
+echo "  journalctl -t health-watchdog --since '1 hour ago'"

--- a/ops/setup-monitoring.sh
+++ b/ops/setup-monitoring.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# External Monitoring Setup Guide
+#
+# This script prints setup instructions for external uptime monitoring.
+# It does NOT create accounts automatically — you set them up manually.
+#
+# Two complementary services (both free tier):
+# 1. UptimeRobot — pings /health/live every 5 min, emails on failure
+# 2. Healthchecks.io — expects daily ping from GitHub Actions, alerts if missed
+#
+# Usage: bash ops/setup-monitoring.sh
+set -euo pipefail
+
+cat << 'GUIDE'
+╔══════════════════════════════════════════════════════════════════╗
+║           External Monitoring Setup Guide                       ║
+╚══════════════════════════════════════════════════════════════════╝
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. UptimeRobot (real-time uptime monitoring)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+What: Pings your feed every 5 minutes, emails you if it goes down.
+Free tier: 50 monitors, 5-minute interval.
+
+Setup:
+  1. Go to https://uptimerobot.com and create a free account
+  2. Click "Add New Monitor"
+  3. Configure:
+     - Monitor Type: HTTP(s)
+     - Friendly Name: Corgi Feed
+     - URL: https://feed.corgi.network/health/live
+     - Monitoring Interval: 5 minutes
+  4. Add your email as an alert contact
+  5. Save
+
+What it catches:
+  ✓ Server completely down
+  ✓ Nginx/TLS issues
+  ✓ DNS resolution failures
+  ✓ HTTP hangs (timeout-based detection)
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+2. Healthchecks.io (cron/pipeline monitoring)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+What: Expects a daily ping from your GitHub Actions health check.
+      If no ping arrives within 24h, it emails you.
+Free tier: 20 checks, 3-month retention.
+
+Setup:
+  1. Go to https://healthchecks.io and create a free account
+  2. Create a new check:
+     - Name: Corgi Daily Health
+     - Period: 1 day
+     - Grace: 1 hour
+  3. Copy the ping URL (looks like: https://hc-ping.com/xxxxxxxx-...)
+  4. Add it as a GitHub Actions secret:
+     - Go to your repo → Settings → Secrets → Actions
+     - Create: HEALTHCHECK_PING_URL = <your ping URL>
+  5. The daily-health.yml workflow will ping it automatically
+
+What it catches:
+  ✓ GitHub Actions workflow failures
+  ✓ Database connectivity issues (caught by CLI health check)
+  ✓ Silent failures where the cron job itself stops running
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+3. GitHub Secrets Required
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+After setup, add this secret to your GitHub repo:
+
+  HEALTHCHECK_PING_URL  — The ping URL from Healthchecks.io
+
+The deploy and daily-health workflows will use this automatically.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+4. Verify
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  # Test UptimeRobot:
+  # Check the UptimeRobot dashboard — should show "Up" status
+
+  # Test Healthchecks.io (manual ping):
+  # curl -fsS https://hc-ping.com/YOUR-UUID-HERE
+
+  # Test failure alert:
+  # Pause UptimeRobot monitor, wait 5 min → should get email
+  # Skip a daily health run → Healthchecks.io alerts after 25h
+
+GUIDE

--- a/package-lock.json
+++ b/package-lock.json
@@ -878,6 +878,22 @@
         "fast-uri": "^3.0.0"
       }
     },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@fastify/cors": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
@@ -1800,6 +1816,22 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
@@ -2788,22 +2820,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
@@ -2819,6 +2835,22 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -4298,6 +4330,22 @@
         "fast-uri": "^3.0.0",
         "json-schema-ref-resolver": "^3.0.0",
         "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/fast-querystring": {

--- a/package.json
+++ b/package.json
@@ -79,5 +79,8 @@
     "community-governance",
     "algorithmic-transparency",
     "typescript"
-  ]
+  ],
+  "overrides": {
+    "ajv": "8.17.1"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
 import { loadTaxonomy, loadTopicEmbeddings } from './scoring/topics/taxonomy.js';
 import { initEmbedder } from './scoring/topics/embedder.js';
 import { loadGovernanceGateWeights } from './ingestion/governance-gate.js';
+import { sdNotifyReady, startWatchdog, stopWatchdog } from './lib/watchdog.js';
 
 async function main() {
   logger.info('Starting Community Feed Generator...');
@@ -48,6 +49,9 @@ async function main() {
       { port: config.FEEDGEN_PORT, host: config.FEEDGEN_LISTENHOST },
       'Feed generator server started'
     );
+
+    // Tell systemd we're ready (Type=notify). No-op outside systemd.
+    sdNotifyReady();
   } catch (err) {
     logger.fatal({ err }, 'Failed to start HTTP server');
     process.exit(1);
@@ -152,20 +156,26 @@ async function main() {
     process.exit(1);
   }
 
-  // 7. Register graceful shutdown handlers
+  // 7. Start systemd watchdog heartbeat (no-op outside systemd).
+  // Sends WATCHDOG=1 every 30s only when DB + Redis are healthy.
+  // If both are down for >60s, systemd kills and restarts us.
+  startWatchdog();
+
+  // 8. Register graceful shutdown handlers
   registerShutdownHandlers({
     server: app,
     stopScoring,
     stopJetstream,
     stopEpochScheduler,
     stopMaintenanceWorkerSupervisor,
+    stopWatchdog,
     // Kept for backwards compatibility in shutdown flow.
     stopCleanup,
     stopInteractionLogger,
     stopInteractionAggregator,
   });
 
-  // 8. Log startup complete
+  // 9. Log startup complete
   logger.info({
     serviceDid: config.FEEDGEN_SERVICE_DID,
     publisherDid: config.FEEDGEN_PUBLISHER_DID,

--- a/src/lib/shutdown.ts
+++ b/src/lib/shutdown.ts
@@ -2,7 +2,7 @@
  * Graceful Shutdown Module
  *
  * Handles clean shutdown of all system components with a timeout.
- * Order: HTTP server → Scoring → Jetstream → Epoch Scheduler → Maintenance Worker Supervisor → Cleanup → Interaction Logger → Interaction Aggregator → Database → Redis
+ * Order: Watchdog → HTTP server → Scoring → Jetstream → Epoch Scheduler → Maintenance Worker Supervisor → Cleanup → Interaction Logger → Interaction Aggregator → Database → Redis
  */
 
 import type { FastifyInstance } from 'fastify';
@@ -19,6 +19,7 @@ export interface ShutdownDependencies {
   stopJetstream: () => Promise<void>;
   stopEpochScheduler?: () => void;
   stopMaintenanceWorkerSupervisor?: () => Promise<void>;
+  stopWatchdog?: () => void;
   stopCleanup?: () => Promise<void>;
   stopInteractionLogger?: () => Promise<void>;
   stopInteractionAggregator?: () => Promise<void>;
@@ -47,6 +48,11 @@ export async function gracefulShutdown(deps: ShutdownDependencies): Promise<void
   }, SHUTDOWN_TIMEOUT_MS);
 
   try {
+    // 0. Stop watchdog heartbeat (prevent systemd kill during shutdown)
+    if (deps.stopWatchdog) {
+      deps.stopWatchdog();
+    }
+
     // 1. Stop accepting new HTTP requests (drain existing)
     logger.info('Closing HTTP server...');
     await deps.server.close();

--- a/src/lib/watchdog.ts
+++ b/src/lib/watchdog.ts
@@ -1,0 +1,112 @@
+/**
+ * Systemd Watchdog Integration
+ *
+ * Sends sd_notify messages to systemd via systemd-notify(1):
+ * - READY=1     — signals successful startup (Type=notify)
+ * - WATCHDOG=1  — heartbeat (must arrive within WatchdogSec or systemd kills us)
+ *
+ * If NOTIFY_SOCKET is not set (dev, Docker, tests) all calls are silent no-ops.
+ * Uses execFile (not exec) with hardcoded args — no shell injection risk.
+ */
+
+import { execFile } from 'node:child_process';
+import { logger } from './logger.js';
+import { isReady } from './health.js';
+
+const NOTIFY_SOCKET = process.env.NOTIFY_SOCKET;
+
+/**
+ * Send a watchdog heartbeat to systemd via systemd-notify(1).
+ * No-op if NOTIFY_SOCKET is not set (non-systemd environments).
+ */
+function sdNotifyWatchdog(): void {
+  if (!NOTIFY_SOCKET) return;
+
+  // execFile with hardcoded args — safe, no shell injection possible
+  execFile('systemd-notify', ['WATCHDOG=1'], (err) => {
+    if (err) {
+      logger.warn({ err }, 'sd_notify WATCHDOG=1 failed');
+    }
+  });
+}
+
+/**
+ * Tell systemd the service is ready to accept connections.
+ * Call once after HTTP server is listening.
+ */
+export function sdNotifyReady(): void {
+  if (!NOTIFY_SOCKET) return;
+
+  // execFile with hardcoded args — safe, no shell injection possible
+  execFile('systemd-notify', ['--ready'], (err) => {
+    if (err) {
+      logger.warn({ err }, 'sd_notify READY=1 failed');
+    } else {
+      logger.info('sd_notify: READY=1 sent to systemd');
+    }
+  });
+}
+
+/**
+ * Send a single watchdog heartbeat.
+ * Only sends if health checks pass (DB + Redis healthy).
+ */
+async function sendHeartbeat(): Promise<void> {
+  try {
+    const healthy = await isReady();
+    if (healthy) {
+      sdNotifyWatchdog();
+    } else {
+      logger.warn('Watchdog heartbeat skipped — service not ready (DB or Redis unhealthy)');
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Watchdog heartbeat check failed');
+    // Don't send heartbeat on error — let systemd kill us if this persists
+  }
+}
+
+// Interval handle for cleanup during shutdown
+let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the watchdog heartbeat loop.
+ *
+ * Sends WATCHDOG=1 every 30s (half of WatchdogSec=60 in the service file).
+ * If isReady() returns false, the heartbeat is skipped. Two consecutive
+ * skips (60s) cause systemd to kill the process, and Restart=on-failure
+ * brings it back.
+ *
+ * No-op if NOTIFY_SOCKET is not set.
+ */
+export function startWatchdog(): void {
+  if (!NOTIFY_SOCKET) {
+    logger.debug('NOTIFY_SOCKET not set — watchdog disabled (non-systemd environment)');
+    return;
+  }
+
+  // Send heartbeat every 30s (half of WatchdogSec=60)
+  const HEARTBEAT_INTERVAL_MS = 30_000;
+
+  heartbeatInterval = setInterval(() => {
+    sendHeartbeat().catch((err) => {
+      logger.error({ err }, 'Watchdog heartbeat loop error');
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+
+  // Don't prevent process exit
+  heartbeatInterval.unref();
+
+  logger.info({ intervalMs: HEARTBEAT_INTERVAL_MS }, 'Watchdog heartbeat started');
+}
+
+/**
+ * Stop the watchdog heartbeat loop.
+ * Called during graceful shutdown.
+ */
+export function stopWatchdog(): void {
+  if (heartbeatInterval) {
+    clearInterval(heartbeatInterval);
+    heartbeatInterval = null;
+    logger.debug('Watchdog heartbeat stopped');
+  }
+}

--- a/tests/watchdog.test.ts
+++ b/tests/watchdog.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { isReadyMock } = vi.hoisted(() => ({
+  isReadyMock: vi.fn(),
+}));
+
+vi.mock('../src/lib/health.js', () => ({
+  isReady: isReadyMock,
+}));
+
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+import { sdNotifyReady, startWatchdog, stopWatchdog } from '../src/lib/watchdog.js';
+
+describe('watchdog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // Remove NOTIFY_SOCKET from env for test isolation
+    delete process.env.NOTIFY_SOCKET;
+  });
+
+  afterEach(() => {
+    stopWatchdog();
+    vi.useRealTimers();
+  });
+
+  it('sdNotifyReady is a no-op without NOTIFY_SOCKET', () => {
+    // Should not throw when NOTIFY_SOCKET is not set
+    expect(() => sdNotifyReady()).not.toThrow();
+  });
+
+  it('startWatchdog is a no-op without NOTIFY_SOCKET', () => {
+    // Should not throw or start intervals when NOTIFY_SOCKET is not set
+    expect(() => startWatchdog()).not.toThrow();
+  });
+
+  it('stopWatchdog is safe to call even if not started', () => {
+    expect(() => stopWatchdog()).not.toThrow();
+  });
+
+  it('stopWatchdog can be called multiple times', () => {
+    expect(() => {
+      stopWatchdog();
+      stopWatchdog();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Prevents silent outages like the recent CORS hang where the Node process stayed alive but stopped serving HTTP — systemd reported "active (running)" while the feed was completely down for days.

- **Systemd watchdog** (`Type=notify`, `WatchdogSec=60`): in-process heartbeat only fires when `isReady()` passes (DB + Redis healthy). Two missed beats → systemd kills and restarts the process automatically.
- **External health-watchdog timer**: bash script checks `/health/ready` every 5 minutes with 3 retries. Restarts the service if all fail. Belt-and-suspenders alongside the in-process watchdog.
- **Post-deploy health verification**: deploy workflow checks `/health/ready` after restart, auto-rolls back to previous commit on failure.
- **Alerting**: daily-health workflow pings healthchecks.io and auto-creates a GitHub Issue on failure. Setup guide for UptimeRobot external monitoring included.
- **Memory limits**: systemd `MemoryMax=1G` + `MemoryHigh=768M` + `NODE_OPTIONS=--max-old-space-size=896` — kills before OOM killer strikes.
- **Crash loop protection**: `StartLimitBurst=5` in 5 minutes, then stop (manual intervention needed).
- **ajv pin**: `overrides` pins ajv@8.17.1 to fix `@fastify/ajv-compiler` compat (fixes 22 of 25 previously broken tests).

## Files changed

| File | What |
|------|------|
| `ops/bluesky-feed.service` | New systemd unit (tracked in repo) |
| `src/lib/watchdog.ts` | sd_notify heartbeat via `systemd-notify(1)` |
| `src/index.ts` | Watchdog integration (ready + heartbeat + shutdown) |
| `src/lib/shutdown.ts` | Stop watchdog first during graceful shutdown |
| `ops/health-watchdog` | External health check script |
| `ops/health-watchdog.{service,timer}` | Systemd timer for health check |
| `ops/setup-monitoring.sh` | UptimeRobot + Healthchecks.io setup guide |
| `ops/install.sh` | Installs systemd units on VPS |
| `.github/workflows/deploy.yml` | Post-deploy health check + rollback |
| `.github/workflows/daily-health.yml` | Failure alerting (ping + GitHub Issue) |
| `package.json` | ajv@8.17.1 override |
| `tests/watchdog.test.ts` | Watchdog no-op tests |

## Test plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `npm test` — 64 passed, 3 failed (pre-existing `@atproto/xrpc-server` issue, not related)
- [x] Watchdog tests pass (no-op when `NOTIFY_SOCKET` unset)
- [ ] After merge: `ssh corgi-vps 'cd /opt/bluesky-feed && bash ops/install.sh'` to install systemd units
- [ ] Verify: `systemctl show bluesky-feed | grep -E "Watchdog|Restart|Memory"`
- [ ] Simulate: stop Redis for >60s, confirm auto-restart
- [ ] Verify health timer: `systemctl list-timers health-watchdog.timer`
- [ ] End-to-end: `curl https://feed.corgi.network/health` returns OK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes production deployment/restart behavior (systemd `Type=notify` watchdog heartbeats, external restart timer, and automated rollback) and modifies CI workflows that can now fail deployments/raise incidents based on health endpoints.
> 
> **Overview**
> Improves production self-healing and monitoring by adding **systemd watchdog integration**: the app now sends `sd_notify --ready` after binding the HTTP port and periodically emits `WATCHDOG=1` only when `isReady()` (DB + Redis) passes, stopping the heartbeat first during graceful shutdown.
> 
> Hardens ops and delivery: introduces a new `ops/bluesky-feed.service` with watchdog/memory/restart limits, adds an external `health-watchdog` systemd timer that restarts the service when `/health/ready` repeatedly fails, and updates `ops/install.sh` to install/enable these units.
> 
> Tightens CI/CD safety and alerting: the deploy workflow now verifies `/health/ready` post-restart with retries and auto-rolls back on failure, while the daily health workflow adds a public endpoint check, pings Healthchecks.io on success/failure, and opens a labeled GitHub issue on failures. Also pins `ajv` via `package.json` `overrides` (lockfile updated) and adds basic no-op tests for the watchdog module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d5721deec227e508f9f40fda6288bc76e3b1c30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->