### PR TITLE
[PROJ-388] Clear Bluesky web npm audit

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   security-gate:
-    uses: andrewnordstrom-eng/.github-public/.github/workflows/security-gate.yml@3eb398cf25fba2dd97a05508678fe48b0b4e0532
+    uses: andrewnordstrom-eng/.github-public/.github/workflows/security-gate.yml@50211138be3f46fcc71f51aca669a3bced13de17

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.96.1",
         "axios": "^1.15.0",
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.2",
         "marked": "^17.0.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2097,9 +2097,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -2920,9 +2920,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.96.1",
     "axios": "^1.15.0",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.2",
     "marked": "^17.0.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
@@ -43,7 +43,9 @@
     "eslint-plugin-react-hooks": {
       "eslint": "$eslint"
     },
-    "flatted": "3.4.2"
+    "flatted": "3.4.2",
+    "follow-redirects": "1.16.0",
+    "postcss": "8.5.13"
   },
   "engines": {
     "node": ">=20.19.0"


### PR DESCRIPTION
## Summary
- Clears the frontend npm audit blocker without changing runtime code.
- Bumps direct DOMPurify from ^3.3.3 to ^3.4.2.
- Adds targeted overrides for follow-redirects 1.16.0 and postcss 8.5.13 so the web lockfile resolves patched transitive packages.
- Pins the Bluesky reusable `security-gate` caller to `.github-public` commit `50211138be3f46fcc71f51aca669a3bced13de17`, which audits changed package directories instead of always auditing repo root.

## Stack
- This PR is intentionally based on `dev/PROJ-388-root-audit-recovery` because GitHub runs full backend and frontend audit gates on every PR.
- As independent PRs against `main`, #194 fails frontend audit and this PR fails backend/root audit. Stacking proves the combined dependency recovery is green before #194 lands on `main`.

## Scope
- Web dependency metadata and reusable workflow pin only.
- This remains separate from `bluesky-community-feed#164` backup mount work.

## Validation
- `npm ci --ignore-scripts --no-audit --no-fund --loglevel warn`
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=moderate`: found 0 vulnerabilities
- `git --no-pager diff --check`
- CodeRabbit local review: no findings
