### PR TITLE
Add automated docs freshness and drift checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,7 @@
 - [ ] `MPLCONFIGDIR=/tmp python3 scripts/generate-report-pdf.py --csv tests/fixtures/report/report-sample.csv --epoch-json tests/fixtures/report/epoch-sample.json --dry-run` passes
 - [ ] `npm audit --audit-level=moderate` passes
 - [ ] `cd web && npm audit --audit-level=moderate` passes
+- [ ] `npm run docs:verify` passes
 - [ ] Migrations included for schema changes
 - [ ] No hardcoded secrets, DIDs, or production domains
 - [ ] Parameterized SQL only (no string interpolation)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,22 @@ permissions:
   contents: read
 
 jobs:
+  docs-verify:
+    name: docs-verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "20"
+
+      - name: Verify docs freshness and integrity
+        run: npm run docs:verify
+
   backend-verify:
     name: backend-verify
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -1,0 +1,73 @@
+name: Docs Freshness
+
+on:
+  schedule:
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  docs-freshness:
+    name: docs-freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "20"
+
+      - name: Run docs verification
+        id: docs_verify
+        continue-on-error: true
+        run: npm run docs:verify
+
+      - name: Open or update docs freshness issue on failure
+        if: steps.docs_verify.outcome == 'failure'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.1
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = 'Docs freshness check failed';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              'The scheduled docs freshness check failed.',
+              '',
+              `- Workflow run: ${runUrl}`,
+              '- Local repro: `npm run docs:verify`',
+              '- Update stale docs and refresh review dates in `docs/freshness.json`.',
+            ].join('\n');
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = openIssues.find(issue => issue.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['documentation'],
+              });
+            }
+
+      - name: Fail workflow if docs verification failed
+        if: steps.docs_verify.outcome == 'failure'
+        run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Bluesky content label filtering (replaces keyword-based NSFW exclusion)
 - Topic taxonomy with co-occurrence disambiguation
 - Hardened PR CI workflow (`backend-verify`, `frontend-verify`, `report-scripts-verify`)
+- Docs freshness automation (`npm run docs:verify`) with CI gate and scheduled GitHub workflow
 - CodeQL scanning workflow and branch-protection-required check integration
 - Offline report fixture data + pinned Python report requirements for reproducible script validation
 - Roadmap, release policy, and issue triage policy docs
@@ -20,6 +21,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - README command examples and tooling descriptions updated to match current CLI and MCP behavior
 - PR template and contributing checklist now enforce changelog and security/audit validation gates
 - PR template and contributor guide now enforce small, single-purpose PR scope and Linear-linked branch/PR conventions
+- MCP/setup, stability, status, and system-overview docs updated to match current command syntax and tool counts
 
 ## [1.1.0] — 2026-03-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ npm run migrate
 - Build frontend: `cd web && npm run build`
 - Run frontend dev server: `cd web && npm run dev`
 - Full local gate: `npm run verify`
+- Docs freshness gate: `npm run docs:verify`
 
 ## Project Structure
 
@@ -101,6 +102,7 @@ npm run migrate
 - `MPLCONFIGDIR=/tmp python3 scripts/generate-report-pdf.py --csv tests/fixtures/report/report-sample.csv --epoch-json tests/fixtures/report/epoch-sample.json --dry-run` passes
 - `npm audit --audit-level=moderate` passes
 - `cd web && npm audit --audit-level=moderate` passes
+- `npm run docs:verify` passes
 - `CHANGELOG.md` updated for user/operator-visible changes
 - Migrations included for schema changes
 - Notes included for operational or rollout impact

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ cd web && npm run dev
 
 ```bash
 npm run verify
+npm run docs:verify
 python3 -m py_compile scripts/generate-report.py scripts/generate-report-pdf.py scripts/report_utils.py
 MPLCONFIGDIR=/tmp python3 scripts/generate-report.py --csv tests/fixtures/report/report-sample.csv --epoch-json tests/fixtures/report/epoch-sample.json --dry-run
 MPLCONFIGDIR=/tmp python3 scripts/generate-report-pdf.py --csv tests/fixtures/report/report-sample.csv --epoch-json tests/fixtures/report/epoch-sample.json --dry-run

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,6 +21,7 @@ Run from repository root:
 
 ```bash
 npm run verify
+npm run docs:verify
 python3 -m py_compile scripts/generate-report.py scripts/generate-report-pdf.py scripts/report_utils.py
 MPLCONFIGDIR=/tmp python3 scripts/generate-report.py --csv tests/fixtures/report/report-sample.csv --epoch-json tests/fixtures/report/epoch-sample.json --dry-run
 MPLCONFIGDIR=/tmp python3 scripts/generate-report-pdf.py --csv tests/fixtures/report/report-sample.csv --epoch-json tests/fixtures/report/epoch-sample.json --dry-run

--- a/docs/MCP_SETUP.md
+++ b/docs/MCP_SETUP.md
@@ -26,7 +26,7 @@ Content-Type: application/json
 Accept: application/json, text/event-stream
 ```
 
-## Tools (23 total)
+## Tools (30 total)
 
 ### Governance (10)
 
@@ -53,6 +53,16 @@ Accept: application/json, text/event-stream
 | `explain_post_score` | Detailed score breakdown for a specific post |
 | `counterfactual_analysis` | What-if analysis with hypothetical weights |
 
+### Topics (5)
+
+| Tool | Description |
+|------|-------------|
+| `list_topics` | List all topics in the catalog with post counts and weights |
+| `add_topic` | Add a new topic to the voting catalog |
+| `update_topic` | Update a topic's metadata and terms |
+| `get_topic_stats` | Topic classification coverage and distribution summary |
+| `classify_text` | Debug classify arbitrary text against the taxonomy |
+
 ### Participants (3)
 
 | Tool | Description |
@@ -75,6 +85,13 @@ Accept: application/json, text/event-stream
 |------|-------------|
 | `list_announcements` | List all announcements |
 | `send_announcement` | Post an announcement (max 280 chars) |
+
+### Reports (2)
+
+| Tool | Description |
+|------|-------------|
+| `generate_feed_report` | Generate the DOCX feed quality report |
+| `get_feed_snapshot` | Return current feed/admin status snapshot JSON |
 
 ## Client Configuration
 

--- a/docs/STABILITY_TEST.md
+++ b/docs/STABILITY_TEST.md
@@ -14,7 +14,7 @@ The stability test validates that the system can:
 
 Before starting the test, verify:
 
-- [ ] Docker containers running (`docker-compose ps`)
+- [ ] Docker containers running (`docker compose ps`)
 - [ ] PostgreSQL has recent data (`SELECT COUNT(*) FROM posts`)
 - [ ] Redis is operational (`redis-cli ping`)
 - [ ] Application starts without errors (`npm run dev`)
@@ -29,7 +29,7 @@ Before starting the test, verify:
 NODE_ENV=production npm run start
 
 # Or with Docker
-docker-compose up -d
+docker compose up -d
 ```
 
 Record start time: `_____________`
@@ -43,7 +43,7 @@ Set up a cron job or monitoring tool to check:
 ```bash
 # Health check
 curl -s http://localhost:3000/health | jq '.status'
-# Expected: "healthy"
+# Expected: "ok"
 
 # Verify feed is returning data
 curl -s "http://localhost:3000/xrpc/app.bsky.feed.getFeedSkeleton?feed=at://...&limit=1" | jq '.feed | length'
@@ -99,9 +99,9 @@ Run each of these once during the 24-hour period:
 #### 1. PostgreSQL Restart (Hour 4)
 
 ```bash
-docker-compose stop postgres
+docker compose stop postgres
 sleep 30
-docker-compose start postgres
+docker compose start postgres
 ```
 
 **Expected behavior:**
@@ -119,9 +119,9 @@ curl http://localhost:3000/health
 #### 2. Redis Restart (Hour 8)
 
 ```bash
-docker-compose stop redis
+docker compose stop redis
 sleep 30
-docker-compose start redis
+docker compose start redis
 ```
 
 **Expected behavior:**

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -75,6 +75,6 @@ Read these files in order:
 3. `docs/SYSTEM_OVERVIEW.md` — Detailed system walkthrough
 4. `docs/dev-journal.md` — Chronological record of every change with rationale
 
-The full test suite: `npm run build && npm test -- --run` (402 tests across 66 files, should all pass)
+The full test suite: `npm run build && npm test -- --run` (400+ tests, should all pass)
 
 Key architectural decisions are documented in the dev journal entries under "Decisions & alternatives" — read those before proposing changes to understand why things are the way they are.

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -242,10 +242,10 @@ cd web && npm run dev    # Start frontend (port 5173)
 
 # Database
 npm run migrate          # Run migrations
-npm run score            # Manually trigger scoring
+npm run cli -- feed rescore  # Manually trigger scoring
 
 # Production
-docker-compose up -d     # Start PostgreSQL + Redis
+docker compose up -d     # Start PostgreSQL + Redis
 npm run build            # Compile TypeScript
 npm start                # Start production server
 ```

--- a/docs/freshness.json
+++ b/docs/freshness.json
@@ -1,0 +1,83 @@
+{
+  "maxAgeDays": 120,
+  "scanPaths": [
+    "README.md",
+    "CONTRIBUTING.md",
+    "RELEASING.md",
+    "ROADMAP.md",
+    "SUPPORT.md",
+    "docs",
+    ".github/PULL_REQUEST_TEMPLATE.md"
+  ],
+  "ignoreFilesForLint": [
+    "docs/dev-journal.md",
+    "docs/SECURITY_AUDIT.md"
+  ],
+  "documents": [
+    {
+      "path": "README.md",
+      "owner": "core",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "owner": "core",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "RELEASING.md",
+      "owner": "core",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "ROADMAP.md",
+      "owner": "core",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "SUPPORT.md",
+      "owner": "core",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "docs/SYSTEM_OVERVIEW.md",
+      "owner": "core",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "docs/DEPLOYMENT.md",
+      "owner": "ops",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "docs/OPS_RUNBOOK.md",
+      "owner": "ops",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "docs/MCP_SETUP.md",
+      "owner": "platform",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "docs/STABILITY_TEST.md",
+      "owner": "ops",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "docs/STATUS.md",
+      "owner": "core",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "docs/ISSUE_TRIAGE.md",
+      "owner": "core",
+      "lastReviewed": "2026-03-16"
+    },
+    {
+      "path": "docs/SECURITY.md",
+      "owner": "security",
+      "lastReviewed": "2026-03-16"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "generate:route": "tsx scripts/generate-route.ts",
     "cli": "cd cli && npx tsx src/index.ts",
     "cli:build": "cd cli && tsc",
+    "docs:verify": "node scripts/verify-docs.mjs",
     "seed-topics": "tsx scripts/seed-topics.ts",
     "backfill-topics": "tsx scripts/backfill-topics.ts",
     "report:pdf": "python3 scripts/generate-report-pdf.py",

--- a/scripts/verify-docs.mjs
+++ b/scripts/verify-docs.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const FRESHNESS_CONFIG_PATH = path.join(repoRoot, 'docs', 'freshness.json');
+const MCP_SETUP_PATH = path.join(repoRoot, 'docs', 'MCP_SETUP.md');
+const MCP_TOOL_SOURCE_DIR = path.join(repoRoot, 'src', 'mcp', 'tools');
+
+const LINK_REGEX = /!?\[[^\]]*]\(([^)]+)\)/g;
+const NPM_RUN_REGEX = /\bnpm run ([a-zA-Z0-9:_-]+)\b/g;
+
+const DEPRECATED_PATTERNS = [
+  { regex: /\b(epoch:status|votes:summary|feed:stats|topics:list|export:votes|scoring:trigger)\b/, message: 'Legacy colon-style CLI syntax found' },
+  { regex: /\bdocker-compose(?:\s+[a-zA-Z]|$)/, message: 'Use "docker compose" (space) instead of "docker-compose"' },
+];
+
+const DEFAULT_SCAN_PATHS = [
+  'README.md',
+  'CONTRIBUTING.md',
+  'RELEASING.md',
+  'ROADMAP.md',
+  'SUPPORT.md',
+  'docs',
+  '.github/PULL_REQUEST_TEMPLATE.md',
+];
+
+function walkMarkdownFiles(rootDir) {
+  const files = [];
+  const queue = [rootDir];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) continue;
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist') continue;
+        queue.push(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        files.push(fullPath);
+      }
+    }
+  }
+  return files;
+}
+
+function collectMarkdownFiles(scanPaths) {
+  const out = new Set();
+  for (const relPath of scanPaths) {
+    const absPath = path.join(repoRoot, relPath);
+    if (!existsSync(absPath)) continue;
+    const stats = statSync(absPath);
+    if (stats.isDirectory()) {
+      for (const file of walkMarkdownFiles(absPath)) {
+        out.add(file);
+      }
+      continue;
+    }
+    if (stats.isFile() && absPath.endsWith('.md')) {
+      out.add(absPath);
+    }
+  }
+  return Array.from(out);
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function relative(filePath) {
+  return path.relative(repoRoot, filePath).replace(/\\/g, '/');
+}
+
+function splitLinkTarget(target) {
+  const clean = target.trim().replace(/^<|>$/g, '');
+  const hashIndex = clean.indexOf('#');
+  if (hashIndex === -1) return { pathPart: clean, anchor: '' };
+  return { pathPart: clean.slice(0, hashIndex), anchor: clean.slice(hashIndex + 1) };
+}
+
+function isExternalLink(target) {
+  return (
+    target.startsWith('http://') ||
+    target.startsWith('https://') ||
+    target.startsWith('mailto:') ||
+    target.startsWith('tel:') ||
+    target.startsWith('#')
+  );
+}
+
+function resolveLink(baseFile, targetPath) {
+  if (targetPath.startsWith('/')) {
+    return path.join(repoRoot, targetPath.slice(1));
+  }
+  return path.resolve(path.dirname(baseFile), targetPath);
+}
+
+function getWorkflowCheckNames(ciPath) {
+  const content = readFileSync(ciPath, 'utf8');
+  const matches = [...content.matchAll(/^\s{2}([a-z0-9-]+):\s*$/gm)];
+  return matches.map(m => m[1]);
+}
+
+function validateFreshness(config, problems) {
+  const now = new Date();
+  const maxAgeDays = Number(config.maxAgeDays);
+  if (!Number.isFinite(maxAgeDays) || maxAgeDays <= 0) {
+    problems.push('docs/freshness.json: maxAgeDays must be a positive number');
+    return;
+  }
+
+  for (const doc of config.documents ?? []) {
+    const docPath = path.join(repoRoot, doc.path ?? '');
+    if (!doc.path || typeof doc.path !== 'string') {
+      problems.push('docs/freshness.json: each document requires a string path');
+      continue;
+    }
+    if (!existsSync(docPath)) {
+      problems.push(`freshness: missing document "${doc.path}"`);
+      continue;
+    }
+    const reviewedAt = new Date(doc.lastReviewed);
+    if (!doc.lastReviewed || Number.isNaN(reviewedAt.getTime())) {
+      problems.push(`freshness: ${doc.path} has invalid lastReviewed date "${doc.lastReviewed}"`);
+      continue;
+    }
+    const ageMs = now.getTime() - reviewedAt.getTime();
+    const ageDays = Math.floor(ageMs / (1000 * 60 * 60 * 24));
+    if (ageDays > maxAgeDays) {
+      problems.push(
+        `freshness: ${doc.path} is ${ageDays} days old (> ${maxAgeDays}); update docs/freshness.json lastReviewed`
+      );
+    }
+  }
+}
+
+function validateMarkdownLinks(markdownFiles, problems) {
+  for (const file of markdownFiles) {
+    const content = readFileSync(file, 'utf8');
+    for (const match of content.matchAll(LINK_REGEX)) {
+      const rawTarget = match[1]?.trim() ?? '';
+      if (!rawTarget || isExternalLink(rawTarget)) continue;
+
+      const withoutTitle = rawTarget.split(/\s+"/)[0];
+      const { pathPart } = splitLinkTarget(withoutTitle);
+      if (!pathPart) continue;
+
+      const resolved = resolveLink(file, decodeURIComponent(pathPart));
+      if (!existsSync(resolved)) {
+        problems.push(
+          `broken link: ${relative(file)} -> ${rawTarget}`
+        );
+      }
+    }
+  }
+}
+
+function validateNpmRunCommands(markdownFiles, problems) {
+  const rootScripts = new Set(Object.keys(readJson(path.join(repoRoot, 'package.json')).scripts ?? {}));
+  const webScripts = new Set(Object.keys(readJson(path.join(repoRoot, 'web', 'package.json')).scripts ?? {}));
+  const cliScripts = new Set(Object.keys(readJson(path.join(repoRoot, 'cli', 'package.json')).scripts ?? {}));
+
+  for (const file of markdownFiles) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, idx) => {
+      for (const match of line.matchAll(NPM_RUN_REGEX)) {
+        const scriptName = match[1];
+        const isWebContext = /cd\s+web\b/.test(line);
+        const isCliContext = /cd\s+cli\b/.test(line);
+        const valid = isWebContext
+          ? webScripts.has(scriptName)
+          : isCliContext
+            ? cliScripts.has(scriptName)
+            : rootScripts.has(scriptName);
+
+        if (!valid) {
+          const scope = isWebContext ? 'web/package.json' : isCliContext ? 'cli/package.json' : 'package.json';
+          problems.push(
+            `invalid npm script: ${relative(file)}:${idx + 1} -> "${scriptName}" not found in ${scope}`
+          );
+        }
+      }
+    });
+  }
+}
+
+function validateDeprecatedPatterns(markdownFiles, ignoreSet, problems) {
+  for (const file of markdownFiles) {
+    const rel = relative(file);
+    if (ignoreSet.has(rel)) continue;
+    const content = readFileSync(file, 'utf8');
+    for (const { regex, message } of DEPRECATED_PATTERNS) {
+      if (regex.test(content)) {
+        problems.push(`${message}: ${rel}`);
+      }
+    }
+  }
+}
+
+function validateMcpToolCount(problems) {
+  const mcpSetup = readFileSync(MCP_SETUP_PATH, 'utf8');
+  const headingMatch = mcpSetup.match(/##\s+Tools\s+\((\d+)\s+total\)/);
+  if (!headingMatch) {
+    problems.push('docs/MCP_SETUP.md missing "## Tools (N total)" heading');
+    return;
+  }
+
+  const documentedCount = Number(headingMatch[1]);
+  const toolFiles = readdirSync(MCP_TOOL_SOURCE_DIR)
+    .filter(f => f.endsWith('.ts') && f !== 'index.ts' && f !== 'format.ts')
+    .map(f => path.join(MCP_TOOL_SOURCE_DIR, f));
+
+  let actualCount = 0;
+  for (const file of toolFiles) {
+    const content = readFileSync(file, 'utf8');
+    const matches = content.match(/server\.registerTool\(/g);
+    actualCount += matches ? matches.length : 0;
+  }
+
+  if (documentedCount !== actualCount) {
+    problems.push(
+      `MCP tool count mismatch: docs/MCP_SETUP.md says ${documentedCount}, source registers ${actualCount}`
+    );
+  }
+}
+
+function validateCiHasDocsVerify(ciPath, problems) {
+  if (!existsSync(ciPath)) {
+    problems.push('.github/workflows/ci.yml not found');
+    return;
+  }
+  const checkNames = getWorkflowCheckNames(ciPath);
+  if (!checkNames.includes('docs-verify')) {
+    problems.push('CI is missing required docs-verify job in .github/workflows/ci.yml');
+  }
+}
+
+function main() {
+  const problems = [];
+
+  if (!existsSync(FRESHNESS_CONFIG_PATH)) {
+    console.error('docs/freshness.json not found');
+    process.exit(1);
+  }
+
+  const config = readJson(FRESHNESS_CONFIG_PATH);
+  const scanPaths = Array.isArray(config.scanPaths) && config.scanPaths.length > 0
+    ? config.scanPaths
+    : DEFAULT_SCAN_PATHS;
+  const markdownFiles = collectMarkdownFiles(scanPaths);
+  const ignoreSet = new Set((config.ignoreFilesForLint ?? []).map(p => String(p)));
+
+  validateFreshness(config, problems);
+  validateMarkdownLinks(markdownFiles, problems);
+  validateNpmRunCommands(markdownFiles, problems);
+  validateDeprecatedPatterns(markdownFiles, ignoreSet, problems);
+  validateMcpToolCount(problems);
+  validateCiHasDocsVerify(path.join(repoRoot, '.github', 'workflows', 'ci.yml'), problems);
+
+  if (problems.length > 0) {
+    console.error('Docs verification failed:');
+    for (const p of problems) {
+      console.error(`- ${p}`);
+    }
+    process.exit(1);
+  }
+
+  const freshnessDocs = Array.isArray(config.documents) ? config.documents.length : 0;
+  const markdownCount = markdownFiles.length;
+  console.log(`Docs verification passed (${freshnessDocs} tracked docs, ${markdownCount} markdown files scanned).`);
+}
+
+main();


### PR DESCRIPTION
## What this PR does
Audits and refreshes core docs for current command/API reality, then adds automated docs drift protection in CI and on a weekly schedule.

## Why
Docs had started drifting (stale MCP tool counts, old command variants, outdated examples). This PR adds a concrete mechanism so docs freshness is enforced continuously instead of manually.

## Scope
- Refresh stale docs in README/system overview/MCP setup/status/stability docs.
- Add `npm run docs:verify` (`scripts/verify-docs.mjs`) to validate:
  - freshness dates (`docs/freshness.json`),
  - broken local markdown links,
  - invalid `npm run` references,
  - deprecated CLI/docker command patterns,
  - MCP tool count parity with source.
- Add `docs-verify` job to CI.
- Add weekly `Docs Freshness` workflow that opens/updates an issue when docs verification fails.
- Add docs verification checklist items in PR/contributor/release guidance.

## Testing
- `npm run docs:verify`

## Reviewer focus
- Freshness policy in `docs/freshness.json` (`maxAgeDays`, tracked docs).
- False-positive risk in `scripts/verify-docs.mjs` pattern checks.
- CI + scheduled workflow behavior for long-term docs drift prevention.

## Notes
- This is one logical docs/governance hardening change.
- Unrelated local workspace files were intentionally left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated documentation verification now integrated into CI pipeline to catch broken links, invalid script references, and deprecated patterns.
  * Weekly scheduled documentation freshness checks with automatic issue reporting for stale content.

* **Chores**
  * Updated documentation reflecting current command syntax and tool inventory.
  * Added documentation ownership and freshness metadata configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->