### PR TITLE
[infra][PROJ-12] Use explicit LINEAR_API_KEY mapping in pr-to-linear caller

### DIFF
--- a/.github/workflows/pr-to-linear.yml
+++ b/.github/workflows/pr-to-linear.yml
@@ -11,4 +11,5 @@ permissions:
 jobs:
   pr-to-linear:
     uses: andrewnordstrom-eng/.github/.github/workflows/pr-to-linear.yml@main
-    secrets: inherit
+    secrets:
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}


### PR DESCRIPTION
Replace secrets: inherit with explicit LINEAR_API_KEY mapping for reusable workflow call compatibility.