### PR TITLE
Fix weekly export workflow authentication on VPS

### DIFF
--- a/.github/workflows/weekly-export.yml
+++ b/.github/workflows/weekly-export.yml
@@ -69,18 +69,14 @@ jobs:
 
       - name: Export CSVs on VPS and copy artifacts
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          EXPORT_ANONYMIZATION_SALT: ${{ secrets.EXPORT_ANONYMIZATION_SALT }}
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
         run: |
           set -euo pipefail
-          DB_Q=$(printf '%q' "$DATABASE_URL")
-          SALT_Q=$(printf '%q' "$EXPORT_ANONYMIZATION_SALT")
           REMOTE_EXPORT_DIR="/tmp/weekly-export-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
           ssh $SSH_STRICT_OPTS "${VPS_USER}@${VPS_HOST}" \
-            "set -euo pipefail; rm -rf ${REMOTE_EXPORT_DIR}; mkdir -p ${REMOTE_EXPORT_DIR}; cd /opt/bluesky-feed; DATABASE_URL=${DB_Q} EXPORT_ANONYMIZATION_SALT=${SALT_Q} node cli/dist/index.js export votes --epoch=current --format=csv --direct > ${REMOTE_EXPORT_DIR}/votes.csv; DATABASE_URL=${DB_Q} EXPORT_ANONYMIZATION_SALT=${SALT_Q} node cli/dist/index.js export scores --epoch=current --format=csv --direct > ${REMOTE_EXPORT_DIR}/scores.csv"
+            "set -euo pipefail; rm -rf ${REMOTE_EXPORT_DIR}; mkdir -p ${REMOTE_EXPORT_DIR}; cd /opt/bluesky-feed; set -a; source .env; set +a; node cli/dist/index.js --server http://localhost:3001 --quiet login \"\$BSKY_IDENTIFIER\" \"\$BSKY_APP_PASSWORD\"; node cli/dist/index.js --server http://localhost:3001 --quiet export votes --epoch=current --format=csv > ${REMOTE_EXPORT_DIR}/votes.csv; node cli/dist/index.js --server http://localhost:3001 --quiet export scores --epoch=current --format=csv > ${REMOTE_EXPORT_DIR}/scores.csv; node cli/dist/index.js --server http://localhost:3001 --quiet logout || true"
 
           mkdir -p data/exports
           scp $SSH_STRICT_OPTS "${VPS_USER}@${VPS_HOST}:${REMOTE_EXPORT_DIR}/votes.csv" data/exports/votes.csv


### PR DESCRIPTION
## What this PR does
- Fixes weekly export workflow auth by switching export execution to authenticated local API calls on the VPS.
- In `weekly-export.yml` export step:
  - source `/opt/bluesky-feed/.env` on VPS,
  - login with `BSKY_IDENTIFIER` + `BSKY_APP_PASSWORD` against `http://localhost:3001`,
  - export votes/scores CSV via CLI API commands,
  - logout and copy artifacts back via `scp`.

## Why
`feed-cli export` commands are API-authenticated and do not support direct DB mode. Previous workflow failed with `Not authenticated. Run: feed-cli login`.

## Testing
- `npm run docs:verify`
- Manual workflow dispatch validation after merge (Weekly Research Export)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the weekly CSV export workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->