### PR TITLE
Fix crash loop protection placement and deploy rollback deps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
               echo "DEPLOY FAILED: service unhealthy after restart"
               echo "Rolling back to $PREV_COMMIT..."
               git checkout "$PREV_COMMIT"
+              npm ci --ignore-scripts
               npm run build
               sudo systemctl restart bluesky-feed
               sleep 5

--- a/ops/bluesky-feed.service
+++ b/ops/bluesky-feed.service
@@ -12,6 +12,12 @@ After=network-online.target docker.service
 Wants=network-online.target
 Requires=docker.service
 
+# Crash loop protection: if the service fails 5 times in 5 minutes,
+# stop trying. Manual intervention is needed at that point.
+# NOTE: These MUST be in [Unit], not [Service] (systemd v229+).
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
 [Service]
 Type=notify
 NotifyAccess=main
@@ -35,11 +41,6 @@ WatchdogSec=60
 # RestartSec adds a 5s delay to avoid rapid restart loops.
 Restart=on-failure
 RestartSec=5
-
-# Crash loop protection: if the service fails 5 times in 5 minutes,
-# stop trying. Manual intervention is needed at that point.
-StartLimitIntervalSec=300
-StartLimitBurst=5
 
 # Memory limits (cgroup v2): cap before OOM killer strikes.
 # MemoryHigh is a soft limit that triggers throttling.


### PR DESCRIPTION
## Summary

Fixes two bugs caught by Cursor Bugbot review on #25:

- **`StartLimitIntervalSec`/`StartLimitBurst` in wrong section**: Moved from `[Service]` to `[Unit]`. Since systemd v229 (2016), these directives are silently ignored in `[Service]` — crash loop protection was not actually working.
- **Deploy rollback missing `npm ci`**: Rollback path now reinstalls dependencies before rebuilding, so `node_modules` matches the reverted `package-lock.json` instead of keeping stale deps from the failed deploy.

## Test plan

- [x] Service file validates (`systemd-analyze verify` on VPS after install)
- [x] Rollback path: `git checkout` → `npm ci` → `npm run build` → restart

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational/config-only changes that improve rollback correctness and service resilience, with minimal runtime behavior impact beyond restart/rollback handling.
> 
> **Overview**
> Ensures systemd crash-loop protection actually takes effect by moving `StartLimitIntervalSec`/`StartLimitBurst` from `[Service]` to `[Unit]` in `ops/bluesky-feed.service`.
> 
> Hardens the GitHub Actions deploy rollback path by running `npm ci --ignore-scripts` after `git checkout` so the rebuilt app uses dependency versions matching the reverted `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a97334c6d262d7efb549379c80bc92861cd775a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->