### PR TITLE
report: deterministic HTML->PDF pipeline + layout hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "cli:build": "cd cli && tsc",
     "seed-topics": "tsx scripts/seed-topics.ts",
     "backfill-topics": "tsx scripts/backfill-topics.ts",
+    "report:pdf": "python3 scripts/generate-report-pdf.py",
+    "build:mcp-local": "cd src/mcp-local && npx tsc -p tsconfig.json",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/generate-report-pdf.py
+++ b/scripts/generate-report-pdf.py
@@ -27,7 +27,7 @@ import json
 import os
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import pandas as pd
@@ -1005,24 +1005,26 @@ def render_pdf_with_playwright(
 
     with sync_playwright() as p:
         browser = p.chromium.launch()
-        page = browser.new_page()
-        page.set_content(html_content, wait_until="networkidle")
-        page.pdf(
-            path=output_pdf,
-            format="Letter",
-            print_background=True,
-            display_header_footer=True,
-            header_template=header_template,
-            footer_template=footer_template,
-            margin={
-                "top": "0.75in",
-                "bottom": "0.70in",
-                "left": "0.55in",
-                "right": "0.55in",
-            },
-            prefer_css_page_size=False,
-        )
-        browser.close()
+        try:
+            page = browser.new_page()
+            page.set_content(html_content, wait_until="networkidle")
+            page.pdf(
+                path=output_pdf,
+                format="Letter",
+                print_background=True,
+                display_header_footer=True,
+                header_template=header_template,
+                footer_template=footer_template,
+                margin={
+                    "top": "0.75in",
+                    "bottom": "0.70in",
+                    "left": "0.55in",
+                    "right": "0.55in",
+                },
+                prefer_css_page_size=False,
+            )
+        finally:
+            browser.close()
 
 
 def print_dry_run(df: pd.DataFrame, epoch: dict[str, Any], stats: dict[str, Any]) -> None:
@@ -1076,8 +1078,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    date_label = args.date or datetime.now().strftime("%B %d, %Y")
-    date_slug = datetime.now().strftime("%b%d").lower()
+    now_utc = datetime.now(timezone.utc)
+    date_label = args.date or now_utc.strftime("%B %d, %Y")
+    date_slug = now_utc.strftime("%b%d").lower()
     output_path = args.output or f"reports/sprint-data-analysis-{date_slug}.pdf"
 
     if args.csv:

--- a/scripts/generate-report-pdf.py
+++ b/scripts/generate-report-pdf.py
@@ -31,6 +31,7 @@ from datetime import datetime
 from typing import Any
 
 import pandas as pd
+from report_utils import format_int
 
 # Keep matplotlib cache writable in restricted environments.
 os.environ.setdefault("MPLCONFIGDIR", "/tmp")
@@ -148,15 +149,6 @@ SELECT row_to_json(s) FROM (
 # Data Helpers
 # ---------------------------------------------------------------------------
 
-
-def format_int(value: Any) -> str:
-    """Format integer-like values with thousands separators."""
-    try:
-        return f"{int(value):,}"
-    except (TypeError, ValueError):
-        return str(value)
-
-
 def format_float(value: Any, precision: int = 3) -> str:
     """Format float safely with configurable precision."""
     try:
@@ -204,12 +196,21 @@ def fetch_from_vps() -> tuple[pd.DataFrame, dict[str, Any], dict[str, Any]]:
         f'&& docker exec bluesky-feed-postgres psql -U feed -d bluesky_feed -t -A -c "{STATS_SQL}"'
     )
     print("Connecting to VPS and pulling data...")
-    result = subprocess.run(
-        ["ssh", "corgi-vps", combined_cmd],
-        capture_output=True,
-        text=True,
-        timeout=90,
-    )
+    try:
+        result = subprocess.run(
+            ["ssh", "corgi-vps", combined_cmd],
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        print(
+            f"SSH command timed out after {exc.timeout} seconds while pulling report data.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     if result.returncode != 0:
         print(f"SSH failed (exit {result.returncode}):", file=sys.stderr)
         print(result.stderr, file=sys.stderr)
@@ -246,16 +247,38 @@ def load_from_csv(
     csv_path: str, epoch_json_path: str | None = None
 ) -> tuple[pd.DataFrame, dict[str, Any], dict[str, Any]]:
     """Load report data from local files for offline generation."""
-    df = pd.read_csv(csv_path)
+    try:
+        df = pd.read_csv(csv_path)
+    except FileNotFoundError:
+        print(f"CSV file not found: {csv_path}", file=sys.stderr)
+        sys.exit(1)
+    except pd.errors.ParserError as exc:
+        print(f"Failed to parse CSV '{csv_path}': {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to load CSV '{csv_path}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
     epoch: dict[str, Any] = {}
     stats: dict[str, Any] = {
         "total_posts": len(df),
         "last_24h": 0,
         "scored_count": len(df),
     }
-    if epoch_json_path and os.path.exists(epoch_json_path):
-        with open(epoch_json_path, encoding="utf-8") as f:
-            epoch = json.load(f)
+    if epoch_json_path:
+        try:
+            with open(epoch_json_path, encoding="utf-8") as f:
+                epoch = json.load(f)
+        except FileNotFoundError:
+            print(f"Epoch JSON file not found: {epoch_json_path}", file=sys.stderr)
+            sys.exit(1)
+        except json.JSONDecodeError as exc:
+            print(f"Failed to parse epoch JSON '{epoch_json_path}': {exc}", file=sys.stderr)
+            sys.exit(1)
+        except Exception as exc:  # noqa: BLE001
+            print(f"Failed to load epoch JSON '{epoch_json_path}': {exc}", file=sys.stderr)
+            sys.exit(1)
+
     return df, epoch, stats
 
 
@@ -1065,6 +1088,27 @@ def main() -> None:
 
     if len(df) == 0:
         print("No data returned. Check VPS connectivity and epoch state.", file=sys.stderr)
+        sys.exit(1)
+
+    required_columns = {
+        "topics",
+        "author_did",
+        "total_score",
+        "classification_method",
+        "relevance_score",
+        "likes",
+        "reposts",
+        "replies",
+        *SCORE_COMPONENTS,
+        *WEIGHT_COLUMNS,
+    }
+    missing_columns = sorted(required_columns - set(df.columns))
+    if missing_columns:
+        print(
+            "Missing required columns in data: "
+            + ", ".join(missing_columns),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     df["primary_topic"] = df["topics"].apply(extract_primary_topic)

--- a/scripts/generate-report-pdf.py
+++ b/scripts/generate-report-pdf.py
@@ -1,0 +1,1094 @@
+#!/usr/bin/env python3
+"""
+Feed Quality Analysis PDF Report Generator
+
+Generates a print-friendly PDF report from live feed data using:
+1) SQL data pulls from VPS (or local CSV),
+2) structured HTML + CSS paged layout,
+3) Playwright Chromium PDF rendering.
+
+This approach avoids Word layout unpredictability and provides deterministic
+pagination for future reports with varying data sizes.
+
+Usage:
+    python3 scripts/generate-report-pdf.py
+    python3 scripts/generate-report-pdf.py --date "March 15, 2026"
+    python3 scripts/generate-report-pdf.py --output reports/my-report.pdf
+    python3 scripts/generate-report-pdf.py --csv data.csv --epoch-json epoch.json
+    python3 scripts/generate-report-pdf.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import io
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+
+# Keep matplotlib cache writable in restricted environments.
+os.environ.setdefault("MPLCONFIGDIR", "/tmp")
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+# ---------------------------------------------------------------------------
+# Design Tokens (aligned with web voting UI, light-mode for print)
+# ---------------------------------------------------------------------------
+
+ACCENT = "#1083FE"
+ACCENT_DARK = "#0A74E8"
+BORDER = "#D7E6FB"
+SOFT_BG = "#F8FBFF"
+CALLOUT_BG = "#EAF4FF"
+TEXT = "#1F2937"
+TEXT_MUTED = "#5F6B7A"
+CHART_GRID = "#E8EEF8"
+
+FONT_STACK = (
+    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, "
+    "Helvetica, Arial, sans-serif"
+)
+
+SCORE_COMPONENTS = [
+    "recency_score",
+    "engagement_score",
+    "bridging_score",
+    "source_diversity_score",
+    "relevance_score",
+]
+COMPONENT_LABELS = [
+    "Recency",
+    "Engagement",
+    "Bridging",
+    "Source Diversity",
+    "Relevance",
+]
+WEIGHT_COLUMNS = [
+    "recency_weight",
+    "engagement_weight",
+    "bridging_weight",
+    "source_diversity_weight",
+    "relevance_weight",
+]
+
+
+# ---------------------------------------------------------------------------
+# SQL
+# ---------------------------------------------------------------------------
+
+MARKER = "---REPORT-MARKER---"
+
+POSTS_SQL = """
+COPY (
+  SELECT
+    p.uri,
+    LEFT(p.text, 280) as text,
+    p.author_did,
+    p.embed_url,
+    p.topic_vector::text as topics,
+    p.classification_method,
+    ps.total_score,
+    ps.recency_score, ps.engagement_score, ps.bridging_score,
+    ps.source_diversity_score, ps.relevance_score,
+    ps.recency_weight, ps.engagement_weight, ps.bridging_weight,
+    ps.source_diversity_weight, ps.relevance_weight,
+    ps.recency_weighted, ps.engagement_weighted, ps.bridging_weighted,
+    ps.source_diversity_weighted, ps.relevance_weighted,
+    COALESCE(pe.like_count,0) as likes,
+    COALESCE(pe.repost_count,0) as reposts,
+    COALESCE(pe.reply_count,0) as replies
+  FROM post_scores ps
+  JOIN posts p ON p.uri = ps.post_uri
+  LEFT JOIN post_engagement pe ON pe.post_uri = ps.post_uri
+  WHERE ps.epoch_id = (
+    SELECT id FROM governance_epochs
+    WHERE status='active' ORDER BY id DESC LIMIT 1
+  )
+    AND p.deleted = FALSE
+  ORDER BY ps.total_score DESC
+  LIMIT 1000
+) TO STDOUT WITH CSV HEADER
+""".strip().replace("\n", " ")
+
+EPOCH_SQL = """
+SELECT row_to_json(e) FROM (
+  SELECT id, status,
+    recency_weight, engagement_weight, bridging_weight,
+    source_diversity_weight, relevance_weight,
+    vote_count, topic_weights::text as topic_weights, created_at::text
+  FROM governance_epochs
+  WHERE status='active' ORDER BY id DESC LIMIT 1
+) e
+""".strip().replace("\n", " ")
+
+STATS_SQL = """
+SELECT row_to_json(s) FROM (
+  SELECT
+    (SELECT COUNT(*) FROM posts WHERE deleted=FALSE) as total_posts,
+    (SELECT COUNT(*) FROM posts WHERE deleted=FALSE
+     AND indexed_at > NOW() - INTERVAL '24 hours') as last_24h,
+    (SELECT COUNT(*) FROM post_scores WHERE epoch_id = (
+      SELECT id FROM governance_epochs
+      WHERE status='active' ORDER BY id DESC LIMIT 1
+    )) as scored_count
+) s
+""".strip().replace("\n", " ")
+
+
+# ---------------------------------------------------------------------------
+# Data Helpers
+# ---------------------------------------------------------------------------
+
+
+def format_int(value: Any) -> str:
+    """Format integer-like values with thousands separators."""
+    try:
+        return f"{int(value):,}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def format_float(value: Any, precision: int = 3) -> str:
+    """Format float safely with configurable precision."""
+    try:
+        return f"{float(value):.{precision}f}"
+    except (TypeError, ValueError):
+        return "N/A"
+
+
+def safe_text(value: Any) -> str:
+    """HTML-escape arbitrary text values."""
+    return html.escape(str(value) if value is not None else "")
+
+
+def parse_topic_vector(tv_str: Any) -> dict[str, float]:
+    """Parse topic_vector JSON string into a dict."""
+    if not tv_str or pd.isna(tv_str) or tv_str in ("", "null", "None"):
+        return {}
+    try:
+        return json.loads(str(tv_str).replace("'", '"'))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {}
+
+
+def extract_primary_topic(tv_str: Any) -> str:
+    """Get top-confidence topic slug from topic vector."""
+    tv = parse_topic_vector(tv_str)
+    if not tv:
+        return "uncategorized"
+    return max(tv, key=tv.get)
+
+
+def normalize_embed_urls(series: pd.Series) -> pd.Series:
+    """Normalize embed URLs and drop empty/null placeholders."""
+    urls = series.dropna().astype(str).str.strip()
+    return urls[~urls.isin(["", "null", "None"])]
+
+
+def fetch_from_vps() -> tuple[pd.DataFrame, dict[str, Any], dict[str, Any]]:
+    """Pull posts + epoch + stats from VPS in a single SSH call."""
+    combined_cmd = (
+        f'docker exec bluesky-feed-postgres psql -U feed -d bluesky_feed -c "{POSTS_SQL}" '
+        f'&& echo "{MARKER}" '
+        f'&& docker exec bluesky-feed-postgres psql -U feed -d bluesky_feed -t -A -c "{EPOCH_SQL}" '
+        f'&& echo "{MARKER}" '
+        f'&& docker exec bluesky-feed-postgres psql -U feed -d bluesky_feed -t -A -c "{STATS_SQL}"'
+    )
+    print("Connecting to VPS and pulling data...")
+    result = subprocess.run(
+        ["ssh", "corgi-vps", combined_cmd],
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    if result.returncode != 0:
+        print(f"SSH failed (exit {result.returncode}):", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    parts = result.stdout.split(MARKER)
+    if len(parts) < 3:
+        print(f"Expected 3 data sections, got {len(parts)}", file=sys.stderr)
+        print("Raw output preview:", result.stdout[:800], file=sys.stderr)
+        sys.exit(1)
+
+    posts_csv = parts[0].strip()
+    epoch_json_str = parts[1].strip()
+    stats_json_str = parts[2].strip()
+
+    df = pd.read_csv(io.StringIO(posts_csv))
+    epoch = json.loads(epoch_json_str) if epoch_json_str else {}
+    stats = json.loads(stats_json_str) if stats_json_str else {}
+
+    if "topic_weights" in epoch and isinstance(epoch["topic_weights"], str):
+        try:
+            epoch["topic_weights"] = json.loads(epoch["topic_weights"])
+        except (json.JSONDecodeError, TypeError):
+            epoch["topic_weights"] = {}
+
+    print(
+        f"  Posts: {len(df)}, Epoch: {epoch.get('id', '?')}, "
+        f"Total indexed: {stats.get('total_posts', '?')}"
+    )
+    return df, epoch, stats
+
+
+def load_from_csv(
+    csv_path: str, epoch_json_path: str | None = None
+) -> tuple[pd.DataFrame, dict[str, Any], dict[str, Any]]:
+    """Load report data from local files for offline generation."""
+    df = pd.read_csv(csv_path)
+    epoch: dict[str, Any] = {}
+    stats: dict[str, Any] = {
+        "total_posts": len(df),
+        "last_24h": 0,
+        "scored_count": len(df),
+    }
+    if epoch_json_path and os.path.exists(epoch_json_path):
+        with open(epoch_json_path, encoding="utf-8") as f:
+            epoch = json.load(f)
+    return df, epoch, stats
+
+
+# ---------------------------------------------------------------------------
+# Chart Rendering
+# ---------------------------------------------------------------------------
+
+
+def fig_to_data_uri(fig: plt.Figure) -> str:
+    """Convert matplotlib figure to base64 PNG data URI."""
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    buf.seek(0)
+    data = buf.read()
+    import base64
+
+    return f"data:image/png;base64,{base64.b64encode(data).decode('ascii')}"
+
+
+def chart_topics(df: pd.DataFrame) -> str:
+    """Top 15 topic horizontal bar chart."""
+    counts = df["primary_topic"].value_counts().head(15).sort_values()
+    fig, ax = plt.subplots(figsize=(8.0, 4.0))
+    fig.patch.set_facecolor("white")
+    counts.plot.barh(ax=ax, color=ACCENT, edgecolor="white")
+    ax.set_xlabel("Post Count", fontsize=9, color=TEXT_MUTED)
+    ax.set_title("Top 15 Topics in Feed", fontsize=11, fontweight="bold", color=ACCENT_DARK)
+    ax.tick_params(labelsize=8, colors=TEXT_MUTED)
+    ax.grid(axis="x", color=CHART_GRID, linewidth=0.8)
+    ax.set_axisbelow(True)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_color(BORDER)
+    ax.spines["bottom"].set_color(BORDER)
+    fig.tight_layout()
+    return fig_to_data_uri(fig)
+
+
+def chart_score_boxplot(df: pd.DataFrame) -> str:
+    """Score component distribution boxplot."""
+    data = [df[col].dropna() for col in SCORE_COMPONENTS]
+    fig, ax = plt.subplots(figsize=(8.0, 3.8))
+    fig.patch.set_facecolor("white")
+    bp = ax.boxplot(
+        data,
+        tick_labels=COMPONENT_LABELS,
+        patch_artist=True,
+        medianprops=dict(color="white", linewidth=1.5),
+    )
+    for patch in bp["boxes"]:
+        patch.set_facecolor(ACCENT)
+        patch.set_alpha(0.85)
+    ax.set_ylabel("Raw Score (0-1)", fontsize=9, color=TEXT_MUTED)
+    ax.set_title(
+        "Score Component Distribution", fontsize=11, fontweight="bold", color=ACCENT_DARK
+    )
+    ax.tick_params(labelsize=8, colors=TEXT_MUTED)
+    ax.grid(axis="y", color=CHART_GRID, linewidth=0.8)
+    ax.set_axisbelow(True)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_color(BORDER)
+    ax.spines["bottom"].set_color(BORDER)
+    fig.tight_layout()
+    return fig_to_data_uri(fig)
+
+
+def chart_classification(df: pd.DataFrame) -> str:
+    """Classification-method donut chart."""
+    counts = df["classification_method"].fillna("unknown").value_counts()
+    labels = [m.capitalize() for m in counts.index]
+    colors = [ACCENT, "#7CB9FF", "#C8DCFA"][: len(counts)]
+    fig, ax = plt.subplots(figsize=(4.2, 4.2))
+    fig.patch.set_facecolor("white")
+    wedges, texts, autotexts = ax.pie(
+        counts.values,
+        labels=labels,
+        autopct="%1.1f%%",
+        colors=colors,
+        startangle=90,
+        pctdistance=0.75,
+        wedgeprops=dict(width=0.4, edgecolor="white"),
+    )
+    for t in autotexts:
+        t.set_fontsize(9)
+        t.set_fontweight("bold")
+    for t in texts:
+        t.set_fontsize(9)
+    ax.set_title("Classification Method Share", fontsize=11, fontweight="bold", color=ACCENT_DARK)
+    fig.tight_layout()
+    return fig_to_data_uri(fig)
+
+
+# ---------------------------------------------------------------------------
+# HTML Builders
+# ---------------------------------------------------------------------------
+
+
+def table_html(
+    headers: list[str],
+    rows: list[list[str]],
+    numeric_cols: set[int] | None = None,
+    compact: bool = False,
+) -> str:
+    """Render standard report table."""
+    numeric_cols = numeric_cols or set()
+    cls = "report-table compact" if compact else "report-table"
+    head = "".join(f"<th>{safe_text(h)}</th>" for h in headers)
+    body_rows = []
+    for row in rows:
+        cells = []
+        for i, cell in enumerate(row):
+            align_class = "num" if i in numeric_cols else "txt"
+            cells.append(f'<td class="{align_class}">{safe_text(cell)}</td>')
+        body_rows.append(f"<tr>{''.join(cells)}</tr>")
+    return f"""
+    <table class="{cls}">
+      <thead><tr>{head}</tr></thead>
+      <tbody>{''.join(body_rows)}</tbody>
+    </table>
+    """
+
+
+def callout_html(text: str, label: str = "Key takeaway") -> str:
+    """Render callout card."""
+    return (
+        f'<div class="callout"><strong>{safe_text(label)}:</strong> {safe_text(text)}</div>'
+    )
+
+
+def section_html(title: str, body: str, section_class: str = "") -> str:
+    """Render content section with optional class."""
+    cls = f'section {section_class}'.strip()
+    return f'<section class="{cls}"><h2>{safe_text(title)}</h2>{body}</section>'
+
+
+def build_report_html(
+    df: pd.DataFrame, epoch: dict[str, Any], stats: dict[str, Any], date_label: str
+) -> str:
+    """Build full HTML report with robust print-oriented layout."""
+    epoch_id = epoch.get("id", "?")
+    unique_authors = int(df["author_did"].dropna().nunique()) if "author_did" in df else 0
+    topic_count = int(df["primary_topic"].nunique()) if "primary_topic" in df else 0
+    scored_count = stats.get("scored_count", len(df))
+    total_posts = stats.get("total_posts", "?")
+    median_score = float(df["total_score"].median()) if "total_score" in df else 0.0
+
+    method_counts = df["classification_method"].fillna("unknown").value_counts()
+    embedding_pct = (
+        float((df["classification_method"] == "embedding").sum()) / len(df) * 100
+        if "classification_method" in df and len(df) > 0
+        else 0.0
+    )
+    top_topic = (
+        str(df["primary_topic"].value_counts().index[0])
+        if "primary_topic" in df and len(df) > 0
+        else "unknown"
+    )
+
+    # Author diversity
+    author_counts = df["author_did"].dropna().value_counts()
+    avg_posts_per_author = float(author_counts.mean()) if len(author_counts) > 0 else 0.0
+    max_posts_single_author = int(author_counts.max()) if len(author_counts) > 0 else 0
+    heavy_posters = author_counts[author_counts >= 5].head(10)
+
+    # URL dedup
+    normalized_urls = normalize_embed_urls(df["embed_url"]) if "embed_url" in df else pd.Series(dtype=str)
+    url_counts = normalized_urls.value_counts()
+    duplicate_urls = url_counts[url_counts > 1]
+    duplicate_posts = int(duplicate_urls.sum()) if len(duplicate_urls) > 0 else 0
+    max_duplicates = int(duplicate_urls.max()) if len(duplicate_urls) > 0 else 0
+
+    # Topic table
+    topic_stats = (
+        df.groupby("primary_topic")
+        .agg(count=("total_score", "size"), avg_relevance=("relevance_score", "mean"))
+        .sort_values("count", ascending=False)
+        .head(10)
+    )
+    topic_rows: list[list[str]] = []
+    for topic, row in topic_stats.iterrows():
+        pct = (row["count"] / len(df) * 100) if len(df) > 0 else 0
+        topic_rows.append(
+            [
+                str(topic).replace("-", " ").title(),
+                format_int(row["count"]),
+                f"{pct:.1f}%",
+                f"{row['avg_relevance']:.3f}",
+            ]
+        )
+
+    # Score table
+    score_rows: list[list[str]] = []
+    medians: dict[str, float] = {}
+    for col, label, wcol in zip(SCORE_COMPONENTS, COMPONENT_LABELS, WEIGHT_COLUMNS):
+        series = df[col].dropna()
+        med = float(series.median()) if len(series) > 0 else 0.0
+        medians[label] = med
+        weight_val = df[wcol].iloc[0] if wcol in df.columns and len(df) > 0 else "N/A"
+        score_rows.append(
+            [
+                label,
+                format_float(series.min()),
+                format_float(series.quantile(0.25)),
+                format_float(series.median()),
+                format_float(series.quantile(0.75)),
+                format_float(series.max()),
+                format_float(weight_val, 2),
+            ]
+        )
+    highest = max(medians, key=medians.get) if medians else "N/A"
+    lowest = min(medians, key=medians.get) if medians else "N/A"
+
+    # Classification rows
+    method_rows = [
+        [str(method).capitalize(), format_int(count), f"{count / len(df) * 100:.1f}%"]
+        for method, count in method_counts.items()
+    ]
+
+    # Engagement
+    top100 = df.head(100) if len(df) >= 100 else df
+    bottom100 = df.tail(100) if len(df) >= 100 else df
+    engagement_rows: list[list[str]] = []
+    for metric in ["likes", "reposts", "replies"]:
+        if metric not in df.columns:
+            continue
+        top_med = float(top100[metric].median())
+        bot_med = float(bottom100[metric].median())
+        ratio = f"{top_med / bot_med:.1f}x" if bot_med > 0 else "inf"
+        engagement_rows.append(
+            [metric.capitalize(), f"{top_med:.1f}", f"{bot_med:.1f}", ratio]
+        )
+
+    # Topic weights
+    topic_weights = epoch.get("topic_weights", {})
+    topic_weight_rows: list[list[str]] = []
+    if topic_weights and isinstance(topic_weights, dict):
+        sorted_tw = sorted(topic_weights.items(), key=lambda x: x[1], reverse=True)[:10]
+        topic_weight_rows = [
+            [slug.replace("-", " ").title(), f"{weight:.3f}"] for slug, weight in sorted_tw
+        ]
+
+    # Sample posts tables
+    def sample_rows(subset: pd.DataFrame) -> list[list[str]]:
+        rows: list[list[str]] = []
+        for _, row in subset.iterrows():
+            text = str(row.get("text", "")).strip()
+            if len(text) > 90:
+                text = text[:90] + "..."
+            topic = str(row.get("primary_topic", "unknown")).replace("-", " ").title()
+            rows.append(
+                [
+                    text,
+                    topic,
+                    format_float(row.get("total_score", 0), 3),
+                    format_int(int(row.get("likes", 0))),
+                    str(row.get("classification_method", "unknown")).capitalize(),
+                ]
+            )
+        return rows
+
+    top_sample_rows = sample_rows(df.head(10))
+    bottom_sample_rows = sample_rows(df.tail(10))
+
+    # Charts
+    topic_chart = chart_topics(df)
+    score_chart = chart_score_boxplot(df)
+    method_chart = chart_classification(df)
+
+    summary_sentence = (
+        f"The top 1000 feed posts span {format_int(unique_authors)} unique authors across "
+        f"{format_int(topic_count)} topics. The database contains {format_int(total_posts)} "
+        f"indexed posts with {format_int(scored_count)} scored in the current epoch."
+    )
+
+    top3_pct = (
+        df["primary_topic"].value_counts().head(3).sum() / len(df) * 100
+        if len(df) > 0 and "primary_topic" in df.columns
+        else 0.0
+    )
+
+    methodology = f"""
+    <div class="method-grid">
+      <div class="method-card">
+        <h3>Scope</h3>
+        <p>Top 1,000 scored posts in active epoch <strong>{safe_text(epoch_id)}</strong>.</p>
+      </div>
+      <div class="method-card">
+        <h3>Data Source</h3>
+        <p>PostgreSQL snapshots pulled at report generation time from feed.corgi.network.</p>
+      </div>
+      <div class="method-card">
+        <h3>Scoring Window</h3>
+        <p>All rows tagged to current active epoch; soft-deleted posts excluded.</p>
+      </div>
+      <div class="method-card">
+        <h3>Generated</h3>
+        <p>{safe_text(date_label)} (live data).</p>
+      </div>
+    </div>
+    """
+
+    executive_section = section_html(
+        "Executive Summary",
+        f"""
+        <div class="metric-grid">
+          <div class="metric-card"><div class="metric-value">{format_int(len(df))}</div><div class="metric-label">Posts in Scope</div></div>
+          <div class="metric-card"><div class="metric-value">{format_int(unique_authors)}</div><div class="metric-label">Unique Authors</div></div>
+          <div class="metric-card"><div class="metric-value">{median_score:.3f}</div><div class="metric-label">Median Score</div></div>
+          <div class="metric-card"><div class="metric-value">{embedding_pct:.1f}%</div><div class="metric-label">Embedding Classified</div></div>
+        </div>
+        <p class="lead">{safe_text(summary_sentence)}</p>
+        {callout_html(f"Most represented topic is {top_topic.replace('-', ' ').title()}.")}
+        <h3>Epoch Weights</h3>
+        {table_html(
+            ["Parameter", "Value"],
+            [
+                ["Recency", format_float(epoch.get("recency_weight", "N/A"), 2)],
+                ["Engagement", format_float(epoch.get("engagement_weight", "N/A"), 2)],
+                ["Bridging", format_float(epoch.get("bridging_weight", "N/A"), 2)],
+                ["Source Diversity", format_float(epoch.get("source_diversity_weight", "N/A"), 2)],
+                ["Relevance", format_float(epoch.get("relevance_weight", "N/A"), 2)],
+                ["Vote Count", format_int(epoch.get("vote_count", "N/A"))],
+            ],
+            numeric_cols={1},
+            compact=True,
+        )}
+        <h3>Methodology</h3>
+        {methodology}
+        """,
+    )
+
+    topic_weight_section = ""
+    if topic_weight_rows:
+        topic_weight_section = section_html(
+            "Top 10 Topic Weights",
+            table_html(["Topic", "Weight"], topic_weight_rows, numeric_cols={1}, compact=True),
+            "",
+        )
+
+    topic_section = section_html(
+        "Topic Distribution",
+        f"""
+        <div class="chart-wrap">
+          <img src="{topic_chart}" alt="Top topics chart" />
+          <p class="caption">Figure 1. Top topics among the top 1,000 scored posts.</p>
+        </div>
+        {table_html(["Topic", "Post Count", "% of Feed", "Avg Relevance"], topic_rows, numeric_cols={1,2,3})}
+        {callout_html(f"The top 3 topics account for {top3_pct:.1f}% of the analyzed feed sample.")}
+        """,
+        "page-break",
+    )
+
+    score_section = section_html(
+        "Score Composition",
+        f"""
+        <div class="chart-wrap">
+          <img src="{score_chart}" alt="Score component distribution chart" />
+          <p class="caption">Figure 2. Distribution of raw score components before weighting.</p>
+        </div>
+        {table_html(["Component", "Min", "P25", "Median", "P75", "Max", "Weight"], score_rows, numeric_cols={1,2,3,4,5,6})}
+        {callout_html(f"{highest} has the highest median raw score while {lowest} is lowest.")}
+        """,
+        "page-break",
+    )
+
+    class_section = section_html(
+        "Classification Methods",
+        f"""
+        <div class="split-grid">
+          <div class="chart-wrap small-chart">
+            <img src="{method_chart}" alt="Classification method chart" />
+            <p class="caption">Figure 3. Classification method share in analyzed sample.</p>
+          </div>
+          <div>
+            {table_html(["Method", "Count", "% of Feed"], method_rows, numeric_cols={1,2}, compact=True)}
+            {callout_html(f"{str(method_counts.index[0]).capitalize()} is dominant at {method_counts.iloc[0] / len(df) * 100:.1f}%." if len(method_counts) > 0 else "No classification data available.")}
+          </div>
+        </div>
+        """,
+        "page-break",
+    )
+
+    heavy_rows = [[f"{did[:22]}...", format_int(count)] for did, count in heavy_posters.items()]
+    diversity_section = section_html(
+        "Author Diversity and URL Deduplication",
+        f"""
+        <p>Total unique authors: <strong>{format_int(unique_authors)}</strong>. Average posts per author: <strong>{avg_posts_per_author:.1f}</strong>. Max posts by single author: <strong>{format_int(max_posts_single_author)}</strong>.</p>
+        {"<h3>Authors with 5+ posts</h3>" + table_html(["Author DID (truncated)", "Post Count"], heavy_rows, numeric_cols={1}, compact=True) if heavy_rows else ""}
+        <h3>URL Deduplication</h3>
+        <p>Posts with an embed URL: <strong>{format_int(len(normalized_urls))}</strong>. Posts sharing a duplicated embed URL: <strong>{format_int(duplicate_posts)}</strong> across <strong>{format_int(len(duplicate_urls))}</strong> URLs. Max duplicates for a single URL: <strong>{format_int(max_duplicates)}</strong>.</p>
+        {callout_html(f"Most repeated external URL appears {format_int(max_duplicates)} times in this 1,000-post scope." if max_duplicates > 0 else "No duplicated embed URLs detected in the analyzed scope.")}
+        """,
+        "",
+    )
+
+    engagement_section = section_html(
+        "Engagement Profile",
+        f"""
+        {table_html(["Metric", "Top 100 Median", "Bottom 100 Median", "Ratio"], engagement_rows, numeric_cols={1,2,3}, compact=True)}
+        {callout_html(f"Top-ranked posts receive approximately {(float(top100['likes'].median()) / float(bottom100['likes'].median())):.1f}x median likes versus bottom-ranked posts." if 'likes' in df.columns and float(bottom100['likes'].median()) > 0 else "Engagement ratio calculation unavailable due zero/insufficient bottom median.")}
+        """,
+        "",
+    )
+
+    appendix_top = section_html(
+        "Appendix A: Top 10 Sample Posts",
+        table_html(["Text Preview", "Topic", "Score", "Likes", "Method"], top_sample_rows, numeric_cols={2,3}, compact=True),
+        "page-break",
+    )
+    appendix_bottom = section_html(
+        "Appendix B: Bottom 10 Sample Posts",
+        table_html(["Text Preview", "Topic", "Score", "Likes", "Method"], bottom_sample_rows, numeric_cols={2,3}, compact=True),
+        "page-break",
+    )
+
+    css = f"""
+    @page {{
+      size: Letter;
+      margin: 0.58in 0.55in 0.70in 0.55in;
+    }}
+
+    * {{
+      box-sizing: border-box;
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }}
+
+    html, body {{
+      margin: 0;
+      padding: 0;
+      color: {TEXT};
+      font-family: {FONT_STACK};
+      font-size: 11px;
+      line-height: 1.35;
+      background: #fff;
+    }}
+
+    .report {{
+      width: 100%;
+    }}
+
+    .cover {{
+      min-height: 8.3in;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      border: 1px solid {BORDER};
+      border-radius: 12px;
+      padding: 24px;
+      background: linear-gradient(180deg, #ffffff 0%, {SOFT_BG} 100%);
+    }}
+
+    .cover h1 {{
+      margin: 0 0 8px 0;
+      color: {ACCENT_DARK};
+      font-size: 30px;
+      line-height: 1.15;
+      letter-spacing: 0.2px;
+    }}
+
+    .cover .sub {{
+      color: {TEXT_MUTED};
+      font-size: 13px;
+      margin-top: 4px;
+    }}
+
+    .section {{
+      margin-top: 6px;
+    }}
+
+    .page-break {{
+      break-before: page;
+      page-break-before: always;
+    }}
+
+    .cover-break {{
+      break-after: page;
+      page-break-after: always;
+    }}
+
+    h2 {{
+      margin: 0 0 8px 0;
+      color: {ACCENT_DARK};
+      font-size: 18px;
+      line-height: 1.2;
+    }}
+
+    h3 {{
+      margin: 10px 0 6px 0;
+      color: {ACCENT};
+      font-size: 13px;
+      line-height: 1.2;
+    }}
+
+    p {{
+      margin: 4px 0 8px 0;
+    }}
+
+    .lead {{
+      margin-top: 10px;
+      font-size: 12px;
+      line-height: 1.4;
+    }}
+
+    .metric-grid {{
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+      margin-bottom: 12px;
+    }}
+
+    .metric-card {{
+      border: 1px solid {BORDER};
+      border-radius: 10px;
+      overflow: hidden;
+      background: #fff;
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }}
+
+    .metric-value {{
+      background: {ACCENT};
+      color: white;
+      font-weight: 700;
+      font-size: 18px;
+      text-align: center;
+      padding: 8px 6px;
+      line-height: 1.1;
+    }}
+
+    .metric-label {{
+      color: {ACCENT_DARK};
+      background: {CALLOUT_BG};
+      font-size: 10px;
+      text-align: center;
+      padding: 6px;
+      font-weight: 600;
+    }}
+
+    .callout {{
+      border: 1px solid #bfd9ff;
+      background: {CALLOUT_BG};
+      border-radius: 8px;
+      padding: 8px 10px;
+      margin: 8px 0 10px 0;
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }}
+
+    .method-grid {{
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px;
+      margin-top: 6px;
+    }}
+
+    .method-card {{
+      border: 1px solid {BORDER};
+      border-radius: 8px;
+      background: {SOFT_BG};
+      padding: 8px;
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }}
+
+    .method-card h3 {{
+      margin: 0 0 4px 0;
+      font-size: 11px;
+    }}
+
+    .method-card p {{
+      margin: 0;
+      color: {TEXT_MUTED};
+      font-size: 10px;
+    }}
+
+    .split-grid {{
+      display: grid;
+      grid-template-columns: 40% 60%;
+      gap: 12px;
+      align-items: start;
+    }}
+
+    .chart-wrap {{
+      break-inside: avoid;
+      page-break-inside: avoid;
+      margin-bottom: 8px;
+    }}
+
+    .chart-wrap img {{
+      width: 100%;
+      max-width: 100%;
+      border: 1px solid {BORDER};
+      border-radius: 8px;
+      background: #fff;
+      display: block;
+    }}
+
+    .small-chart img {{
+      max-width: 96%;
+      margin: 0 auto;
+    }}
+
+    .caption {{
+      margin: 4px 0 0 0;
+      text-align: center;
+      font-size: 9px;
+      color: {TEXT_MUTED};
+    }}
+
+    .report-table {{
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid {BORDER};
+      margin: 6px 0 10px 0;
+      font-size: 10px;
+      table-layout: fixed;
+    }}
+
+    .report-table.compact {{
+      font-size: 9.5px;
+    }}
+
+    .report-table thead {{
+      display: table-header-group;
+    }}
+
+    .report-table th {{
+      background: {ACCENT};
+      color: #fff;
+      border: 1px solid {BORDER};
+      padding: 5px 6px;
+      text-align: center;
+      font-weight: 700;
+      line-height: 1.2;
+    }}
+
+    .report-table td {{
+      border: 1px solid {BORDER};
+      padding: 4px 6px;
+      vertical-align: top;
+      line-height: 1.25;
+      word-break: break-word;
+      overflow-wrap: anywhere;
+    }}
+
+    .report-table tbody tr:nth-child(even) {{
+      background: {SOFT_BG};
+    }}
+
+    .report-table td.num {{
+      text-align: right;
+      white-space: nowrap;
+    }}
+
+    .report-table td.txt {{
+      text-align: left;
+    }}
+
+    .report-table tr {{
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }}
+    """
+
+    return f"""
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Feed Quality Analysis - {safe_text(date_label)}</title>
+        <style>{css}</style>
+      </head>
+      <body>
+        <div class="report">
+          <section class="cover cover-break">
+            <h1>Feed Quality Analysis</h1>
+            <div class="sub">{safe_text(date_label)}</div>
+            <div class="sub">Community-governed feed | feed.corgi.network | Epoch {safe_text(epoch_id)}</div>
+          </section>
+          {executive_section}
+          {topic_weight_section}
+          {topic_section}
+          {score_section}
+          {class_section}
+          {diversity_section}
+          {engagement_section}
+          {appendix_top}
+          {appendix_bottom}
+        </div>
+      </body>
+    </html>
+    """
+
+
+def render_pdf_with_playwright(
+    html_content: str, output_pdf: str, date_label: str, epoch_id: Any
+) -> None:
+    """Render HTML to PDF with Playwright Chromium."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception as exc:
+        print("Playwright import failed. Install with: pip install playwright", file=sys.stderr)
+        raise exc
+
+    header_template = (
+        "<div style=\"width:100%;font-size:8px;color:#5F6B7A;padding:0 12px;"
+        "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;\">"
+        "Community-Governed Bluesky Feed - Quality Report</div>"
+    )
+    footer_template = (
+        "<div style=\"width:100%;font-size:8px;color:#5F6B7A;padding:0 12px;"
+        "display:flex;justify-content:center;"
+        "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;\">"
+        f"Epoch {html.escape(str(epoch_id))} | {html.escape(str(date_label))} | "
+        "Page <span class=\"pageNumber\"></span> of <span class=\"totalPages\"></span> "
+        "</div>"
+    )
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.set_content(html_content, wait_until="networkidle")
+        page.pdf(
+            path=output_pdf,
+            format="Letter",
+            print_background=True,
+            display_header_footer=True,
+            header_template=header_template,
+            footer_template=footer_template,
+            margin={
+                "top": "0.75in",
+                "bottom": "0.70in",
+                "left": "0.55in",
+                "right": "0.55in",
+            },
+            prefer_css_page_size=False,
+        )
+        browser.close()
+
+
+def print_dry_run(df: pd.DataFrame, epoch: dict[str, Any], stats: dict[str, Any]) -> None:
+    """Print data summary to stdout without generating PDF."""
+    print("\n" + "=" * 60)
+    print("DRY RUN - Data Summary")
+    print("=" * 60)
+    print(f"\nPosts loaded: {len(df)}")
+    print(f"Unique authors: {df['author_did'].dropna().nunique()}")
+    print(f"Median total score: {df['total_score'].median():.4f}")
+
+    if "classification_method" in df.columns:
+        print("\nClassification methods:")
+        for method, count in df["classification_method"].fillna("unknown").value_counts().items():
+            print(f"  {method}: {count} ({count / len(df) * 100:.1f}%)")
+
+    if "primary_topic" in df.columns:
+        print("\nTop 10 topics:")
+        for topic, count in df["primary_topic"].value_counts().head(10).items():
+            print(f"  {topic}: {count}")
+
+    print("\nScore components (medians):")
+    for col, label in zip(SCORE_COMPONENTS, COMPONENT_LABELS):
+        if col in df.columns:
+            print(f"  {label}: {df[col].median():.4f}")
+
+    print(
+        f"\nEpoch: {epoch.get('id', '?')} (status: {epoch.get('status', '?')}, "
+        f"votes: {epoch.get('vote_count', '?')})"
+    )
+    print(
+        f"System stats: {stats.get('total_posts', '?')} total posts, "
+        f"{stats.get('last_24h', '?')} last 24h, "
+        f"{stats.get('scored_count', '?')} scored"
+    )
+    print("\n" + "=" * 60)
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(
+        description="Generate feed quality analysis report (HTML + PDF)"
+    )
+    parser.add_argument("--csv", help="Read from local CSV instead of VPS")
+    parser.add_argument("--epoch-json", help="Epoch JSON file (offline mode)")
+    parser.add_argument("--output", help="Output PDF file path")
+    parser.add_argument("--html-output", help="Optional output path for rendered HTML")
+    parser.add_argument("--date", help="Date label for report title")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print summary only (no PDF generation)"
+    )
+    args = parser.parse_args()
+
+    date_label = args.date or datetime.now().strftime("%B %d, %Y")
+    date_slug = datetime.now().strftime("%b%d").lower()
+    output_path = args.output or f"reports/sprint-data-analysis-{date_slug}.pdf"
+
+    if args.csv:
+        print(f"Loading from CSV: {args.csv}")
+        df, epoch, stats = load_from_csv(args.csv, args.epoch_json)
+    else:
+        df, epoch, stats = fetch_from_vps()
+
+    if len(df) == 0:
+        print("No data returned. Check VPS connectivity and epoch state.", file=sys.stderr)
+        sys.exit(1)
+
+    df["primary_topic"] = df["topics"].apply(extract_primary_topic)
+
+    if args.dry_run:
+        print_dry_run(df, epoch, stats)
+        return
+
+    print("Rendering report HTML...")
+    html_content = build_report_html(df, epoch, stats, date_label)
+
+    if args.html_output:
+        os.makedirs(os.path.dirname(args.html_output) or ".", exist_ok=True)
+        with open(args.html_output, "w", encoding="utf-8") as f:
+            f.write(html_content)
+        print(f"Saved HTML preview: {args.html_output}")
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    print(f"Generating PDF: {output_path}")
+    render_pdf_with_playwright(html_content, output_path, date_label, epoch.get("id", "?"))
+
+    file_size_kb = os.path.getsize(output_path) / 1024
+    print(f"Report saved: {output_path} ({file_size_kb:.0f} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -22,7 +22,7 @@ import json
 import os
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 import matplotlib
 matplotlib.use("Agg")  # Non-interactive backend
@@ -36,6 +36,7 @@ from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 from docx.shared import Inches, Pt, RGBColor, Twips
+from report_utils import format_int
 
 # ---------------------------------------------------------------------------
 # Constants & Design Tokens
@@ -196,7 +197,7 @@ def load_from_csv(csv_path, epoch_json_path=None):
     epoch = {}
     stats = {"total_posts": len(df), "last_24h": 0, "scored_count": len(df)}
     if epoch_json_path and os.path.exists(epoch_json_path):
-        with open(epoch_json_path) as f:
+        with open(epoch_json_path, encoding="utf-8") as f:
             epoch = json.load(f)
     return df, epoch, stats
 
@@ -742,14 +743,6 @@ def add_callout_box(doc, bullets, label="Key Takeaways"):
         wrapper.paragraph_format.space_after = Pt(12)
 
 
-def format_int(value):
-    """Format integer-like values with thousands separators."""
-    try:
-        return f"{int(value):,}"
-    except (TypeError, ValueError):
-        return str(value)
-
-
 def add_styled_table(doc, headers, rows, col_widths=None, numeric_cols=None):
     """Add a formatted table with accent header, subtle borders, and cell padding."""
     table = doc.add_table(rows=1 + len(rows), cols=len(headers))
@@ -881,7 +874,7 @@ def build_title_page(doc, date_label, epoch):
     run.font.size = BODY_SIZE
 
 
-def build_executive_summary(doc, df, epoch, stats, date_label):
+def build_executive_summary(doc, df, epoch, stats):
     """Executive summary with key metrics and governance state."""
     styled_heading(doc, "Executive Summary")
 
@@ -988,7 +981,7 @@ def build_methodology_block(doc, epoch, stats, date_label):
     total_posts = format_int(stats.get("total_posts", "?"))
     scored_count = format_int(stats.get("scored_count", "?"))
     last_24h = format_int(stats.get("last_24h", "?"))
-    gen_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+    gen_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
     lines = [
         f"Scope: Top 1,000 scored posts from the active governance epoch.",
@@ -1451,7 +1444,7 @@ def main():
     doc.add_page_break()
 
     # --- Executive Summary ---
-    build_executive_summary(doc, df, epoch, stats, date_label)
+    build_executive_summary(doc, df, epoch, stats)
 
     # --- Methodology ---
     build_methodology_block(doc, epoch, stats, date_label)

--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -857,7 +857,7 @@ def build_title_page(doc, date_label, epoch):
     epoch_id = epoch.get("id", "?")
 
     title = doc.add_paragraph(style="Title")
-    run = title.add_run(f"Feed Quality Analysis")
+    run = title.add_run("Feed Quality Analysis")
     run.font.name = FONT
 
     # Date subtitle
@@ -964,7 +964,7 @@ def build_executive_summary(doc, df, epoch, stats):
     )
 
 
-def build_methodology_block(doc, epoch, stats, date_label):
+def build_methodology_block(doc, epoch, stats):
     """Data freshness and methodology disclosure block."""
     styled_heading(doc, "Methodology & Data Freshness", level=2)
 
@@ -984,13 +984,13 @@ def build_methodology_block(doc, epoch, stats, date_label):
     gen_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
     lines = [
-        f"Scope: Top 1,000 scored posts from the active governance epoch.",
+        "Scope: Top 1,000 scored posts from the active governance epoch.",
         f"Epoch: {epoch_id} (created {created_at}).",
         f"Database: {total_posts} total indexed posts, {scored_count} scored this epoch, "
         f"{last_24h} ingested in last 24 hours.",
         f"Generated: {gen_time}.",
-        f"Note: Engagement metrics (likes, reposts, replies) reflect counts at time of "
-        f"data extraction and may differ from current values.",
+        "Note: Engagement metrics (likes, reposts, replies) reflect counts at time of "
+        "data extraction and may differ from current values.",
     ]
 
     p = cell.paragraphs[0]
@@ -1447,7 +1447,7 @@ def main():
     build_executive_summary(doc, df, epoch, stats)
 
     # --- Methodology ---
-    build_methodology_block(doc, epoch, stats, date_label)
+    build_methodology_block(doc, epoch, stats)
 
     # --- Topic Weights (if available) ---
     topic_weights = epoch.get("topic_weights")

--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -29,31 +29,55 @@ matplotlib.use("Agg")  # Non-interactive backend
 import matplotlib.pyplot as plt
 import pandas as pd
 from docx import Document
-from docx.enum.section import WD_ORIENT
+from docx.enum.section import WD_ORIENT, WD_SECTION_START
+from docx.enum.style import WD_STYLE_TYPE
 from docx.enum.table import WD_TABLE_ALIGNMENT
 from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
-from docx.shared import Inches, Pt, RGBColor
+from docx.shared import Inches, Pt, RGBColor, Twips
 
 # ---------------------------------------------------------------------------
-# Constants & Style
+# Constants & Design Tokens
 # ---------------------------------------------------------------------------
+# Aligned with web/src/styles/tokens.css, adapted for light-mode print.
 
-ACCENT_COLOR = "#1B4F72"
-ACCENT_RGB = RGBColor(0x1B, 0x4F, 0x72)
-LIGHT_ACCENT = "#EBF5FB"
-LIGHT_ACCENT_RGB = RGBColor(0xEB, 0xF5, 0xFB)
-FONT = "Arial"
-TITLE_SIZE = Pt(18)
-HEADING_SIZE = Pt(12)
+ACCENT_COLOR = "#1083FE"
+ACCENT_RGB = RGBColor(0x10, 0x83, 0xFE)
+ACCENT_DARK_RGB = RGBColor(0x0A, 0x74, 0xE8)
+LIGHT_ACCENT = "#EAF4FF"
+CARD_BG = "#F8FAFC"
+ROW_ALT_COLOR = "#F8FBFF"
+BORDER_COLOR = "D7E6FB"
+BORDER_COLOR_HEX = "#D7E6FB"
+TEXT_PRIMARY_RGB = RGBColor(0x1F, 0x29, 0x37)
+TEXT_SECONDARY_RGB = RGBColor(0x5F, 0x6B, 0x7A)
+
+# Status colors (from tokens.css)
+SUCCESS_HEX = "#34C759"
+WARNING_HEX = "#FF9F0A"
+ERROR_HEX = "#FF453A"
+
+# Typography
+FONT = "Segoe UI"
+TITLE_SIZE = Pt(20)
+H1_SIZE = Pt(14)
+H2_SIZE = Pt(12)
 BODY_SIZE = Pt(10)
-SMALL_SIZE = Pt(8)
+SMALL_SIZE = Pt(8.5)
+METHODOLOGY_SIZE = Pt(9)
+
+# Chart constants
+CHART_GRID_COLOR = "#E8EEF8"
+CHART_TEXT_COLOR = "#5F6B7A"
+CHART_SPINE_COLOR = "#D7E6FB"
+CHART_DPI = 150
 
 SCORE_COMPONENTS = [
     "recency_score", "engagement_score", "bridging_score",
     "source_diversity_score", "relevance_score",
 ]
-COMPONENT_LABELS = ["Recency", "Engagement", "Bridging", "Src Diversity", "Relevance"]
+COMPONENT_LABELS = ["Recency", "Engagement", "Bridging", "Source Diversity", "Relevance"]
 WEIGHT_COLUMNS = [
     "recency_weight", "engagement_weight", "bridging_weight",
     "source_diversity_weight", "relevance_weight",
@@ -66,6 +90,7 @@ POSTS_SQL = """
 COPY (
   SELECT
     p.uri, LEFT(p.text, 200) as text, p.author_did,
+    p.embed_url,
     p.topic_vector::text as topics,
     p.classification_method,
     ps.total_score,
@@ -203,76 +228,142 @@ def extract_topic_confidence(tv_str):
 
 
 # ---------------------------------------------------------------------------
-# Chart Generation (each returns PNG bytes)
+# Matplotlib Setup & Chart Generation
 # ---------------------------------------------------------------------------
 
-def generate_topic_chart(df):
-    """Horizontal bar chart of top 15 topics."""
-    topics = df["primary_topic"].value_counts().head(15)
-    fig, ax = plt.subplots(figsize=(7, 4))
-    topics.sort_values().plot.barh(ax=ax, color=ACCENT_COLOR, edgecolor="white")
-    ax.set_xlabel("Post Count", fontsize=9)
-    ax.set_title("Top 15 Topics in Feed", fontsize=11, fontweight="bold",
-                 color=ACCENT_COLOR)
-    ax.tick_params(labelsize=8)
+def setup_matplotlib_defaults():
+    """Configure matplotlib for consistent, professional chart output."""
+    plt.rcParams.update({
+        "font.family": "sans-serif",
+        "font.sans-serif": ["Segoe UI", "Helvetica Neue", "Helvetica", "Arial", "sans-serif"],
+        "font.size": 9,
+        "axes.titlesize": 11,
+        "axes.titleweight": "semibold",
+        "axes.labelsize": 9,
+        "axes.labelcolor": CHART_TEXT_COLOR,
+        "xtick.labelsize": 8,
+        "ytick.labelsize": 8,
+        "xtick.color": CHART_TEXT_COLOR,
+        "ytick.color": CHART_TEXT_COLOR,
+        "figure.facecolor": "white",
+        "axes.facecolor": "white",
+        "savefig.dpi": CHART_DPI,
+        "savefig.bbox": "tight",
+    })
+
+
+def configure_chart_axes(ax):
+    """Apply consistent axis styling to a chart axes object."""
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
-    fig.tight_layout()
+    ax.spines["bottom"].set_color(CHART_SPINE_COLOR)
+    ax.spines["left"].set_color(CHART_SPINE_COLOR)
+    ax.tick_params(colors=CHART_TEXT_COLOR, labelsize=8)
+    ax.set_axisbelow(True)
+
+
+def _save_chart(fig):
+    """Save a matplotlib figure to PNG bytes and clean up."""
     buf = io.BytesIO()
-    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight")
+    fig.savefig(buf, format="png", dpi=CHART_DPI, bbox_inches="tight",
+                facecolor="white", edgecolor="none")
     plt.close(fig)
     buf.seek(0)
     return buf.read()
+
+
+def generate_topic_chart(df):
+    """Horizontal bar chart of top 15 topics with value labels."""
+    topics = df["primary_topic"].value_counts().head(15)
+    sorted_topics = topics.sort_values()
+
+    fig, ax = plt.subplots(figsize=(7.5, 4.5))
+    bars = ax.barh(range(len(sorted_topics)), sorted_topics.values,
+                   color=ACCENT_COLOR, edgecolor="white", height=0.7)
+    ax.set_yticks(range(len(sorted_topics)))
+    ax.set_yticklabels([t.replace("-", " ").title() for t in sorted_topics.index],
+                       fontsize=8)
+    ax.set_xlabel("Post Count", fontsize=9, color=CHART_TEXT_COLOR)
+    ax.set_title("Top 15 Topics in Feed", fontsize=11, fontweight="semibold",
+                 color="#1F2937", pad=12)
+    configure_chart_axes(ax)
+    ax.grid(axis="x", color=CHART_GRID_COLOR, linewidth=0.6, alpha=0.8)
+    ax.bar_label(bars, padding=4, fontsize=7, color=CHART_TEXT_COLOR, fmt="%d")
+
+    # Add a bit of right margin for labels
+    x_max = sorted_topics.max()
+    ax.set_xlim(right=x_max * 1.12)
+    fig.tight_layout()
+    return _save_chart(fig)
 
 
 def generate_score_boxplot(df):
-    """Box plot of the 5 score components."""
+    """Box plot of the 5 score components with median annotations."""
     data = [df[col].dropna() for col in SCORE_COMPONENTS]
-    fig, ax = plt.subplots(figsize=(7, 3.5))
-    bp = ax.boxplot(data, tick_labels=COMPONENT_LABELS, patch_artist=True,
-                    medianprops=dict(color="white", linewidth=1.5))
+    fig, ax = plt.subplots(figsize=(8.5, 4.0))
+
+    bp = ax.boxplot(
+        data, tick_labels=COMPONENT_LABELS, patch_artist=True,
+        medianprops=dict(color="white", linewidth=1.5),
+        flierprops=dict(marker=".", markersize=3, markerfacecolor=CHART_TEXT_COLOR,
+                        markeredgecolor=CHART_TEXT_COLOR, alpha=0.4),
+        whiskerprops=dict(color=CHART_TEXT_COLOR, linewidth=0.8),
+        capprops=dict(color=CHART_TEXT_COLOR, linewidth=0.8),
+    )
     for patch in bp["boxes"]:
         patch.set_facecolor(ACCENT_COLOR)
-        patch.set_alpha(0.8)
-    ax.set_ylabel("Raw Score (0-1)", fontsize=9)
+        patch.set_alpha(0.85)
+        patch.set_edgecolor(ACCENT_COLOR)
+
+    # Median value annotations
+    for i, line in enumerate(bp["medians"]):
+        x, y = line.get_xydata()[1]
+        median_val = data[i].median()
+        ax.text(x + 0.15, y, f"{median_val:.3f}",
+                fontsize=7, color=CHART_TEXT_COLOR, va="center", fontweight="medium")
+
+    ax.set_ylabel("Raw Score (0\u20131)", fontsize=9, color=CHART_TEXT_COLOR)
     ax.set_title("Score Component Distribution", fontsize=11,
-                 fontweight="bold", color=ACCENT_COLOR)
-    ax.tick_params(labelsize=8)
-    ax.spines["top"].set_visible(False)
-    ax.spines["right"].set_visible(False)
+                 fontweight="semibold", color="#1F2937", pad=12)
+    configure_chart_axes(ax)
+    ax.grid(axis="y", color=CHART_GRID_COLOR, linewidth=0.6, alpha=0.8)
     fig.tight_layout()
-    buf = io.BytesIO()
-    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight")
-    plt.close(fig)
-    buf.seek(0)
-    return buf.read()
+    return _save_chart(fig)
 
 
 def generate_classification_donut(df):
-    """Donut chart showing keyword vs embedding classification split."""
+    """Donut chart with colorblind-safe palette and center total."""
     counts = df["classification_method"].fillna("unknown").value_counts()
     labels = [m.capitalize() for m in counts.index]
-    colors = [ACCENT_COLOR, "#AED6F1", "#D5DBDB"][:len(counts)]
+    # Colorblind-safe: blue, green, amber (from design tokens status colors)
+    palette = [ACCENT_COLOR, SUCCESS_HEX, WARNING_HEX]
+    colors = palette[:len(counts)]
 
-    fig, ax = plt.subplots(figsize=(4, 4))
+    fig, ax = plt.subplots(figsize=(4.2, 4.2))
     wedges, texts, autotexts = ax.pie(
         counts.values, labels=labels, autopct="%1.1f%%",
         colors=colors, startangle=90, pctdistance=0.75,
-        wedgeprops=dict(width=0.4, edgecolor="white"),
+        wedgeprops=dict(width=0.4, edgecolor="white", linewidth=2),
     )
     for t in autotexts:
         t.set_fontsize(9)
         t.set_fontweight("bold")
+        t.set_color("#1F2937")
     for t in texts:
         t.set_fontsize(9)
+        t.set_color(CHART_TEXT_COLOR)
+
+    # Center label — total count
+    total = int(counts.sum())
+    ax.text(0, 0.05, f"{total:,}", ha="center", va="center",
+            fontsize=16, fontweight="bold", color="#1F2937")
+    ax.text(0, -0.12, "posts", ha="center", va="center",
+            fontsize=8, color=CHART_TEXT_COLOR)
+
     ax.set_title("Classification Method", fontsize=11,
-                 fontweight="bold", color=ACCENT_COLOR)
+                 fontweight="semibold", color="#1F2937", pad=12)
     fig.tight_layout()
-    buf = io.BytesIO()
-    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight")
-    plt.close(fig)
-    buf.seek(0)
-    return buf.read()
+    return _save_chart(fig)
 
 
 # ---------------------------------------------------------------------------
@@ -281,44 +372,398 @@ def generate_classification_donut(df):
 
 def set_cell_shading(cell, hex_color):
     """Apply background shading to a table cell."""
-    shading_elm = cell._element.get_or_add_tcPr()
-    shading = shading_elm.makeelement(qn("w:shd"), {
-        qn("w:fill"): hex_color.replace("#", ""),
-        qn("w:val"): "clear",
-    })
-    shading_elm.append(shading)
+    tc_pr = cell._element.get_or_add_tcPr()
+    existing = tc_pr.find(qn("w:shd"))
+    if existing is not None:
+        tc_pr.remove(existing)
+    shading = OxmlElement("w:shd")
+    shading.set(qn("w:fill"), hex_color.replace("#", ""))
+    shading.set(qn("w:val"), "clear")
+    tc_pr.append(shading)
 
 
-def styled_heading(doc, text, level=1):
-    """Add a styled heading."""
-    h = doc.add_heading(text, level=level)
-    for run in h.runs:
-        run.font.name = FONT
-        run.font.color.rgb = ACCENT_RGB
-    return h
+def set_cell_margins(cell, top=0, bottom=0, left=0, right=0):
+    """Set cell margins in twips via XML."""
+    tc_pr = cell._element.get_or_add_tcPr()
+    existing = tc_pr.find(qn("w:tcMar"))
+    if existing is not None:
+        tc_pr.remove(existing)
+    tc_mar = OxmlElement("w:tcMar")
+    for edge, val in [("top", top), ("bottom", bottom),
+                      ("left", left), ("right", right)]:
+        el = OxmlElement(f"w:{edge}")
+        el.set(qn("w:w"), str(val))
+        el.set(qn("w:type"), "dxa")
+        tc_mar.append(el)
+    tc_pr.append(tc_mar)
 
 
-def styled_paragraph(doc, text, bold=False, size=None):
+def set_table_borders(table, color=BORDER_COLOR, size=4, inside_v=True):
+    """Apply subtle table borders for a cleaner, print-friendly look."""
+    tbl = table._tbl
+    tbl_pr = tbl.tblPr
+    borders = tbl_pr.find(qn("w:tblBorders"))
+    if borders is None:
+        borders = OxmlElement("w:tblBorders")
+        tbl_pr.append(borders)
+
+    edges = ["top", "left", "bottom", "right", "insideH"]
+    if inside_v:
+        edges.append("insideV")
+
+    for edge in edges:
+        element = borders.find(qn(f"w:{edge}"))
+        if element is None:
+            element = OxmlElement(f"w:{edge}")
+            borders.append(element)
+        element.set(qn("w:val"), "single")
+        element.set(qn("w:sz"), str(size))
+        element.set(qn("w:space"), "0")
+        element.set(qn("w:color"), color)
+
+
+def set_row_border(row, edge="bottom", color=BORDER_COLOR, size=6):
+    """Set a specific border on all cells in a row."""
+    for cell in row.cells:
+        tc_pr = cell._element.get_or_add_tcPr()
+        tc_borders = tc_pr.find(qn("w:tcBorders"))
+        if tc_borders is None:
+            tc_borders = OxmlElement("w:tcBorders")
+            tc_pr.append(tc_borders)
+        el = tc_borders.find(qn(f"w:{edge}"))
+        if el is None:
+            el = OxmlElement(f"w:{edge}")
+            tc_borders.append(el)
+        el.set(qn("w:val"), "single")
+        el.set(qn("w:sz"), str(size))
+        el.set(qn("w:space"), "0")
+        el.set(qn("w:color"), color)
+
+
+def add_paragraph_border(paragraph, edge="bottom", color=BORDER_COLOR, size=4, space=4):
+    """Add a border to a paragraph via XML."""
+    p_pr = paragraph._p.get_or_add_pPr()
+    p_bdr = p_pr.find(qn("w:pBdr"))
+    if p_bdr is None:
+        p_bdr = OxmlElement("w:pBdr")
+        p_pr.append(p_bdr)
+    el = OxmlElement(f"w:{edge}")
+    el.set(qn("w:val"), "single")
+    el.set(qn("w:sz"), str(size))
+    el.set(qn("w:space"), str(space))
+    el.set(qn("w:color"), color)
+    p_bdr.append(el)
+
+
+def add_simple_field(paragraph, field_code):
+    """Insert a Word field (e.g., PAGE or NUMPAGES) into a paragraph."""
+    fld = OxmlElement("w:fldSimple")
+    fld.set(qn("w:instr"), field_code)
+    run = OxmlElement("w:r")
+    text = OxmlElement("w:t")
+    text.text = "1"
+    run.append(text)
+    fld.append(run)
+    paragraph._p.append(fld)
+
+
+def configure_document_styles(doc):
+    """Configure reusable typography styles for a polished report."""
+    # Normal body style
+    normal = doc.styles["Normal"]
+    normal.font.name = FONT
+    normal.font.size = BODY_SIZE
+    normal.font.color.rgb = TEXT_PRIMARY_RGB
+    normal.paragraph_format.space_after = Pt(6)
+    normal.paragraph_format.line_spacing = 1.3
+    normal.paragraph_format.widow_control = True
+
+    # Title
+    title_style = doc.styles["Title"]
+    title_style.font.name = FONT
+    title_style.font.size = TITLE_SIZE
+    title_style.font.bold = True
+    title_style.font.color.rgb = ACCENT_DARK_RGB
+    title_style.paragraph_format.space_before = Pt(48)
+    title_style.paragraph_format.space_after = Pt(8)
+    title_style.paragraph_format.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    # Heading 1 — with bottom accent border
+    h1 = doc.styles["Heading 1"]
+    h1.font.name = FONT
+    h1.font.size = H1_SIZE
+    h1.font.bold = True
+    h1.font.color.rgb = ACCENT_DARK_RGB
+    h1.paragraph_format.space_before = Pt(24)
+    h1.paragraph_format.space_after = Pt(8)
+    h1.paragraph_format.keep_with_next = True
+
+    # Heading 2
+    h2 = doc.styles["Heading 2"]
+    h2.font.name = FONT
+    h2.font.size = H2_SIZE
+    h2.font.bold = True
+    h2.font.color.rgb = ACCENT_RGB
+    h2.paragraph_format.space_before = Pt(16)
+    h2.paragraph_format.space_after = Pt(6)
+    h2.paragraph_format.keep_with_next = True
+
+    # Custom styles
+    existing = {s.name for s in doc.styles}
+
+    if "ReportCaption" not in existing:
+        cap = doc.styles.add_style("ReportCaption", WD_STYLE_TYPE.PARAGRAPH)
+        cap.font.name = FONT
+        cap.font.size = SMALL_SIZE
+        cap.font.color.rgb = TEXT_SECONDARY_RGB
+        cap.font.italic = True
+        cap.paragraph_format.space_before = Pt(4)
+        cap.paragraph_format.space_after = Pt(10)
+        cap.paragraph_format.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    if "ReportSubtitle" not in existing:
+        sub = doc.styles.add_style("ReportSubtitle", WD_STYLE_TYPE.PARAGRAPH)
+        sub.font.name = FONT
+        sub.font.size = Pt(12)
+        sub.font.color.rgb = TEXT_SECONDARY_RGB
+        sub.paragraph_format.space_after = Pt(16)
+        sub.paragraph_format.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    if "MethodologyBody" not in existing:
+        meth = doc.styles.add_style("MethodologyBody", WD_STYLE_TYPE.PARAGRAPH)
+        meth.font.name = FONT
+        meth.font.size = METHODOLOGY_SIZE
+        meth.font.color.rgb = TEXT_SECONDARY_RGB
+        meth.paragraph_format.space_after = Pt(4)
+        meth.paragraph_format.line_spacing = 1.3
+
+    if "AppendixHeading" not in existing:
+        app_h = doc.styles.add_style("AppendixHeading", WD_STYLE_TYPE.PARAGRAPH)
+        app_h.font.name = FONT
+        app_h.font.size = Pt(13)
+        app_h.font.bold = True
+        app_h.font.color.rgb = ACCENT_RGB
+        app_h.paragraph_format.space_before = Pt(20)
+        app_h.paragraph_format.space_after = Pt(8)
+        app_h.paragraph_format.keep_with_next = True
+
+
+def configure_section_layout(section, landscape=False):
+    """Apply consistent page layout and orientation."""
+    if landscape and section.orientation != WD_ORIENT.LANDSCAPE:
+        section.orientation = WD_ORIENT.LANDSCAPE
+        section.page_width, section.page_height = section.page_height, section.page_width
+    if not landscape and section.orientation != WD_ORIENT.PORTRAIT:
+        section.orientation = WD_ORIENT.PORTRAIT
+        section.page_width, section.page_height = section.page_height, section.page_width
+
+    section.left_margin = Inches(0.75)
+    section.right_margin = Inches(0.75)
+    section.top_margin = Inches(0.7)
+    section.bottom_margin = Inches(0.7)
+
+
+def add_landscape_section(doc, date_label, epoch_id):
+    """Insert a new landscape section with header/footer."""
+    section = doc.add_section(WD_SECTION_START.NEW_PAGE)
+    configure_section_layout(section, landscape=True)
+    set_document_header_footer(section, date_label, epoch_id)
+    return section
+
+
+def restore_portrait_section(doc, date_label, epoch_id):
+    """Insert a new portrait section with header/footer."""
+    section = doc.add_section(WD_SECTION_START.NEW_PAGE)
+    configure_section_layout(section, landscape=False)
+    set_document_header_footer(section, date_label, epoch_id)
+    return section
+
+
+def set_document_header_footer(section, date_label, epoch_id):
+    """Set professional header/footer with borders and page numbering."""
+    section.header.is_linked_to_previous = False
+    section.footer.is_linked_to_previous = False
+
+    # --- Header: left title, right date, bottom border ---
+    header = section.header
+    header_para = header.paragraphs[0]
+    header_para.text = ""
+    header_para.alignment = WD_ALIGN_PARAGRAPH.LEFT
+
+    # Left-aligned title
+    title_run = header_para.add_run("Corgi Network Feed Quality Report")
+    title_run.font.name = FONT
+    title_run.font.size = SMALL_SIZE
+    title_run.font.color.rgb = TEXT_SECONDARY_RGB
+
+    # Tab + right-aligned date
+    tab_run = header_para.add_run("\t\t")
+    tab_run.font.name = FONT
+    tab_run.font.size = SMALL_SIZE
+    date_run = header_para.add_run(date_label)
+    date_run.font.name = FONT
+    date_run.font.size = SMALL_SIZE
+    date_run.font.color.rgb = TEXT_SECONDARY_RGB
+
+    # Add right tab stop
+    is_landscape = section.orientation == WD_ORIENT.LANDSCAPE
+    tab_pos = Inches(9.5) if is_landscape else Inches(7.0)
+    pPr = header_para._p.get_or_add_pPr()
+    tabs = OxmlElement("w:tabs")
+    tab = OxmlElement("w:tab")
+    tab.set(qn("w:val"), "right")
+    tab.set(qn("w:pos"), str(int(tab_pos)))
+    tabs.append(tab)
+    pPr.append(tabs)
+
+    # Bottom border on header
+    add_paragraph_border(header_para, "bottom", BORDER_COLOR, size=4, space=6)
+
+    # --- Footer: feed.corgi.network (left), Epoch | Page (center), top border ---
+    footer = section.footer
+    footer_para = footer.paragraphs[0]
+    footer_para.text = ""
+    footer_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    # Top border on footer
+    add_paragraph_border(footer_para, "top", BORDER_COLOR, size=4, space=6)
+
+    # Footer content
+    site_run = footer_para.add_run("feed.corgi.network  |  ")
+    site_run.font.name = FONT
+    site_run.font.size = Pt(7.5)
+    site_run.font.color.rgb = TEXT_SECONDARY_RGB
+
+    meta = footer_para.add_run(f"Epoch {epoch_id}  |  ")
+    meta.font.name = FONT
+    meta.font.size = SMALL_SIZE
+    meta.font.color.rgb = TEXT_SECONDARY_RGB
+
+    page_label = footer_para.add_run("Page ")
+    page_label.font.name = FONT
+    page_label.font.size = SMALL_SIZE
+    page_label.font.color.rgb = TEXT_SECONDARY_RGB
+    add_simple_field(footer_para, "PAGE")
+
+    of_run = footer_para.add_run(" of ")
+    of_run.font.name = FONT
+    of_run.font.size = SMALL_SIZE
+    of_run.font.color.rgb = TEXT_SECONDARY_RGB
+    add_simple_field(footer_para, "NUMPAGES")
+
+
+def styled_heading(doc, text, level=1, style_name=None):
+    """Add a styled heading. Use style_name='AppendixHeading' for appendix sections."""
+    if style_name:
+        heading = doc.add_paragraph(text, style=style_name)
+    else:
+        heading = doc.add_heading(text, level=level)
+    # Add bottom accent border to Heading 1
+    if level == 1 and not style_name:
+        add_paragraph_border(heading, "bottom", BORDER_COLOR, size=4, space=4)
+    return heading
+
+
+def styled_paragraph(doc, text, bold=False, size=None, style=None):
     """Add a styled body paragraph."""
-    p = doc.add_paragraph()
+    p = doc.add_paragraph(style=style or "Normal")
     run = p.add_run(text)
     run.font.name = FONT
     run.font.size = size or BODY_SIZE
     run.bold = bold
+    run.font.color.rgb = TEXT_PRIMARY_RGB
     return p
 
 
-def add_styled_table(doc, headers, rows, col_widths=None):
-    """Add a formatted table with accent header row."""
+def styled_caption(doc, text):
+    """Add a centered caption under charts/figures."""
+    return doc.add_paragraph(text, style="ReportCaption")
+
+
+def add_callout_box(doc, bullets, label="Key Takeaways"):
+    """Add a styled callout box with multi-bullet support and left accent border."""
+    # Backward compat: string → list
+    if isinstance(bullets, str):
+        bullets = [bullets]
+
+    box = doc.add_table(rows=1, cols=1)
+    box.alignment = WD_TABLE_ALIGNMENT.CENTER
+
+    # Left accent border only — clean "quote block" look
+    tbl = box._tbl
+    tbl_pr = tbl.tblPr
+    borders = OxmlElement("w:tblBorders")
+    for edge in ["top", "right", "bottom", "insideH", "insideV"]:
+        el = OxmlElement(f"w:{edge}")
+        el.set(qn("w:val"), "none")
+        el.set(qn("w:sz"), "0")
+        el.set(qn("w:space"), "0")
+        el.set(qn("w:color"), "auto")
+        borders.append(el)
+    left_border = OxmlElement("w:left")
+    left_border.set(qn("w:val"), "single")
+    left_border.set(qn("w:sz"), "18")  # ~3pt
+    left_border.set(qn("w:space"), "0")
+    left_border.set(qn("w:color"), ACCENT_COLOR.replace("#", ""))
+    borders.append(left_border)
+    existing = tbl_pr.find(qn("w:tblBorders"))
+    if existing is not None:
+        tbl_pr.remove(existing)
+    tbl_pr.append(borders)
+
+    cell = box.rows[0].cells[0]
+    set_cell_shading(cell, CARD_BG)
+    set_cell_margins(cell, top=100, bottom=100, left=180, right=140)
+
+    # Label paragraph
+    p = cell.paragraphs[0]
+    p.paragraph_format.space_before = Pt(2)
+    p.paragraph_format.space_after = Pt(4)
+    lead = p.add_run(label)
+    lead.bold = True
+    lead.font.name = FONT
+    lead.font.size = BODY_SIZE
+    lead.font.color.rgb = ACCENT_DARK_RGB
+
+    # Bullet paragraphs
+    for bullet_text in bullets:
+        bp = cell.add_paragraph()
+        bp.paragraph_format.space_before = Pt(2)
+        bp.paragraph_format.space_after = Pt(2)
+        bp.paragraph_format.line_spacing = 1.3
+        run = bp.add_run(f"\u2022  {bullet_text}")
+        run.font.name = FONT
+        run.font.size = SMALL_SIZE
+        run.font.color.rgb = TEXT_PRIMARY_RGB
+
+    # Space after the callout via paragraph spacing on the wrapper
+    wrapper = doc.paragraphs[-1] if doc.paragraphs else None
+    if wrapper:
+        wrapper.paragraph_format.space_after = Pt(12)
+
+
+def format_int(value):
+    """Format integer-like values with thousands separators."""
+    try:
+        return f"{int(value):,}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def add_styled_table(doc, headers, rows, col_widths=None, numeric_cols=None):
+    """Add a formatted table with accent header, subtle borders, and cell padding."""
     table = doc.add_table(rows=1 + len(rows), cols=len(headers))
     table.alignment = WD_TABLE_ALIGNMENT.CENTER
-    table.style = "Table Grid"
+    table.autofit = False
+    set_table_borders(table)
+    numeric_cols = numeric_cols or set()
 
     # Header row
     for i, header in enumerate(headers):
         cell = table.rows[0].cells[i]
         cell.text = header
         set_cell_shading(cell, ACCENT_COLOR)
+        set_cell_margins(cell, top=50, bottom=50, left=60, right=60)
         for paragraph in cell.paragraphs:
             paragraph.alignment = WD_ALIGN_PARAGRAPH.CENTER
             for run in paragraph.runs:
@@ -327,46 +772,118 @@ def add_styled_table(doc, headers, rows, col_widths=None):
                 run.font.color.rgb = RGBColor(0xFF, 0xFF, 0xFF)
                 run.bold = True
 
+    # Thicker bottom border on header row
+    set_row_border(table.rows[0], "bottom",
+                   color=ACCENT_COLOR.replace("#", ""), size=8)
+
+    # Column widths
+    if col_widths:
+        for row in table.rows:
+            for c, width in enumerate(col_widths):
+                row.cells[c].width = width
+
     # Data rows
     for r, row_data in enumerate(rows):
         for c, value in enumerate(row_data):
             cell = table.rows[r + 1].cells[c]
             cell.text = str(value)
+            set_cell_margins(cell, top=40, bottom=40, left=60, right=60)
             if r % 2 == 1:
-                set_cell_shading(cell, LIGHT_ACCENT)
+                set_cell_shading(cell, ROW_ALT_COLOR)
             for paragraph in cell.paragraphs:
+                paragraph.alignment = (
+                    WD_ALIGN_PARAGRAPH.RIGHT if c in numeric_cols
+                    else WD_ALIGN_PARAGRAPH.LEFT
+                )
                 for run in paragraph.runs:
                     run.font.name = FONT
                     run.font.size = SMALL_SIZE
+                    run.font.color.rgb = TEXT_PRIMARY_RGB
 
     return table
+
+
+def add_horizontal_rule(doc):
+    """Add a thin horizontal rule paragraph."""
+    p = doc.add_paragraph()
+    p.paragraph_format.space_before = Pt(8)
+    p.paragraph_format.space_after = Pt(4)
+    add_paragraph_border(p, "bottom", BORDER_COLOR, size=4, space=0)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Table of Contents
+# ---------------------------------------------------------------------------
+
+def add_table_of_contents(doc):
+    """Insert a Word TOC field that can be updated when opened."""
+    styled_heading(doc, "Contents")
+
+    # TOC field
+    paragraph = doc.add_paragraph()
+    paragraph.paragraph_format.space_after = Pt(6)
+
+    run = paragraph.add_run()
+    fld_char_begin = OxmlElement("w:fldChar")
+    fld_char_begin.set(qn("w:fldCharType"), "begin")
+    run._r.append(fld_char_begin)
+
+    instr_run = paragraph.add_run()
+    instr_text = OxmlElement("w:instrText")
+    instr_text.set(qn("xml:space"), "preserve")
+    instr_text.text = ' TOC \\o "1-2" \\h \\z \\u '
+    instr_run._r.append(instr_text)
+
+    fld_char_separate = OxmlElement("w:fldChar")
+    fld_char_separate.set(qn("w:fldCharType"), "separate")
+    sep_run = paragraph.add_run()
+    sep_run._r.append(fld_char_separate)
+
+    # Placeholder text
+    placeholder = paragraph.add_run(
+        "[Right-click \u2192 Update Field to populate table of contents]"
+    )
+    placeholder.font.name = FONT
+    placeholder.font.size = SMALL_SIZE
+    placeholder.font.color.rgb = TEXT_SECONDARY_RGB
+    placeholder.font.italic = True
+
+    fld_char_end = OxmlElement("w:fldChar")
+    fld_char_end.set(qn("w:fldCharType"), "end")
+    end_run = paragraph.add_run()
+    end_run._r.append(fld_char_end)
 
 
 # ---------------------------------------------------------------------------
 # Page Builders
 # ---------------------------------------------------------------------------
 
-def build_executive_summary(doc, df, epoch, stats, date_label):
-    """Page 1: Executive summary with key metrics and governance state."""
-    # Title
-    title = doc.add_paragraph()
-    title.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    run = title.add_run(f"Feed Quality Analysis \u2014 {date_label}")
-    run.font.name = FONT
-    run.font.size = TITLE_SIZE
-    run.font.color.rgb = ACCENT_RGB
-    run.bold = True
-
-    # Subtitle
+def build_title_page(doc, date_label, epoch):
+    """Title page with report name and subtitle."""
     epoch_id = epoch.get("id", "?")
-    sub = doc.add_paragraph()
-    sub.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    run = sub.add_run(
-        f"Community Governed Feed | feed.corgi.network | Epoch {epoch_id}"
+
+    title = doc.add_paragraph(style="Title")
+    run = title.add_run(f"Feed Quality Analysis")
+    run.font.name = FONT
+
+    # Date subtitle
+    date_p = doc.add_paragraph(style="ReportSubtitle")
+    run = date_p.add_run(date_label)
+    run.font.name = FONT
+
+    # Info line
+    info = doc.add_paragraph(style="ReportSubtitle")
+    run = info.add_run(
+        f"Community-Governed Feed  |  feed.corgi.network  |  Epoch {epoch_id}"
     )
     run.font.name = FONT
     run.font.size = BODY_SIZE
-    run.font.color.rgb = RGBColor(0x80, 0x80, 0x80)
+
+
+def build_executive_summary(doc, df, epoch, stats, date_label):
+    """Executive summary with key metrics and governance state."""
+    styled_heading(doc, "Executive Summary")
 
     # 4-stat banner
     unique_authors = df["author_did"].nunique() if "author_did" in df.columns else 0
@@ -377,18 +894,20 @@ def build_executive_summary(doc, df, epoch, stats, date_label):
         embedding_pct = (emb_count / len(df) * 100) if len(df) > 0 else 0
 
     banner_data = [
-        ("Posts in Feed", str(len(df))),
-        ("Unique Authors", str(unique_authors)),
+        ("Posts in Scope", format_int(len(df))),
+        ("Unique Authors", format_int(unique_authors)),
         ("Median Score", f"{median_score:.3f}"),
         ("% Embedding", f"{embedding_pct:.1f}%"),
     ]
     table = doc.add_table(rows=2, cols=4)
     table.alignment = WD_TABLE_ALIGNMENT.CENTER
+    set_table_borders(table, size=4, inside_v=True)
     for i, (label, value) in enumerate(banner_data):
         # Value row (large number)
         cell = table.rows[0].cells[i]
         cell.text = value
         set_cell_shading(cell, ACCENT_COLOR)
+        set_cell_margins(cell, top=80, bottom=60, left=40, right=40)
         for p in cell.paragraphs:
             p.alignment = WD_ALIGN_PARAGRAPH.CENTER
             for run in p.runs:
@@ -400,6 +919,7 @@ def build_executive_summary(doc, df, epoch, stats, date_label):
         cell = table.rows[1].cells[i]
         cell.text = label
         set_cell_shading(cell, LIGHT_ACCENT)
+        set_cell_margins(cell, top=40, bottom=40, left=40, right=40)
         for p in cell.paragraphs:
             p.alignment = WD_ALIGN_PARAGRAPH.CENTER
             for run in p.runs:
@@ -407,22 +927,30 @@ def build_executive_summary(doc, df, epoch, stats, date_label):
                 run.font.size = SMALL_SIZE
                 run.font.color.rgb = ACCENT_RGB
 
-    doc.add_paragraph()  # spacer
-
     # Summary paragraph
     total_posts = stats.get("total_posts", "?")
-    last_24h = stats.get("last_24h", "?")
     scored_count = stats.get("scored_count", len(df))
-    top_topic = df["primary_topic"].value_counts().index[0] if "primary_topic" in df.columns and len(df) > 0 else "unknown"
+    topic_count = df["primary_topic"].nunique() if "primary_topic" in df.columns else 0
     summary = (
-        f"The feed currently contains {scored_count} scored posts from "
-        f"{unique_authors} unique authors across {df['primary_topic'].nunique() if 'primary_topic' in df.columns else 0} "
-        f"topic categories. "
-        f"The most common topic is \"{top_topic.replace('-', ' ').title()}\". "
-        f"In the last 24 hours, {last_24h} new posts were ingested out of "
-        f"{total_posts} total indexed posts."
+        f"The top {len(df):,} feed posts span {format_int(unique_authors)} unique "
+        f"authors across {format_int(topic_count)} topics. The database contains "
+        f"{format_int(total_posts)} indexed posts with {format_int(scored_count)} "
+        f"scored in the current epoch."
     )
-    styled_paragraph(doc, summary)
+    p = styled_paragraph(doc, summary)
+    p.paragraph_format.space_before = Pt(12)
+
+    # Key Takeaways
+    top_topic = (
+        df["primary_topic"].value_counts().index[0]
+        if "primary_topic" in df.columns and len(df) > 0
+        else "unknown"
+    )
+    add_callout_box(doc, [
+        f"Most represented topic: {top_topic.replace('-', ' ').title()}",
+        f"{embedding_pct:.1f}% of analyzed posts used embedding classification",
+        f"{format_int(unique_authors)} unique authors contribute to feed diversity",
+    ])
 
     # Governance weights table
     styled_heading(doc, "Epoch Weights", level=2)
@@ -433,32 +961,89 @@ def build_executive_summary(doc, df, epoch, stats, date_label):
     for name, key in zip(weight_names, weight_keys):
         val = epoch.get(key, "?")
         weight_rows.append((name, f"{val:.2f}" if isinstance(val, (int, float)) else str(val)))
-    weight_rows.append(("Vote Count", str(epoch.get("vote_count", "?"))))
-    add_styled_table(doc, ["Parameter", "Value"], weight_rows)
+    weight_rows.append(("Vote Count", format_int(epoch.get("vote_count", "?"))))
+    add_styled_table(
+        doc,
+        ["Parameter", "Value"],
+        weight_rows,
+        col_widths=[Inches(4.7), Inches(2.0)],
+        numeric_cols={1},
+    )
 
-    # Top 10 topic weights
+
+def build_methodology_block(doc, epoch, stats, date_label):
+    """Data freshness and methodology disclosure block."""
+    styled_heading(doc, "Methodology & Data Freshness", level=2)
+
+    # Methodology content in a subtle box
+    box = doc.add_table(rows=1, cols=1)
+    box.alignment = WD_TABLE_ALIGNMENT.CENTER
+    set_table_borders(box, color=BORDER_COLOR, size=4)
+    cell = box.rows[0].cells[0]
+    set_cell_shading(cell, CARD_BG)
+    set_cell_margins(cell, top=120, bottom=120, left=160, right=160)
+
+    epoch_id = epoch.get("id", "?")
+    created_at = epoch.get("created_at", "unknown")
+    total_posts = format_int(stats.get("total_posts", "?"))
+    scored_count = format_int(stats.get("scored_count", "?"))
+    last_24h = format_int(stats.get("last_24h", "?"))
+    gen_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+
+    lines = [
+        f"Scope: Top 1,000 scored posts from the active governance epoch.",
+        f"Epoch: {epoch_id} (created {created_at}).",
+        f"Database: {total_posts} total indexed posts, {scored_count} scored this epoch, "
+        f"{last_24h} ingested in last 24 hours.",
+        f"Generated: {gen_time}.",
+        f"Note: Engagement metrics (likes, reposts, replies) reflect counts at time of "
+        f"data extraction and may differ from current values.",
+    ]
+
+    p = cell.paragraphs[0]
+    p.text = ""
+    for i, line in enumerate(lines):
+        if i > 0:
+            p = cell.add_paragraph()
+        p.style = doc.styles["MethodologyBody"]
+        run = p.add_run(line)
+        run.font.name = FONT
+        run.font.size = METHODOLOGY_SIZE
+        run.font.color.rgb = TEXT_SECONDARY_RGB
+
+
+def build_topic_weights_page(doc, epoch):
+    """Dedicated topic-weight table to avoid overflow on executive page."""
     topic_weights = epoch.get("topic_weights", {})
-    if topic_weights and isinstance(topic_weights, dict):
-        doc.add_paragraph()
-        styled_heading(doc, "Top 10 Topic Weights", level=2)
-        sorted_tw = sorted(topic_weights.items(), key=lambda x: x[1], reverse=True)[:10]
-        tw_rows = [(slug.replace("-", " ").title(), f"{w:.3f}") for slug, w in sorted_tw]
-        add_styled_table(doc, ["Topic", "Weight"], tw_rows)
+    if not (topic_weights and isinstance(topic_weights, dict)):
+        return False
 
-    doc.add_page_break()
+    styled_heading(doc, "Topic Weights")
+    styled_paragraph(
+        doc,
+        "Topic-level governance weights for the currently active epoch.",
+    )
+    sorted_tw = sorted(topic_weights.items(), key=lambda x: x[1], reverse=True)[:10]
+    tw_rows = [(slug.replace("-", " ").title(), f"{w:.3f}") for slug, w in sorted_tw]
+    add_styled_table(
+        doc,
+        ["Topic", "Weight"],
+        tw_rows,
+        col_widths=[Inches(4.7), Inches(2.0)],
+        numeric_cols={1},
+    )
+    return True
 
 
 def build_topic_page(doc, df):
-    """Page 2: Topic distribution chart and stats table."""
+    """Topic distribution chart and stats table."""
     styled_heading(doc, "Topic Distribution")
 
     # Chart
     chart_bytes = generate_topic_chart(df)
-    doc.add_picture(io.BytesIO(chart_bytes), width=Inches(6))
-    last_paragraph = doc.paragraphs[-1]
-    last_paragraph.alignment = WD_ALIGN_PARAGRAPH.CENTER
-
-    doc.add_paragraph()
+    doc.add_picture(io.BytesIO(chart_bytes), width=Inches(6.6))
+    doc.paragraphs[-1].alignment = WD_ALIGN_PARAGRAPH.CENTER
+    styled_caption(doc, "Figure 1. Top topics among the top 1,000 scored posts.")
 
     # Stats table
     topic_stats = df.groupby("primary_topic").agg(
@@ -472,28 +1057,53 @@ def build_topic_page(doc, df):
         pct = (row["count"] / total * 100) if total > 0 else 0
         rows.append((
             str(topic).replace("-", " ").title(),
-            str(int(row["count"])),
+            format_int(row["count"]),
             f"{pct:.1f}%",
             f"{row['avg_relevance']:.3f}",
         ))
-    add_styled_table(doc, ["Topic", "Post Count", "% of Feed", "Avg Relevance"], rows)
+    add_styled_table(
+        doc,
+        ["Topic", "Post Count", "% of Feed", "Avg Relevance"],
+        rows,
+        col_widths=[Inches(3.3), Inches(1.1), Inches(1.1), Inches(1.2)],
+        numeric_cols={1, 2, 3},
+    )
 
-    doc.add_page_break()
+    # Key Takeaways
+    top3_pct = (
+        df["primary_topic"].value_counts().head(3).sum() / len(df) * 100
+        if len(df) > 0 and "primary_topic" in df.columns
+        else 0
+    )
+    top_relevance_topic = (
+        topic_stats["avg_relevance"].idxmax()
+        if len(topic_stats) > 0 else "unknown"
+    )
+    top_relevance_val = (
+        topic_stats["avg_relevance"].max()
+        if len(topic_stats) > 0 else 0
+    )
+    total_topics = df["primary_topic"].nunique() if "primary_topic" in df.columns else 0
+
+    add_callout_box(doc, [
+        f"Top 3 topics account for {top3_pct:.1f}% of the analyzed feed sample",
+        f"Highest avg relevance: {str(top_relevance_topic).replace('-', ' ').title()} "
+        f"({top_relevance_val:.3f})",
+        f"{format_int(total_topics)} distinct topics detected across the sample",
+    ])
 
 
 def build_score_page(doc, df):
-    """Page 3: Score composition box plot and stats."""
+    """Score composition box plot and stats (rendered on landscape page)."""
     styled_heading(doc, "Score Composition")
 
     # Box plot chart
     chart_bytes = generate_score_boxplot(df)
-    doc.add_picture(io.BytesIO(chart_bytes), width=Inches(6))
-    last_paragraph = doc.paragraphs[-1]
-    last_paragraph.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    doc.add_picture(io.BytesIO(chart_bytes), width=Inches(8.5))
+    doc.paragraphs[-1].alignment = WD_ALIGN_PARAGRAPH.CENTER
+    styled_caption(doc, "Figure 2. Distribution of raw score components before weighting.")
 
-    doc.add_paragraph()
-
-    # Stats table
+    # Stats table — wider columns for landscape
     headers = ["Component", "Min", "P25", "Median", "P75", "Max", "Weight"]
     rows = []
     for col, label, wcol in zip(SCORE_COMPONENTS, COMPONENT_LABELS, WEIGHT_COLUMNS):
@@ -508,86 +1118,147 @@ def build_score_page(doc, df):
             f"{series.max():.3f}" if len(series) > 0 else "N/A",
             f"{weight_val:.2f}" if isinstance(weight_val, (int, float)) else str(weight_val),
         ))
-    add_styled_table(doc, headers, rows)
+    add_styled_table(
+        doc,
+        headers,
+        rows,
+        col_widths=[
+            Inches(2.0), Inches(1.2), Inches(1.2), Inches(1.2),
+            Inches(1.2), Inches(1.2), Inches(1.1),
+        ],
+        numeric_cols={1, 2, 3, 4, 5, 6},
+    )
 
-    # Key finding
-    doc.add_paragraph()
+    # Key Takeaways
     medians = {label: df[col].median() for col, label in zip(SCORE_COMPONENTS, COMPONENT_LABELS)}
     highest = max(medians, key=medians.get)
     lowest = min(medians, key=medians.get)
-    styled_paragraph(
-        doc,
-        f"Key finding: {highest} has the highest median raw score "
-        f"({medians[highest]:.3f}), while {lowest} has the lowest "
-        f"({medians[lowest]:.3f}). This suggests the feed's posts tend to "
-        f"score well on {highest.lower()} but have room for improvement in "
-        f"{lowest.lower()}.",
-    )
+    gap = medians[highest] - medians[lowest]
 
-    doc.add_page_break()
+    # Find which weight is highest
+    weight_vals = {}
+    for label, wcol in zip(COMPONENT_LABELS, WEIGHT_COLUMNS):
+        if wcol in df.columns and len(df) > 0:
+            weight_vals[label] = df[wcol].iloc[0]
+    top_weight = max(weight_vals, key=weight_vals.get) if weight_vals else "?"
+    top_weight_val = weight_vals.get(top_weight, 0)
+
+    add_callout_box(doc, [
+        f"{highest} has the highest median raw score ({medians[highest]:.3f}), "
+        f"{lowest} the lowest ({medians[lowest]:.3f})",
+        f"Median gap between highest and lowest components: {gap:.3f}",
+        f"Highest governance weight: {top_weight} ({top_weight_val:.2f})",
+    ])
 
 
 def build_classification_page(doc, df):
-    """Page 4: Classification method split + author diversity."""
-    styled_heading(doc, "Classification & Diversity")
+    """Classification method distribution."""
+    styled_heading(doc, "Classification Methods")
 
     # Donut chart
     chart_bytes = generate_classification_donut(df)
-    doc.add_picture(io.BytesIO(chart_bytes), width=Inches(3.5))
-    last_paragraph = doc.paragraphs[-1]
-    last_paragraph.alignment = WD_ALIGN_PARAGRAPH.CENTER
-
-    doc.add_paragraph()
+    doc.add_picture(io.BytesIO(chart_bytes), width=Inches(4.2))
+    doc.paragraphs[-1].alignment = WD_ALIGN_PARAGRAPH.CENTER
+    styled_caption(doc, "Figure 3. Classification method share in the analyzed sample.")
 
     # Classification stats
     method_counts = df["classification_method"].fillna("unknown").value_counts()
-    method_rows = [(m.capitalize(), str(c), f"{c/len(df)*100:.1f}%")
+    method_rows = [(m.capitalize(), format_int(c), f"{c/len(df)*100:.1f}%")
                    for m, c in method_counts.items()]
-    add_styled_table(doc, ["Method", "Count", "% of Feed"], method_rows)
+    add_styled_table(
+        doc,
+        ["Method", "Count", "% of Feed"],
+        method_rows,
+        col_widths=[Inches(3.3), Inches(1.2), Inches(1.4)],
+        numeric_cols={1, 2},
+    )
 
-    doc.add_paragraph()
+    # Key Takeaways
+    dominant_method = method_counts.index[0] if len(method_counts) > 0 else "unknown"
+    dominant_pct = (method_counts.iloc[0] / len(df) * 100) if len(df) > 0 else 0
+    method_count = len(method_counts)
+    add_callout_box(doc, [
+        f"{str(dominant_method).capitalize()} is the dominant classifier at "
+        f"{dominant_pct:.1f}% of analyzed posts",
+        f"{method_count} classification method(s) active in the current pipeline",
+    ])
+
+
+def build_diversity_page(doc, df):
+    """Author diversity and URL deduplication diagnostics."""
+    styled_heading(doc, "Author Diversity & URL Deduplication")
 
     # Author diversity
-    styled_heading(doc, "Author Diversity", level=2)
-    author_counts = df["author_did"].value_counts()
+    author_counts = df["author_did"].dropna().value_counts()
+    total_unique_authors = df["author_did"].dropna().nunique()
+    avg_posts_per_author = author_counts.mean() if len(author_counts) > 0 else 0
+    max_posts_single_author = int(author_counts.max()) if len(author_counts) > 0 else 0
     styled_paragraph(
         doc,
-        f"Total unique authors: {author_counts.nunique()}. "
-        f"Average posts per author: {author_counts.mean():.1f}. "
-        f"Max posts by single author: {author_counts.max()}.",
+        f"Total unique authors: {format_int(total_unique_authors)}. "
+        f"Average posts per author: {avg_posts_per_author:.1f}. "
+        f"Max posts by single author: {format_int(max_posts_single_author)}.",
     )
 
     # Flag authors with 5+ posts
     heavy_posters = author_counts[author_counts >= 5]
     if len(heavy_posters) > 0:
-        doc.add_paragraph()
-        rows = [(did[:20] + "...", str(count)) for did, count in heavy_posters.head(10).items()]
-        add_styled_table(doc, ["Author DID (truncated)", "Post Count"], rows)
-
-    # URL dedup stats
-    if "uri" in df.columns:
-        doc.add_paragraph()
-        styled_heading(doc, "URL Deduplication", level=2)
-        total = len(df)
-        unique_uris = df["uri"].nunique()
-        styled_paragraph(
+        rows = [(did[:20] + "...", format_int(count))
+                for did, count in heavy_posters.head(10).items()]
+        add_styled_table(
             doc,
-            f"All {unique_uris} post URIs are unique (no duplicates detected "
-            f"out of {total} scored posts)." if unique_uris == total else
-            f"Warning: {total - unique_uris} duplicate URIs detected.",
+            ["Author DID (truncated)", "Post Count"],
+            rows,
+            col_widths=[Inches(4.7), Inches(2.0)],
+            numeric_cols={1},
         )
 
-    doc.add_page_break()
+    # URL dedup stats
+    max_duplicates = 0
+    if "embed_url" in df.columns:
+        styled_heading(doc, "URL Deduplication", level=2)
+        normalized_urls = (
+            df["embed_url"]
+            .dropna()
+            .astype(str)
+            .str.strip()
+        )
+        normalized_urls = normalized_urls[~normalized_urls.isin(["", "null", "None"])]
+
+        url_counts = normalized_urls.value_counts()
+        duplicate_urls = url_counts[url_counts > 1]
+        duplicate_posts = int(duplicate_urls.sum()) if len(duplicate_urls) > 0 else 0
+        max_duplicates = int(duplicate_urls.max()) if len(duplicate_urls) > 0 else 0
+
+        styled_paragraph(
+            doc,
+            f"Posts with an embed URL: {format_int(len(normalized_urls))}. "
+            f"Posts sharing a duplicated embed URL: {format_int(duplicate_posts)} "
+            f"across {format_int(len(duplicate_urls))} URLs. "
+            f"Max duplicates for a single URL: {format_int(max_duplicates)}.",
+        )
+
+    # Key Takeaways
+    max_author_pct = (max_posts_single_author / len(df) * 100) if len(df) > 0 else 0
+    takeaways = [
+        f"Top author concentration: {max_posts_single_author} posts "
+        f"({max_author_pct:.1f}% of sample)",
+        f"{len(heavy_posters)} author(s) have 5+ posts in the top 1,000",
+    ]
+    if max_duplicates > 0:
+        takeaways.append(
+            f"Most repeated external URL appears {format_int(max_duplicates)} times"
+        )
+    add_callout_box(doc, takeaways)
 
 
 def build_engagement_page(doc, df):
-    """Page 5: Engagement profile — top vs bottom comparison."""
+    """Engagement profile - top vs bottom comparison."""
     styled_heading(doc, "Engagement Profile")
 
     if len(df) < 200:
         styled_paragraph(doc, f"Insufficient data for top/bottom comparison "
                          f"(need 200+ posts, have {len(df)}).")
-        doc.add_page_break()
         return
 
     top100 = df.head(100)
@@ -595,67 +1266,78 @@ def build_engagement_page(doc, df):
 
     metrics = ["likes", "reposts", "replies"]
     rows = []
+    ratios = {}
     for metric in metrics:
         if metric not in df.columns:
             continue
         top_med = top100[metric].median()
         bot_med = bottom100[metric].median()
-        ratio = f"{top_med / bot_med:.1f}x" if bot_med > 0 else "inf"
+        ratio_val = top_med / bot_med if bot_med > 0 else float("inf")
+        ratio_str = f"{ratio_val:.1f}x" if bot_med > 0 else "\u221e"
+        ratios[metric] = ratio_str
         rows.append((
             metric.capitalize(),
             f"{top_med:.1f}",
             f"{bot_med:.1f}",
-            ratio,
+            ratio_str,
         ))
 
     add_styled_table(
         doc,
         ["Metric", "Top 100 Median", "Bottom 100 Median", "Ratio"],
         rows,
+        col_widths=[Inches(2.0), Inches(1.5), Inches(1.7), Inches(1.3)],
+        numeric_cols={1, 2, 3},
     )
 
-    doc.add_paragraph()
-
-    # Key finding
+    # Key Takeaways
     if "likes" in df.columns:
         top_likes = top100["likes"].median()
         bot_likes = bottom100["likes"].median()
-        styled_paragraph(
-            doc,
-            f"Key finding: The top-scoring 100 posts have a median of "
-            f"{top_likes:.0f} likes compared to {bot_likes:.0f} for the "
-            f"bottom 100, suggesting the scoring algorithm is effectively "
-            f"surfacing content that resonates with the community.",
+        ratio = (top_likes / bot_likes) if bot_likes > 0 else 0
+
+        takeaways = [
+            f"Top-ranked posts receive ~{ratio:.1f}x median likes vs bottom-ranked",
+        ]
+        if "reposts" in ratios:
+            takeaways.append(
+                f"Repost ratio: {ratios['reposts']} (top 100 vs bottom 100)"
+            )
+        takeaways.append(
+            "Scoring algorithm effectively surfaces community-resonant content"
         )
+        add_callout_box(doc, takeaways)
 
-    doc.add_page_break()
 
+def build_sample_posts_page(doc, subset, title, intro_text, is_appendix=False):
+    """Sample post table, optionally styled as appendix (landscape expected)."""
+    if is_appendix:
+        add_horizontal_rule(doc)
+        styled_heading(doc, title, style_name="AppendixHeading")
+        styled_paragraph(doc, intro_text, size=METHODOLOGY_SIZE)
+    else:
+        styled_heading(doc, title)
+        styled_paragraph(doc, intro_text)
 
-def build_sample_posts_page(doc, df):
-    """Page 6: Top 10 and bottom 10 sample posts."""
-    styled_heading(doc, "Sample Posts")
+    rows = []
+    for _, row in subset.iterrows():
+        text = str(row.get("text", ""))[:100]
+        if len(str(row.get("text", ""))) > 100:
+            text += "..."
+        topic = str(row.get("primary_topic", "?")).replace("-", " ").title()
+        score = f"{row.get('total_score', 0):.3f}"
+        likes = format_int(int(row.get("likes", 0)))
+        method = str(row.get("classification_method", "?")).capitalize()
+        rows.append((text, topic, score, likes, method))
 
-    def post_table(doc, subset, title):
-        styled_heading(doc, title, level=2)
-        rows = []
-        for _, row in subset.iterrows():
-            text = str(row.get("text", ""))[:120]
-            if len(str(row.get("text", ""))) > 120:
-                text += "..."
-            topic = str(row.get("primary_topic", "?")).replace("-", " ").title()
-            score = f"{row.get('total_score', 0):.3f}"
-            likes = str(int(row.get("likes", 0)))
-            method = str(row.get("classification_method", "?"))
-            rows.append((text, topic, score, likes, method))
-        add_styled_table(
-            doc,
-            ["Text Preview", "Topic", "Score", "Likes", "Method"],
-            rows,
-        )
-
-    post_table(doc, df.head(10), "Top 10 Posts")
-    doc.add_paragraph()
-    post_table(doc, df.tail(10), "Bottom 10 Posts")
+    # Landscape widths
+    add_styled_table(
+        doc,
+        ["Text Preview", "Topic", "Score", "Likes", "Method"],
+        rows,
+        col_widths=[Inches(4.5), Inches(1.5), Inches(1.0), Inches(0.8), Inches(1.2)],
+        numeric_cols={2, 3},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -665,7 +1347,7 @@ def build_sample_posts_page(doc, df):
 def print_dry_run(df, epoch, stats):
     """Print data summary to stdout without generating docx."""
     print("\n" + "=" * 60)
-    print("DRY RUN \u2014 Data Summary")
+    print("DRY RUN - Data Summary")
     print("=" * 60)
 
     print(f"\nPosts loaded: {len(df)}")
@@ -746,21 +1428,78 @@ def main():
         print_dry_run(df, epoch, stats)
         return
 
+    # Initialize matplotlib
+    setup_matplotlib_defaults()
+
     # Build document
     print(f"Generating report: {output_path}")
     doc = Document()
 
-    # Set default font
-    style = doc.styles["Normal"]
-    style.font.name = FONT
-    style.font.size = BODY_SIZE
+    # Global document theme/layout
+    configure_document_styles(doc)
+    first_section = doc.sections[0]
+    configure_section_layout(first_section, landscape=False)
+    epoch_id = epoch.get("id", "?")
+    set_document_header_footer(first_section, date_label, epoch_id)
 
+    # --- Title Page ---
+    build_title_page(doc, date_label, epoch)
+    doc.add_page_break()
+
+    # --- Table of Contents ---
+    add_table_of_contents(doc)
+    doc.add_page_break()
+
+    # --- Executive Summary ---
     build_executive_summary(doc, df, epoch, stats, date_label)
+
+    # --- Methodology ---
+    build_methodology_block(doc, epoch, stats, date_label)
+
+    # --- Topic Weights (if available) ---
+    topic_weights = epoch.get("topic_weights")
+    if topic_weights and isinstance(topic_weights, dict):
+        doc.add_page_break()
+        build_topic_weights_page(doc, epoch)
+
+    # --- Topic Distribution ---
+    doc.add_page_break()
     build_topic_page(doc, df)
+
+    # --- Score Composition (landscape) ---
+    add_landscape_section(doc, date_label, epoch_id)
     build_score_page(doc, df)
+
+    # --- Classification Methods (portrait) ---
+    restore_portrait_section(doc, date_label, epoch_id)
     build_classification_page(doc, df)
+
+    # --- Author Diversity ---
+    doc.add_page_break()
+    build_diversity_page(doc, df)
+
+    # --- Engagement Profile ---
+    doc.add_page_break()
     build_engagement_page(doc, df)
-    build_sample_posts_page(doc, df)
+
+    # --- Appendix (landscape) ---
+    add_landscape_section(doc, date_label, epoch_id)
+    build_sample_posts_page(
+        doc,
+        df.head(10),
+        "Appendix A \u2014 Top 10 Sample Posts",
+        "These examples are included for qualitative review and traceability. "
+        "They are not exhaustive of all scored content.",
+        is_appendix=True,
+    )
+    doc.add_page_break()
+    build_sample_posts_page(
+        doc,
+        df.tail(10),
+        "Appendix B \u2014 Bottom 10 Sample Posts",
+        "Lower-ranked examples from the same top-1,000 analysis scope.",
+        is_appendix=True,
+    )
 
     # Ensure output directory exists
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)

--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -35,7 +35,7 @@ from docx.enum.table import WD_TABLE_ALIGNMENT
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
-from docx.shared import Inches, Pt, RGBColor, Twips
+from docx.shared import Inches, Pt, RGBColor
 from report_utils import format_int
 
 # ---------------------------------------------------------------------------
@@ -1348,16 +1348,16 @@ def print_dry_run(df, epoch, stats):
     print(f"Median total score: {df['total_score'].median():.4f}")
 
     if "classification_method" in df.columns:
-        print(f"\nClassification methods:")
+        print("\nClassification methods:")
         for method, count in df["classification_method"].fillna("unknown").value_counts().items():
             print(f"  {method}: {count} ({count/len(df)*100:.1f}%)")
 
     if "primary_topic" in df.columns:
-        print(f"\nTop 10 topics:")
+        print("\nTop 10 topics:")
         for topic, count in df["primary_topic"].value_counts().head(10).items():
             print(f"  {topic}: {count}")
 
-    print(f"\nScore components (medians):")
+    print("\nScore components (medians):")
     for col, label in zip(SCORE_COMPONENTS, COMPONENT_LABELS):
         if col in df.columns:
             print(f"  {label}: {df[col].median():.4f}")

--- a/scripts/report_utils.py
+++ b/scripts/report_utils.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Shared utility helpers for report-generation scripts."""
+
+from typing import Any
+
+
+def format_int(value: Any) -> str:
+    """Format integer-like values with thousands separators."""
+    try:
+        return f"{int(value):,}"
+    except (TypeError, ValueError):
+        return str(value)


### PR DESCRIPTION
## Summary
- add a new report generator (`scripts/generate-report-pdf.py`) that renders deterministic print-friendly PDFs from live feed data using HTML/CSS + Playwright
- keep light-mode design language aligned with voting UI tokens and add robust table/chart rendering
- harden `scripts/generate-report.py` pagination/layout behavior and add `npm run report:pdf` shortcut

## Why
Word/docx pagination can vary across machines and data shape. This adds a stable, code-driven print pipeline to avoid overflow/orientation surprises in future runs.

## Validation
- `python3 -m py_compile scripts/generate-report.py scripts/generate-report-pdf.py`
- `MPLCONFIGDIR=/tmp python3 scripts/generate-report-pdf.py --date "March 15, 2026" --output reports/sprint-data-analysis-mar15.pdf --html-output reports/sprint-data-analysis-mar15.preview.html`
- `pdfinfo reports/sprint-data-analysis-mar15.pdf`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end PDF report generation for feed-quality analysis with cover, executive summary, tables, appendices, and multiple chart types.
  * CLI options for CSV/JSON input, live extraction, HTML preview, dry-run, and output PDF.

* **Improvements**
  * Token-driven visual design, refined typography, enhanced table styling, headers/footers, TOC, landscape appendix, and consistent chart styling.
  * New visuals: topic bars, score boxplots, classification donut.

* **Chores**
  * Added report-generation and local build scripts; small formatting utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->