### PR TITLE
[infra][PROJ-0] Add issue and PR templates locally

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,33 @@
+name: Bug Report
+description: Report a defect with reproducible steps.
+title: "[Bug]: "
+labels: [bug, needs-triage]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken and what did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction Steps
+      description: Step-by-step instructions to reproduce.
+    validations:
+      required: true
+  - type: input
+    id: impact
+    attributes:
+      label: Impact
+      description: User/system impact (low/medium/high).
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Conditions that must be true when fixed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Architecture discussion
+    url: https://github.com/andrewnordstrom-eng/.github/discussions
+    about: Use discussions for broad technical design topics.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature Request
+description: Request a product/engineering enhancement.
+title: "[Feature]: "
+labels: [enhancement, needs-triage]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are we solving?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: Describe the desired behavior and approach.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (In/Out)
+      description: What is explicitly in scope and out of scope?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Testable criteria for completion.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,33 @@
+name: Engineering Task
+description: Structured implementation task.
+title: "[Task]: "
+labels: [task, needs-triage]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why this task matters now.
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation Plan
+      description: Key steps and expected artifacts.
+    validations:
+      required: true
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test Plan
+      description: How we prove this is done safely.
+    validations:
+      required: true
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback Plan
+      description: How to undo safely if needed.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+Describe what changed and why.
+
+## Linear Link
+
+Include a Linear issue key in title or body (e.g., `ENG-123`).
+
+## Test Evidence
+
+- [ ] Added/updated tests where appropriate
+- [ ] Ran relevant checks locally
+- [ ] Included screenshots/logs if behavior changed
+
+## Rollout / Rollback
+
+- Rollout approach:
+- Rollback approach:
+
+## Checklist
+
+- [ ] PR scope is focused and reviewable
+- [ ] No secrets or credentials added
+- [ ] Documentation/changelog updated if needed


### PR DESCRIPTION
## Summary

Adds issue templates (bug, feature, task) and PR template directly to this repo so they work independently of org-level defaults.

PROJ-0

## Linear Link

PROJ-0

## Test Evidence

- [x] Templates are copies of the org defaults
- [x] No functional changes to existing workflows

## Rollout / Rollback

- Rollout: Merge
- Rollback: Delete the template files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added standardized GitHub issue forms for bug reports, feature requests, and engineering tasks with title prefixes, required fields, and default labels.
  * Added a pull request template with sections for summary, required issue reference, test evidence, rollout/rollback plans, and a final checklist.
  * Configured issue template settings and added a contact link for architecture discussions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->