### PR TITLE
[infra][PROJ-0] Activate PM intake and Linear sync workflows

### DIFF
--- a/.github/workflows/issue-intake-triage.yml
+++ b/.github/workflows/issue-intake-triage.yml
@@ -1,0 +1,14 @@
+name: issue-intake-triage
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  issue-intake-triage:
+    uses: andrewnordstrom-eng/.github/.github/workflows/issue-intake-triage.yml@main
+    secrets: inherit

--- a/.github/workflows/linear-state-sync.yml
+++ b/.github/workflows/linear-state-sync.yml
@@ -1,0 +1,15 @@
+name: linear-state-sync
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  linear-state-sync:
+    uses: andrewnordstrom-eng/.github/.github/workflows/linear-state-sync.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add issue intake triage wrapper workflow (auto-label priority/type metadata)
- add Linear state sync wrapper workflow for PR lifecycle events

## Notes
- Linear state sync uses the shared workflow and safely skips when LINEAR_API_KEY is not configured.

Linear: PROJ-0