### PR TITLE
[infra][PROJ-12] Harden pr-to-linear trigger for Dependabot context

### DIFF
--- a/.github/workflows/pr-to-linear.yml
+++ b/.github/workflows/pr-to-linear.yml
@@ -1,7 +1,7 @@
 name: pr-to-linear
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 permissions:


### PR DESCRIPTION
## Summary\n- switch pr-to-linear caller trigger from pull_request to pull_request_target\n- preserves reusable workflow call while avoiding Dependabot pull_request context failures\n\n## Why\nRecent Dependabot PR-open events were failing before jobs with a workflow-file resolution error; pull_request_target provides stable caller context for this metadata-only workflow.