### PR TITLE
Fix watchdog startup race that caused feed downtime

### DIFF
--- a/ops/bluesky-feed.service
+++ b/ops/bluesky-feed.service
@@ -32,7 +32,8 @@ Environment=NODE_OPTIONS=--max-old-space-size=896
 ExecStart=/usr/bin/node dist/index.js
 
 # Watchdog: process must send WATCHDOG=1 every 60s or systemd kills it.
-# The app sends heartbeats every 30s (half of WatchdogSec) only when
+# The app schedules heartbeats at half of WATCHDOG_USEC and sends an
+# immediate first heartbeat after READY=1. Heartbeats are sent only when
 # database AND Redis health checks pass. If dependencies are down for
 # >60s the process is killed and restarted automatically.
 WatchdogSec=60

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,10 @@ async function main() {
 
     // Tell systemd we're ready (Type=notify). No-op outside systemd.
     sdNotifyReady();
+
+    // Start watchdog heartbeat immediately after READY so long startup
+    // phases cannot miss the first watchdog deadline.
+    startWatchdog();
   } catch (err) {
     logger.fatal({ err }, 'Failed to start HTTP server');
     process.exit(1);
@@ -156,12 +160,7 @@ async function main() {
     process.exit(1);
   }
 
-  // 7. Start systemd watchdog heartbeat (no-op outside systemd).
-  // Sends WATCHDOG=1 every 30s only when DB + Redis are healthy.
-  // If both are down for >60s, systemd kills and restarts us.
-  startWatchdog();
-
-  // 8. Register graceful shutdown handlers
+  // 7. Register graceful shutdown handlers
   registerShutdownHandlers({
     server: app,
     stopScoring,
@@ -175,7 +174,7 @@ async function main() {
     stopInteractionAggregator,
   });
 
-  // 9. Log startup complete
+  // 8. Log startup complete
   logger.info({
     serviceDid: config.FEEDGEN_SERVICE_DID,
     publisherDid: config.FEEDGEN_PUBLISHER_DID,

--- a/src/lib/watchdog.ts
+++ b/src/lib/watchdog.ts
@@ -13,14 +13,34 @@ import { execFile } from 'node:child_process';
 import { logger } from './logger.js';
 import { isReady } from './health.js';
 
-const NOTIFY_SOCKET = process.env.NOTIFY_SOCKET;
+// Default to 60s if systemd does not set WATCHDOG_USEC.
+const DEFAULT_WATCHDOG_MS = 60_000;
+// Never schedule faster than 1s to avoid tight loops on malformed env.
+const MIN_HEARTBEAT_INTERVAL_MS = 1_000;
+
+function hasNotifySocket(): boolean {
+  return Boolean(process.env.NOTIFY_SOCKET);
+}
+
+function getWatchdogIntervalMs(): number {
+  const raw = process.env.WATCHDOG_USEC;
+  if (!raw) return DEFAULT_WATCHDOG_MS / 2;
+
+  const watchdogUsec = Number(raw);
+  if (!Number.isFinite(watchdogUsec) || watchdogUsec <= 0) {
+    return DEFAULT_WATCHDOG_MS / 2;
+  }
+
+  const watchdogMs = Math.floor(watchdogUsec / 1000);
+  return Math.max(MIN_HEARTBEAT_INTERVAL_MS, Math.floor(watchdogMs / 2));
+}
 
 /**
  * Send a watchdog heartbeat to systemd via systemd-notify(1).
  * No-op if NOTIFY_SOCKET is not set (non-systemd environments).
  */
 function sdNotifyWatchdog(): void {
-  if (!NOTIFY_SOCKET) return;
+  if (!hasNotifySocket()) return;
 
   // execFile with hardcoded args — safe, no shell injection possible
   execFile('systemd-notify', ['WATCHDOG=1'], (err) => {
@@ -35,7 +55,7 @@ function sdNotifyWatchdog(): void {
  * Call once after HTTP server is listening.
  */
 export function sdNotifyReady(): void {
-  if (!NOTIFY_SOCKET) return;
+  if (!hasNotifySocket()) return;
 
   // execFile with hardcoded args — safe, no shell injection possible
   execFile('systemd-notify', ['--ready'], (err) => {
@@ -79,24 +99,32 @@ let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
  * No-op if NOTIFY_SOCKET is not set.
  */
 export function startWatchdog(): void {
-  if (!NOTIFY_SOCKET) {
+  if (!hasNotifySocket()) {
     logger.debug('NOTIFY_SOCKET not set — watchdog disabled (non-systemd environment)');
     return;
   }
 
-  // Send heartbeat every 30s (half of WatchdogSec=60)
-  const HEARTBEAT_INTERVAL_MS = 30_000;
+  // Ensure we never leave a stale interval around if called twice.
+  stopWatchdog();
+
+  // Send first heartbeat immediately so long startup paths do not miss
+  // the initial watchdog deadline.
+  sendHeartbeat().catch((err) => {
+    logger.error({ err }, 'Initial watchdog heartbeat failed');
+  });
+
+  const intervalMs = getWatchdogIntervalMs();
 
   heartbeatInterval = setInterval(() => {
     sendHeartbeat().catch((err) => {
       logger.error({ err }, 'Watchdog heartbeat loop error');
     });
-  }, HEARTBEAT_INTERVAL_MS);
+  }, intervalMs);
 
   // Don't prevent process exit
   heartbeatInterval.unref();
 
-  logger.info({ intervalMs: HEARTBEAT_INTERVAL_MS }, 'Watchdog heartbeat started');
+  logger.info({ intervalMs }, 'Watchdog heartbeat started');
 }
 
 /**

--- a/tests/watchdog.test.ts
+++ b/tests/watchdog.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { isReadyMock } = vi.hoisted(() => ({
+const { isReadyMock, execFileMock } = vi.hoisted(() => ({
   isReadyMock: vi.fn(),
+  execFileMock: vi.fn((_cmd: string, _args: string[], cb?: (err?: Error | null) => void) => cb?.(null)),
 }));
 
 vi.mock('../src/lib/health.js', () => ({
   isReady: isReadyMock,
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
 }));
 
 vi.mock('../src/lib/logger.js', () => ({
@@ -24,8 +29,9 @@ describe('watchdog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    // Remove NOTIFY_SOCKET from env for test isolation
     delete process.env.NOTIFY_SOCKET;
+    delete process.env.WATCHDOG_USEC;
+    isReadyMock.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -39,8 +45,9 @@ describe('watchdog', () => {
   });
 
   it('startWatchdog is a no-op without NOTIFY_SOCKET', () => {
-    // Should not throw or start intervals when NOTIFY_SOCKET is not set
     expect(() => startWatchdog()).not.toThrow();
+    expect(isReadyMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   it('stopWatchdog is safe to call even if not started', () => {
@@ -52,5 +59,33 @@ describe('watchdog', () => {
       stopWatchdog();
       stopWatchdog();
     }).not.toThrow();
+  });
+
+  it('sends an immediate heartbeat after start when notify socket is present', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    process.env.WATCHDOG_USEC = '60000000'; // 60s watchdog => 30s heartbeat
+
+    startWatchdog();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(isReadyMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledWith('systemd-notify', ['WATCHDOG=1'], expect.any(Function));
+  });
+
+  it('uses half of WATCHDOG_USEC for recurring heartbeat interval', async () => {
+    process.env.NOTIFY_SOCKET = '/run/systemd/notify';
+    process.env.WATCHDOG_USEC = '120000000'; // 120s watchdog => 60s heartbeat
+
+    startWatchdog();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(isReadyMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(isReadyMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(isReadyMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## What this PR does
Fixes a production watchdog startup race by starting systemd watchdog heartbeats immediately after `READY=1` and sending an immediate first heartbeat.

## Why
The feed process was getting killed by systemd watchdog during long startup phases, causing repeated ABRT restart loops and eventual downtime.

## Scope
- Start watchdog earlier in startup lifecycle (right after `sdNotifyReady()`).
- Send an immediate heartbeat on watchdog start.
- Derive recurring heartbeat interval from systemd `WATCHDOG_USEC` (half interval), with safe fallback.
- Add/expand watchdog tests for immediate heartbeat and dynamic interval behavior.
- Update unit-file comments to match runtime behavior.

## Testing
- `npm run build`
- `npm test -- --run tests/watchdog.test.ts`
- `npm test -- --run`

## Reviewer focus
- Watchdog startup order in `src/index.ts`
- Heartbeat timing logic in `src/lib/watchdog.ts`
- Test coverage for interval/first-heartbeat behavior

## Notes
- Temporary VPS hotfix currently sets `WatchdogSec=180`; after this deploy we can restore to baseline if desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced watchdog initialization to begin immediately after systemd readiness notification for faster supervision
  * Watchdog heartbeat interval now dynamically calculated from systemd configuration, replacing fixed intervals
  * Improved systemd environment detection for more robust operation across different deployment scenarios

* **Tests**
  * Added comprehensive test coverage for watchdog startup and heartbeat behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->