### PR TITLE
PROJ-32: Enable CodeRabbit auto-review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@ language: "en-US"
 
 reviews:
   auto_review:
-    enabled: false
+    enabled: true
     labels:
       - "coderabbit:active"
       - "!coderabbit:hold"


### PR DESCRIPTION
Enables auto_review in .coderabbit.yaml. Was disabled, so CodeRabbit skipped all PRs. Queue labels (coderabbit:active) gate which PR gets reviewed.