### PR TITLE
Use VPS readiness endpoint in daily health workflow

### DIFF
--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -74,16 +74,14 @@ jobs:
           ssh $SSH_STRICT_OPTS "${VPS_USER}@${VPS_HOST}" \
             "cd /opt/bluesky-feed && DATABASE_URL=${DB_Q} node cli/dist/index.js epoch status --direct --json"
 
-      - name: Check feed health on VPS
+      - name: Check local service health on VPS
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
         run: |
           set -euo pipefail
-          DB_Q=$(printf '%q' "$DATABASE_URL")
           ssh $SSH_STRICT_OPTS "${VPS_USER}@${VPS_HOST}" \
-            "cd /opt/bluesky-feed && DATABASE_URL=${DB_Q} node cli/dist/index.js feed health --direct --json"
+            "curl -sf --max-time 10 http://localhost:3001/health/ready > /dev/null"
 
       - name: Check public endpoint
         run: |


### PR DESCRIPTION
## What this PR does
- Replaces the failing `feed health` CLI step in `daily-health.yml` with an SSH-executed local readiness probe on the VPS:
  - `curl -sf --max-time 10 http://localhost:3001/health/ready`

## Why
The `feed health` CLI command is API-authenticated and fails in automation (`Not authenticated`) even when run on the VPS. A direct local readiness endpoint check is the correct non-auth health signal for scheduled monitoring.

## Testing
- `npm run docs:verify`
- `npm run build`
- `set -a; source .env.example; set +a; npm test -- --run`
- `cd web && npm run lint && npm run build`
- `python3 -m py_compile scripts/generate-report.py scripts/generate-report-pdf.py scripts/report_utils.py`
