### PR TITLE
[PROJ-241] Add Aikido review gate caller

### DIFF
--- a/.github/workflows/aikido-thread-check.yml
+++ b/.github/workflows/aikido-thread-check.yml
@@ -1,0 +1,21 @@
+name: aikido-thread-check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review_comment:
+    types: [created, edited]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to evaluate"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  aikido-thread-check:
+    uses: andrewnordstrom-eng/.github/.github/workflows/aikido-thread-check.yml@e1973881413c810eb9682744951d09ae7f29e51c


### PR DESCRIPTION
## Summary
- add the reusable aikido-thread-check workflow caller
- align the repo with the org Aikido thread-gate pattern

## Validation
- python3 ../.github/ops/flow.py validate-contract bluesky-feed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated quality checks for pull requests. Checks now run automatically when pull requests are created, updated, reopened, marked ready for review, or reviewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->