### PR TITLE
Harden weekly export auth fallback on VPS

### DIFF
--- a/.github/workflows/weekly-export.yml
+++ b/.github/workflows/weekly-export.yml
@@ -114,8 +114,17 @@ jobs:
             exit 1
           fi
 
-          node cli/dist/index.js --server http://localhost:3001 --quiet export votes --epoch=current --format=csv > "$REMOTE_EXPORT_DIR/votes.csv"
-          node cli/dist/index.js --server http://localhost:3001 --quiet export scores --epoch=current --format=csv > "$REMOTE_EXPORT_DIR/scores.csv"
+          EPOCH_ID="$(
+            curl -fsS http://localhost:3001/api/governance/epochs/current \
+              | node -e 'const fs = require("fs"); const data = JSON.parse(fs.readFileSync(0, "utf8")); if (!Number.isInteger(data?.id)) { process.exit(1); } process.stdout.write(String(data.id));'
+          )"
+          if [ -z "$EPOCH_ID" ]; then
+            echo "Could not resolve current epoch ID from local governance API." >&2
+            exit 1
+          fi
+
+          node cli/dist/index.js --server http://localhost:3001 --quiet export votes --epoch="$EPOCH_ID" --format=csv > "$REMOTE_EXPORT_DIR/votes.csv"
+          node cli/dist/index.js --server http://localhost:3001 --quiet export scores --epoch="$EPOCH_ID" --format=csv > "$REMOTE_EXPORT_DIR/scores.csv"
           node cli/dist/index.js --server http://localhost:3001 --quiet logout || true
           EOF
 


### PR DESCRIPTION
## What\nMake weekly export workflow resilient to VPS .env credential drift/format differences by trying BOT credentials first, then BSKY credentials, with safe quote stripping and clear failure messaging.\n\n## Why\nPost-transfer validation found weekly export failing with 401 from credentials loaded on VPS. This keeps the workflow stable without changing export outputs.\n\n## Testing\n- npm run docs:verify\n- python3 -m py_compile scripts/generate-report.py scripts/generate-report-pdf.py scripts/report_utils.py\n- Manual workflow dispatch validation will be run before merge\n\nFixes PROJ-0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when credentials are missing or export operations fail
  * Implemented robust fallback logic for authentication resolution

* **Chores**
  * Optimized automated export workflow for improved reliability and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->