### PR TITLE
[PROJ-21] Fix pr-to-linear workflow caller

### DIFF
--- a/.github/workflows/pr-to-linear.yml
+++ b/.github/workflows/pr-to-linear.yml
@@ -11,5 +11,4 @@ permissions:
 jobs:
   pr-to-linear:
     uses: andrewnordstrom-eng/.github/.github/workflows/pr-to-linear.yml@main
-    secrets:
-      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Switch from explicit `LINEAR_API_KEY` secret mapping to `secrets: inherit` in the pr-to-linear caller workflow
- Aligns with the pattern used across all other repos in the org
- Fixes consistent workflow file resolution failures on `pull_request_target` events

## Test plan
- [ ] Verify pr-to-linear triggers successfully on next PR opened/reopened event
- [ ] Confirm Linear issue creation still works with inherited secrets