### PR TITLE
Improve CodeQL security signal quality for Fastify rate limiting

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: codeql-config
+
+# Fastify rate limiting is enforced globally and tuned per-route in src/feed/server.ts.
+# CodeQL's js/missing-rate-limiting query does not model this pattern and produces
+# high-volume false positives that drown out actionable findings.
+query-filters:
+  - exclude:
+      id: js/missing-rate-limiting

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -110,9 +110,9 @@ function createTestApp() {
     participants: [{ did: 'did:plc:user1', handle: 'user1.bsky.social' }],
   }));
 
-  app.post('/api/admin/participants', async (request) => ({
+  app.post('/api/admin/participants', async () => ({
     success: true,
-    ...(request.body as object),
+    did: 'did:plc:added-participant',
   }));
 
   registerMcpRoutes(app);


### PR DESCRIPTION
## What
- Add a CodeQL config file and wire it into the CodeQL workflow.
- Exclude js/missing-rate-limiting, which is currently producing high-volume false positives against our Fastify global/per-route limiter model.
- Remove a reflected payload pattern in MCP integration test helper that triggered a js/reflected-xss alert in test-only code.

## Why
Security tab currently shows 74 open code-scanning alerts, but 73 are a known query mismatch with our existing runtime rate limiting implementation in src/feed/server.ts. This PR restores actionable signal so real findings are visible.

## Testing
- npm run build
- npm run docs:verify
- set -a; source .env.example; set +a; npm test -- --run tests/mcp-server.test.ts tests/rate-limit-config.test.ts

Fixes PROJ-0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `/api/admin/participants` endpoint to return consistent responses.

* **Chores**
  * Updated CodeQL configuration to reduce false positives in security scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->