### PR TITLE
[infra][PROJ-0] Internal tooling hygiene updates

### DIFF
--- a/.github/workflows/internal-tooling-hygiene.yml
+++ b/.github/workflows/internal-tooling-hygiene.yml
@@ -1,0 +1,13 @@
+name: internal-tooling-hygiene
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  internal-tooling-hygiene:
+    uses: andrewnordstrom-eng/.github/.github/workflows/internal-tooling-hygiene.yml@main
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,15 @@ test-results/
 
 # Research exports
 data/exports/
+
+# Internal tooling artifacts (local-only; never commit)
+/.claude/
+/.cursor/
+/.codex/
+/.aider/
+/.copilot/
+/AGENTS.md
+/CLAUDE.md
+/CLAUDE_CODE_PROMPT.md
+/TASKING.md
+/Prompts/


### PR DESCRIPTION
## Summary
- add repo-level wrapper for internal-tooling-hygiene check
- standardize local-only internal tooling ignore entries in gitignore
- scrub tracked internal tooling artifacts from version control where present

## Why
Aligns this repo to org policy that AI/agent build tooling artifacts remain local and untracked.

Linear: PROJ-0