### PR TITLE
[PROJ-38] Add copilot-instructions.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ data/exports/
 /CLAUDE_CODE_PROMPT.md
 /TASKING.md
 /Prompts/
+/copilot-instructions.md


### PR DESCRIPTION
## Summary

- Adds `/copilot-instructions.md` pattern to `.gitignore` to prevent accidental commits of generated development context files

## Linear Link

PROJ-38