### PR TITLE
Upgrade CodeQL workflow actions to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,13 +26,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What
- Update CodeQL workflow action versions from v3 to v4 in .github/workflows/codeql.yml.

## Why
GitHub Actions warns that Node.js 20 and CodeQL Action v3 are deprecated. This keeps code scanning on the supported runtime and avoids future breakage.

## Testing
- npm run docs:verify

Fixes PROJ-0