### PR TITLE
[PROJ-21] Bump public reusable workflow pin

### DIFF
--- a/.github/workflows/coderabbit-queue.yml
+++ b/.github/workflows/coderabbit-queue.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   coderabbit-queue:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/coderabbit-queue.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/coderabbit-queue.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dependabot-automerge:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/dependabot-automerge.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/dependabot-automerge.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db

--- a/.github/workflows/internal-tooling-hygiene.yml
+++ b/.github/workflows/internal-tooling-hygiene.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   internal-tooling-hygiene:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/internal-tooling-hygiene.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/internal-tooling-hygiene.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db

--- a/.github/workflows/issue-intake-triage.yml
+++ b/.github/workflows/issue-intake-triage.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   issue-intake-triage:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/issue-intake-triage.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/issue-intake-triage.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db

--- a/.github/workflows/issue-to-linear.yml
+++ b/.github/workflows/issue-to-linear.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   issue-to-linear:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/issue-to-linear.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/issue-to-linear.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db
     secrets:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY_PUBLIC }}

--- a/.github/workflows/linear-policy.yml
+++ b/.github/workflows/linear-policy.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   linear-policy:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/linear-policy.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/linear-policy.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db
     secrets:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY_PUBLIC }}

--- a/.github/workflows/linear-state-sync.yml
+++ b/.github/workflows/linear-state-sync.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   linear-state-sync:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/linear-state-sync.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/linear-state-sync.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db
     secrets:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY_PUBLIC }}

--- a/.github/workflows/pr-to-linear.yml
+++ b/.github/workflows/pr-to-linear.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   pr-to-linear:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/pr-to-linear.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/pr-to-linear.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db
     secrets:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY_PUBLIC }}

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   quality-gate:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/quality-gate.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/quality-gate.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   release-notes:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/release-notes.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/release-notes.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   security-gate:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/security-gate.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/security-gate.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db

--- a/.github/workflows/stale-triage.yml
+++ b/.github/workflows/stale-triage.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   stale-triage:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/stale-triage.yml@ed97e9febd99c0e70f55ce64b57db46dd5aded8b
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/stale-triage.yml@3aaa6ed6e1feef3410e1c5bbdbfa669d43ca39db


### PR DESCRIPTION
Pins Bluesky reusable workflow callers to the latest .github-public hardening commit (dependabot label-step resilience).