### PR TITLE
Harden docs deploy workflow validation and SSH checks

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,24 +28,34 @@ jobs:
 
       - name: Validate docs artifacts
         run: |
+          set -euo pipefail
           test -s docs/docs-site/index.html
           test -s docs/docs-site/openapi.json
+          # Sanity thresholds to catch truncated artifacts before deployment.
+          [ "$(wc -c < docs/docs-site/index.html)" -ge 1500 ]
+          [ "$(wc -c < docs/docs-site/openapi.json)" -ge 10000 ]
+          jq -e '.openapi and .info.title and (.paths | type == "object")' docs/docs-site/openapi.json > /dev/null
 
       - name: Configure SSH access
         env:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
           VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_SSH_HOST_KEY: ${{ secrets.VPS_SSH_HOST_KEY }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${VPS_HOST}" >> ~/.ssh/known_hosts
+          if [ -n "${VPS_SSH_HOST_KEY:-}" ]; then
+            printf '%s\n' "${VPS_SSH_HOST_KEY}" > ~/.ssh/known_hosts
+          else
+            ssh-keyscan -H "${VPS_HOST}" >> ~/.ssh/known_hosts
+          fi
           chmod 644 ~/.ssh/known_hosts
           # Fail fast if connection/auth is invalid.
-          ssh -i ~/.ssh/id_ed25519 -o BatchMode=yes "${VPS_USER}@${VPS_HOST}" 'echo "SSH connection OK"'
+          ssh -i ~/.ssh/id_ed25519 -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=10 "${VPS_USER}@${VPS_HOST}" 'echo "SSH connection OK"'
 
       - name: Publish docs bundle to VPS
         env:
@@ -54,8 +64,8 @@ jobs:
         run: |
           set -euo pipefail
           tar -C docs/docs-site -czf /tmp/corgi-docs.tgz .
-          scp -i ~/.ssh/id_ed25519 /tmp/corgi-docs.tgz "${VPS_USER}@${VPS_HOST}:/tmp/corgi-docs.tgz"
-          ssh -i ~/.ssh/id_ed25519 "${VPS_USER}@${VPS_HOST}" '
+          scp -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes -o ConnectTimeout=10 /tmp/corgi-docs.tgz "${VPS_USER}@${VPS_HOST}:/tmp/corgi-docs.tgz"
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes -o ConnectTimeout=10 "${VPS_USER}@${VPS_HOST}" '
             set -euo pipefail
             DEPLOY_DIR="$(mktemp -d /tmp/corgi-docs-deploy.XXXXXX)"
             cleanup() {
@@ -82,14 +92,35 @@ jobs:
           ACTUAL_INDEX_SHA=""
           ACTUAL_OPENAPI_SHA=""
           for attempt in 1 2 3 4 5; do
-            ACTUAL_INDEX_SHA="$(curl -fsSL --max-time 10 https://docs.corgi.network/ | sha256sum | awk '{print $1}')"
-            ACTUAL_OPENAPI_SHA="$(curl -fsSL --max-time 10 https://docs.corgi.network/openapi.json | sha256sum | awk '{print $1}')"
+            INDEX_TMP="$(mktemp /tmp/corgi-docs-index.XXXXXX)"
+            OPENAPI_TMP="$(mktemp /tmp/corgi-docs-openapi.XXXXXX)"
+            if ! curl -fsSL --max-time 10 --connect-timeout 5 https://docs.corgi.network/ -o "${INDEX_TMP}"; then
+              echo "Attempt ${attempt}/5: failed to fetch docs homepage."
+              rm -f "${INDEX_TMP}" "${OPENAPI_TMP}"
+              sleep $((attempt * 2))
+              continue
+            fi
+            if ! curl -fsSL --max-time 10 --connect-timeout 5 https://docs.corgi.network/openapi.json -o "${OPENAPI_TMP}"; then
+              echo "Attempt ${attempt}/5: failed to fetch docs OpenAPI JSON."
+              rm -f "${INDEX_TMP}" "${OPENAPI_TMP}"
+              sleep $((attempt * 2))
+              continue
+            fi
+            if ! jq -e '.openapi and .info.title and (.paths | type == "object")' "${OPENAPI_TMP}" > /dev/null; then
+              echo "Attempt ${attempt}/5: live OpenAPI JSON failed schema sanity check."
+              rm -f "${INDEX_TMP}" "${OPENAPI_TMP}"
+              sleep $((attempt * 2))
+              continue
+            fi
+            ACTUAL_INDEX_SHA="$(sha256sum "${INDEX_TMP}" | awk '{print $1}')"
+            ACTUAL_OPENAPI_SHA="$(sha256sum "${OPENAPI_TMP}" | awk '{print $1}')"
+            rm -f "${INDEX_TMP}" "${OPENAPI_TMP}"
             if [ "${ACTUAL_INDEX_SHA}" = "${EXPECTED_INDEX_SHA}" ] && [ "${ACTUAL_OPENAPI_SHA}" = "${EXPECTED_OPENAPI_SHA}" ]; then
               echo "Live docs match repo artifacts."
               exit 0
             fi
-            echo "Attempt ${attempt}/5: docs hash mismatch, retrying in 3s..."
-            sleep 3
+            echo "Attempt ${attempt}/5: docs hash mismatch, retrying..."
+            sleep $((attempt * 2))
           done
           echo "Live docs hash verification failed."
           echo "Expected index:  ${EXPECTED_INDEX_SHA}"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -228,6 +228,7 @@ Required GitHub Actions secrets:
 - `VPS_HOST`
 - `VPS_USER`
 - `VPS_SSH_KEY`
+- `VPS_SSH_HOST_KEY` (recommended host-key pin for strict SSH verification)
 
 On each `main` push that changes `docs/docs-site/**`, the workflow uploads the docs bundle to the VPS and verifies that live `https://docs.corgi.network/` and `/openapi.json` hashes match the repository artifacts.
 


### PR DESCRIPTION
## What this PR does
Hardens the new docs deployment workflow based on CodeRabbit's reliability/security concerns.

## Why
The initial workflow works and is live, but this pass adds stronger safety checks to reduce edge-case deploy risk and improve trust in verification.

## Changes
- `.github/workflows/deploy-docs.yml`
  - Adds stricter local artifact validation before deploy:
    - file size thresholds
    - OpenAPI JSON sanity check (`openapi`, `info.title`, `paths`)
  - Adds optional host-key pinning secret:
    - `VPS_SSH_HOST_KEY` (uses pinned known_hosts when provided)
    - keeps strict host key checking enabled
  - Adds explicit SSH/SCP connect timeout and strict host-key options
  - Makes live verification retry logic more robust:
    - retries on fetch failures
    - retries on malformed live OpenAPI JSON
    - progressive backoff (`attempt * 2` seconds)
- `docs/DEPLOYMENT.md`
  - documents new optional `VPS_SSH_HOST_KEY` secret

## Testing
- `npm run docs:verify` (pass)
- Local artifact sanity checks for workflow conditions (pass)

## Reviewer focus
- Host-key pinning fallback behavior
- Live verification retry/failure semantics
- Any shell safety or quoting issues in workflow run steps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened deployment security with enhanced SSH host key verification and stricter connection handling
  * Improved deployment reliability through pre-deployment artifact validation and robust retry logic with timeout handling
  * Added more detailed error reporting for failed deployments with better diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->