### PR TITLE
Automate repo-driven deployment for docs.corgi.network

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,99 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/docs-site/**
+      - .github/workflows/deploy-docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
+jobs:
+  deploy-docs:
+    name: deploy-docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate docs artifacts
+        run: |
+          test -s docs/docs-site/index.html
+          test -s docs/docs-site/openapi.json
+
+      - name: Configure SSH access
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "${VPS_HOST}" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+          # Fail fast if connection/auth is invalid.
+          ssh -i ~/.ssh/id_ed25519 -o BatchMode=yes "${VPS_USER}@${VPS_HOST}" 'echo "SSH connection OK"'
+
+      - name: Publish docs bundle to VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+        run: |
+          set -euo pipefail
+          tar -C docs/docs-site -czf /tmp/corgi-docs.tgz .
+          scp -i ~/.ssh/id_ed25519 /tmp/corgi-docs.tgz "${VPS_USER}@${VPS_HOST}:/tmp/corgi-docs.tgz"
+          ssh -i ~/.ssh/id_ed25519 "${VPS_USER}@${VPS_HOST}" '
+            set -euo pipefail
+            DEPLOY_DIR="$(mktemp -d /tmp/corgi-docs-deploy.XXXXXX)"
+            cleanup() {
+              rm -rf "${DEPLOY_DIR}"
+              rm -f /tmp/corgi-docs.tgz
+            }
+            trap cleanup EXIT
+            tar -xzf /tmp/corgi-docs.tgz -C "${DEPLOY_DIR}"
+            sudo mkdir -p /var/www/corgi-docs
+            sudo rsync -a --delete "${DEPLOY_DIR}/" /var/www/corgi-docs/
+            sudo chown -R root:root /var/www/corgi-docs
+            sudo find /var/www/corgi-docs -type d -exec chmod 755 {} +
+            sudo find /var/www/corgi-docs -type f -exec chmod 644 {} +
+            test -s /var/www/corgi-docs/index.html
+            test -s /var/www/corgi-docs/openapi.json
+          '
+          rm -f /tmp/corgi-docs.tgz
+
+      - name: Verify live docs hashes match repo artifacts
+        run: |
+          set -euo pipefail
+          EXPECTED_INDEX_SHA="$(sha256sum docs/docs-site/index.html | awk '{print $1}')"
+          EXPECTED_OPENAPI_SHA="$(sha256sum docs/docs-site/openapi.json | awk '{print $1}')"
+          ACTUAL_INDEX_SHA=""
+          ACTUAL_OPENAPI_SHA=""
+          for attempt in 1 2 3 4 5; do
+            ACTUAL_INDEX_SHA="$(curl -fsSL --max-time 10 https://docs.corgi.network/ | sha256sum | awk '{print $1}')"
+            ACTUAL_OPENAPI_SHA="$(curl -fsSL --max-time 10 https://docs.corgi.network/openapi.json | sha256sum | awk '{print $1}')"
+            if [ "${ACTUAL_INDEX_SHA}" = "${EXPECTED_INDEX_SHA}" ] && [ "${ACTUAL_OPENAPI_SHA}" = "${EXPECTED_OPENAPI_SHA}" ]; then
+              echo "Live docs match repo artifacts."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/5: docs hash mismatch, retrying in 3s..."
+            sleep 3
+          done
+          echo "Live docs hash verification failed."
+          echo "Expected index:  ${EXPECTED_INDEX_SHA}"
+          echo "Actual index:    ${ACTUAL_INDEX_SHA}"
+          echo "Expected openapi: ${EXPECTED_OPENAPI_SHA}"
+          echo "Actual openapi:   ${ACTUAL_OPENAPI_SHA}"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Community-Governed Bluesky Feed
 
 [![Deploy](https://github.com/AndrewNordstrom/bluesky-community-feed/actions/workflows/deploy.yml/badge.svg)](https://github.com/AndrewNordstrom/bluesky-community-feed/actions/workflows/deploy.yml)
+[![Deploy Docs](https://github.com/AndrewNordstrom/bluesky-community-feed/actions/workflows/deploy-docs.yml/badge.svg)](https://github.com/AndrewNordstrom/bluesky-community-feed/actions/workflows/deploy-docs.yml)
 [![CI](https://github.com/AndrewNordstrom/bluesky-community-feed/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/AndrewNordstrom/bluesky-community-feed/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/AndrewNordstrom/bluesky-community-feed/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/AndrewNordstrom/bluesky-community-feed/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -59,7 +60,8 @@ A production Bluesky custom feed where subscribers democratically vote on rankin
 - Admin dashboard: governance controls, feed health, interactions, audit log
 - CLI tool (`feed-cli`): full admin operations from any terminal, no VPS access required
 - MCP server: Streamable HTTP admin tools for natural-language feed management
-- OpenAPI documentation at `/docs`
+- Public API reference at [docs.corgi.network](https://docs.corgi.network), auto-deployed from `docs/docs-site/`
+- Admin Swagger UI at `/docs` (production-gated)
 - Research data export: votes, scores, engagement, epochs, audit log (CSV/JSON)
 
 **Engineering**

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -205,6 +205,32 @@ sudo journalctl -u bluesky-feed -f
 sudo systemctl restart bluesky-feed
 ```
 
+## 13. Optional: public docs subdomain (`docs.corgi.network`)
+
+This repository includes a dedicated docs deployment workflow:
+
+- Workflow: `.github/workflows/deploy-docs.yml`
+- Source artifacts: `docs/docs-site/index.html` and `docs/docs-site/openapi.json`
+- VPS target directory: `/var/www/corgi-docs`
+
+Expected Nginx location:
+
+```nginx
+location / {
+    root /var/www/corgi-docs;
+    index index.html;
+    try_files $uri $uri/ /index.html;
+}
+```
+
+Required GitHub Actions secrets:
+
+- `VPS_HOST`
+- `VPS_USER`
+- `VPS_SSH_KEY`
+
+On each `main` push that changes `docs/docs-site/**`, the workflow uploads the docs bundle to the VPS and verifies that live `https://docs.corgi.network/` and `/openapi.json` hashes match the repository artifacts.
+
 ## Operations checklist
 
 - Keep ports `5432` and `6379` private.


### PR DESCRIPTION
## What this PR does
Adds a dedicated GitHub Actions workflow to deploy `docs/docs-site` artifacts to `docs.corgi.network` from the repository on `main` pushes.

## Why
The docs domain was live on VPS, but deployment was effectively manual. This makes the repo the source of truth and verifies live parity after each docs deploy.

## Changes
- Adds `.github/workflows/deploy-docs.yml`
  - triggers on `main` pushes that touch `docs/docs-site/**` (plus manual dispatch)
  - uploads docs bundle to VPS and syncs into `/var/www/corgi-docs`
  - verifies deployed files exist and permissions are normalized
  - verifies public `https://docs.corgi.network/` and `/openapi.json` SHA-256 hashes match repo artifacts
- Updates `README.md`
  - adds Deploy Docs badge
  - clarifies public docs URL vs admin-gated `/docs`
- Updates `docs/DEPLOYMENT.md`
  - documents docs subdomain deploy path, required secrets, and workflow behavior

## Testing
- `npm run docs:verify` (pass)
- Manual end-to-end dry run of the same publish logic against VPS (pass)
- Manual hash parity checks for:
  - `docs/docs-site/index.html` vs `https://docs.corgi.network/`
  - `docs/docs-site/openapi.json` vs `https://docs.corgi.network/openapi.json`

## Reviewer focus
- Workflow security posture for SSH/scp handling
- Deploy idempotency and hash verification logic
- Docs wording clarity around public vs admin docs endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Public API reference now available at docs.corgi.network with automatic deployment
  * Added deployment configuration guide for public docs infrastructure
  
* **Chores**
  * Introduced automated GitHub Actions workflow for documentation build, deployment, and verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->