### PR TITLE
[PROJ-110] Contain feed secret exposure

### DIFF
--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -23,6 +23,7 @@ jobs:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
           VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_SSH_HOST_KEY: ${{ secrets.VPS_SSH_HOST_KEY }}
         run: |
           missing=0
           if [ -z "${DATABASE_URL:-}" ]; then
@@ -41,6 +42,10 @@ jobs:
             echo "::error title=Missing secret::Required repository secret VPS_SSH_KEY is not set. Add it in Settings -> Secrets and variables -> Actions."
             missing=1
           fi
+          if [ -z "${VPS_SSH_HOST_KEY:-}" ]; then
+            echo "::error title=Missing secret::Required repository secret VPS_SSH_HOST_KEY is not set. Add it in Settings -> Secrets and variables -> Actions."
+            missing=1
+          fi
           if [ "$missing" -ne 0 ]; then
             exit 1
           fi
@@ -55,13 +60,9 @@ jobs:
           chmod 700 "$HOME/.ssh"
           printf '%s\n' "${VPS_SSH_KEY}" > "$HOME/.ssh/id_ed25519"
           chmod 600 "$HOME/.ssh/id_ed25519"
-          if [ -n "${VPS_SSH_HOST_KEY:-}" ]; then
-            printf '%s\n' "${VPS_SSH_HOST_KEY}" > "$HOME/.ssh/known_hosts"
-            chmod 644 "$HOME/.ssh/known_hosts"
-            echo "SSH_STRICT_OPTS=-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts" >> "$GITHUB_ENV"
-          else
-            echo "SSH_STRICT_OPTS=-o StrictHostKeyChecking=accept-new" >> "$GITHUB_ENV"
-          fi
+          printf '%s\n' "${VPS_SSH_HOST_KEY}" > "$HOME/.ssh/known_hosts"
+          chmod 644 "$HOME/.ssh/known_hosts"
+          echo "SSH_STRICT_OPTS=-o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts" >> "$GITHUB_ENV"
 
       - name: Check epoch status on VPS
         env:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,6 +21,10 @@ This document covers operational and contributor security expectations for this 
 ## Secrets and credentials
 
 - Never commit `.env`.
+- Never print a full environment file during incident response. To inspect deployed
+  key names, use a key-name-only command such as
+  `sudo awk -F= '/^[A-Za-z_][A-Za-z0-9_]*=/ {print $1}' /opt/bluesky-feed/.env`
+  and then run `npm run receipts:verify` before committing receipts.
 - Use Bluesky **app passwords** only; never use account main passwords.
 - Keep database/Redis credentials unique and strong.
 - Rotate `BSKY_APP_PASSWORD`/`BOT_APP_PASSWORD` if leaked.

--- a/ops/receipts/2026-05-05/PROJ-110/bluesky-community-feed-threat-model.md
+++ b/ops/receipts/2026-05-05/PROJ-110/bluesky-community-feed-threat-model.md
@@ -1,0 +1,131 @@
+# Bluesky Community Feed Threat Model
+
+Date: 2026-05-05
+Scope: incident-focused threat model for the production Bluesky feed service and
+operator/CI credential surfaces.
+
+## Assumptions
+
+- Deployment model: single production VPS running `bluesky-feed.service` behind
+  nginx at `https://feed.corgi.network`.
+- Trust boundary: public HTTP traffic terminates at nginx, then reaches the
+  Node/Fastify service on localhost.
+- Trust boundary: GitHub Actions uses repository secrets to SSH to the VPS for
+  health/export/deploy workflows.
+- Trust boundary: ATProto/Bluesky credentials are app passwords, not account main
+  passwords.
+- This report intentionally excludes a full product auth review; it focuses on
+  the May 5 secret exposure and immediate hardening.
+
+## Assets
+
+- PostgreSQL data and connection credentials.
+- Research export anonymization salt.
+- Bluesky app password and bot app password.
+- GitHub Actions SSH key and host-key verification state.
+- Redis bot session cache.
+- Incident receipts and operator transcript artifacts.
+
+## Entry Points And Boundaries
+
+- Public feed endpoints: `/health`, `/health/ready`, `/health/live`, feed routes,
+  transparency routes, governance routes.
+- Operator shell over SSH to `corgi-vps`.
+- GitHub Actions workflows using `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`,
+  `VPS_SSH_HOST_KEY`, and `DATABASE_URL`.
+- ATProto app-password APIs used by local scripts and bot login.
+- Receipt sanitizer before evidence is committed.
+
+## Threats
+
+### T1: Transcript Or Receipt Secret Disclosure
+
+Likelihood: high. Impact: high. Priority: critical.
+
+The concrete incident was a production `.env` value dump into the operator
+transcript. Any value copied into receipts, chat, shell history, or PR artifacts
+could be reused by an attacker or future tooling.
+
+Existing controls:
+
+- `.env` is not committed.
+- Receipt sanitizer existed for stable provider/disk identifiers.
+
+New controls:
+
+- Receipt sanitizer now redacts dotenv-style secret assignments and
+  credential-bearing URLs.
+- Security guide now requires key-name-only env inspection.
+- Production `.env` and secret backups are root-only `0600`.
+
+### T2: Database Or Export-Salt Reuse After Exposure
+
+Likelihood: medium. Impact: high. Priority: high.
+
+The exposed database URL could allow data read/write if combined with network
+path access. The exposed export salt could weaken anonymized export privacy.
+
+Mitigation applied:
+
+- Database password and `DATABASE_URL` rotated.
+- PostgreSQL role password changed and TCP auth verified.
+- Export anonymization salt rotated in GitHub Actions and deployed env.
+
+### T3: Bluesky App-Password Abuse
+
+Likelihood: medium. Impact: medium. Priority: high.
+
+An attacker with the exposed app password could authenticate to the Bluesky
+account with the app-password scope. This could affect bot posting or feed
+publishing operations.
+
+Mitigation applied:
+
+- App password named `Corgi` revoked through ATProto.
+- Same-password login probe rejected after revocation.
+- Active deployed env scrubbed to a placeholder.
+- Bot password cleared, bot disabled, and Redis cached bot session deleted.
+
+Residual risk:
+
+- Bot posting remains off until a new app password is created and installed
+  through a channel that does not expose the generated password to screenshots,
+  logs, shell history, or chat.
+
+### T4: CI SSH Credential Drift Or MITM
+
+Likelihood: medium. Impact: high. Priority: high.
+
+Daily Health Check was failing on SSH public-key authentication, and the workflow
+fell back to `StrictHostKeyChecking=accept-new` when no host-key secret existed.
+
+Mitigation applied:
+
+- Repo-level `VPS_SSH_KEY` replaced with a fresh key.
+- New public key installed only for existing `andrew` user on the VPS.
+- Repo-level `VPS_SSH_HOST_KEY` added.
+- Hosted Daily Health Check passed after rotation.
+
+### T5: Runtime Availability Regression During Credential Response
+
+Likelihood: medium. Impact: medium. Priority: medium.
+
+Credential scrubbing and restart could break service boot, bot initialization, or
+health checks.
+
+Mitigation applied:
+
+- Startup checks passed.
+- Systemd active/running after restart.
+- Local `/health/ready`, `/health/live`, and `/health` passed.
+- Public `/health` passed.
+- Hosted Daily Health Check passed after final scrub.
+
+## Follow-Ups
+
+- Create a new Bluesky app password out of band, then update deployed env without
+  exposing the value in chat, screenshots, shell history, or receipts.
+- Track persistent Jetstream saturation separately if it continues after the
+  service settles.
+- Keep sanitizer coverage in the docs verification lane so future receipts fail
+  closed on dotenv-style secrets.

--- a/ops/receipts/2026-05-05/PROJ-110/receipt_index.json
+++ b/ops/receipts/2026-05-05/PROJ-110/receipt_index.json
@@ -5,7 +5,7 @@
   "artifacts": [
     {
       "path": "ops/receipts/2026-05-05/PROJ-110/secret-exposure-response.md",
-      "sha256": "5ea16acc6128a39099aead86bce8829da040002ab69394430e75482c07d25cd7"
+      "sha256": "dcf0970ec2a4618baa2f048734113e28367083f273d311bdcf738895d023d1ee"
     },
     {
       "path": "ops/receipts/2026-05-05/PROJ-110/bluesky-community-feed-threat-model.md",
@@ -13,15 +13,15 @@
     },
     {
       "path": "ops/receipts/2026-05-05/PROJ-110/security-ownership-summary.json",
-      "sha256": "2aca61f34bc30363bfe2c5ca668ba89d278c12a2eb25a023177b71020aaa6708"
+      "sha256": "0a7dec23d0c3fa6ea5cc2c1d7996b1948b7e2e271b2f8324970e987aadcc65a3"
     },
     {
       "path": "ops/receipts/2026-05-05/PROJ-110/security-best-practices-summary.md",
-      "sha256": "3ad590569cde1ab29c44d08c349a017726f80f0db725a17909765d96701f10c7"
+      "sha256": "2e454b9c92b05245a00c3dbbeb3504dba46a703c15a62c0549ebf47710a92bb4"
     },
     {
       "path": "ops/receipts/2026-05-05/PROJ-110/validation-summary.md",
-      "sha256": "1a8226d74fb40c1847548a793e59adc7dc05671c2e23fe2b01eeed861f33a532"
+      "sha256": "f72244fd2ad4e4ba208b9290bed42fdb2d713dacce4b604d82c7b4fd717c5cf5"
     }
   ],
   "hosted_workflow_receipts": [

--- a/ops/receipts/2026-05-05/PROJ-110/receipt_index.json
+++ b/ops/receipts/2026-05-05/PROJ-110/receipt_index.json
@@ -1,0 +1,39 @@
+{
+  "generated_at": "2026-05-05T08:56:00Z",
+  "issue": "PROJ-110",
+  "scope": "secret exposure response, production health restoration, and repo hardening",
+  "artifacts": [
+    {
+      "path": "ops/receipts/2026-05-05/PROJ-110/secret-exposure-response.md",
+      "sha256": "5ea16acc6128a39099aead86bce8829da040002ab69394430e75482c07d25cd7"
+    },
+    {
+      "path": "ops/receipts/2026-05-05/PROJ-110/bluesky-community-feed-threat-model.md",
+      "sha256": "cfc352d62076f59b49e78e422a4487fb34ce61de70b14ced15491b6c2d81dc61"
+    },
+    {
+      "path": "ops/receipts/2026-05-05/PROJ-110/security-ownership-summary.json",
+      "sha256": "2aca61f34bc30363bfe2c5ca668ba89d278c12a2eb25a023177b71020aaa6708"
+    },
+    {
+      "path": "ops/receipts/2026-05-05/PROJ-110/security-best-practices-summary.md",
+      "sha256": "3ad590569cde1ab29c44d08c349a017726f80f0db725a17909765d96701f10c7"
+    },
+    {
+      "path": "ops/receipts/2026-05-05/PROJ-110/validation-summary.md",
+      "sha256": "1a8226d74fb40c1847548a793e59adc7dc05671c2e23fe2b01eeed861f33a532"
+    }
+  ],
+  "hosted_workflow_receipts": [
+    {
+      "name": "Daily Health Check after SSH credential rotation",
+      "url": "https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366648561",
+      "conclusion": "success"
+    },
+    {
+      "name": "Daily Health Check after Bluesky app-password revocation and env scrub",
+      "url": "https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366964265",
+      "conclusion": "success"
+    }
+  ]
+}

--- a/ops/receipts/2026-05-05/PROJ-110/secret-exposure-response.md
+++ b/ops/receipts/2026-05-05/PROJ-110/secret-exposure-response.md
@@ -1,0 +1,78 @@
+# PROJ-110 Secret Exposure Response
+
+Date: 2026-05-05
+
+## Incident Classification
+
+This was a real credential exposure incident. A production `.env` inspection printed
+secret values into the operator transcript. The exposed classes were treated as
+compromised:
+
+- PostgreSQL connection secret: rotated.
+- Research export anonymization salt: rotated.
+- Bluesky app password: revoked at provider, removed from active deployed env.
+- Bot app password: removed from active deployed env; bot login disabled until a
+  new app password is created out of band.
+
+The following were also hardened because the service health gate was already red:
+
+- GitHub Actions `VPS_SSH_KEY`: replaced with a fresh repo-level SSH key.
+- GitHub Actions `VPS_SSH_HOST_KEY`: added so health checks use pinned host-key
+  verification instead of first-use trust.
+
+No raw secret values were intentionally recorded in this receipt.
+
+## Containment Receipts
+
+- Database/env rotation helper reported: `rotated keys: DATABASE_URL, POSTGRES_PASSWORD, EXPORT_ANONYMIZATION_SALT`.
+- Root-only backup was created at `/root/bluesky-feed-secret-rotation-backups/.env.20260505T083505Z.incident-rotation`.
+- Active env permissions after rotation: `/opt/bluesky-feed/.env` is `0600 root:root`.
+- Previously world-readable `/opt/bluesky-feed/.env.backup` was moved to `/root/bluesky-feed-secret-rotation-backups/.env.backup.pre-incident` and chmodded `0600`.
+- GitHub repository secrets updated by name/timestamp only:
+  - `DATABASE_URL`: `2026-05-05T08:35:22Z`
+  - `EXPORT_ANONYMIZATION_SALT`: `2026-05-05T08:35:32Z`
+  - `VPS_HOST`: `2026-05-05T08:45:55Z`
+  - `VPS_USER`: `2026-05-05T08:45:56Z`
+  - `VPS_SSH_KEY`: `2026-05-05T08:45:58Z`
+  - `VPS_SSH_HOST_KEY`: `2026-05-05T08:46:00Z`
+- New SSH key local auth probe succeeded with explicit `-i`, `IdentitiesOnly=yes`, and `BatchMode=yes`.
+- Bluesky app-password API receipt: `{"ok":true,"listedCount":1,"revokedNames":["Corgi"],"oldLoginRejected":true}`.
+- Deployed env scrub receipt:
+  - `BOT_ENABLED=false`
+  - `BOT_APP_PASSWORD_empty=True`
+  - `BSKY_APP_PASSWORD_placeholder=True`
+  - Redis `bot:session` delete count: `1`
+- Root-only scrub backup was created at `/root/bluesky-feed-secret-rotation-backups/.env.20260505T085242Z.bsky-app-password-scrub`.
+
+## Runtime Receipts
+
+- `systemctl show bluesky-feed`: `ActiveState=active`, `SubState=running`, `NRestarts=0`.
+- Localhost probes after scrub/restart:
+  - `/health/ready`: `{"status":"ready"}`
+  - `/health/live`: `{"status":"live"}`
+  - `/health`: `{"status":"ok"}` after startup scoring completed.
+- Public probe after scrub/restart:
+  - `https://feed.corgi.network/health`: HTTP `200`, body `{"status":"ok"}`.
+- Hosted Daily Health Check:
+  - First post-SSH-rotation run: `https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366648561`, success.
+  - Post-Bluesky-revoke/scrub run: `https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366964265`, success.
+
+## Residual Risk
+
+- Bot posting is intentionally disabled until a new Bluesky app password is created
+  through the Bluesky account UI and installed without exposing it to chat, logs,
+  screenshots, or shell history.
+- The feed service remains healthy without bot login. Logs show `Bot is disabled,
+  skipping initialization`.
+- Jetstream saturation/reconnect warnings existed after restart and should be
+  tracked separately if they persist; they did not block readiness, public health,
+  feed freshness, or the hosted Daily Health Check.
+
+## Repo Hardening
+
+- `scripts/sanitize-receipts.mjs` now redacts dotenv-style secret assignments and
+  credential-bearing URLs.
+- `tests/sanitize-receipts.test.ts` includes RED/GREEN coverage for the exact
+  exposure pattern.
+- `docs/SECURITY.md` now instructs operators to inspect deployed env key names
+  only and run receipt verification before committing evidence.

--- a/ops/receipts/2026-05-05/PROJ-110/secret-exposure-response.md
+++ b/ops/receipts/2026-05-05/PROJ-110/secret-exposure-response.md
@@ -19,6 +19,9 @@ The following were also hardened because the service health gate was already red
 - GitHub Actions `VPS_SSH_KEY`: replaced with a fresh repo-level SSH key.
 - GitHub Actions `VPS_SSH_HOST_KEY`: added so health checks use pinned host-key
   verification instead of first-use trust.
+- `.github/workflows/daily-health.yml`: hardened so `VPS_SSH_HOST_KEY` is a
+  required secret and the health workflow always uses
+  `StrictHostKeyChecking=yes`.
 
 No raw secret values were intentionally recorded in this receipt.
 
@@ -76,3 +79,5 @@ No raw secret values were intentionally recorded in this receipt.
   exposure pattern.
 - `docs/SECURITY.md` now instructs operators to inspect deployed env key names
   only and run receipt verification before committing evidence.
+- `.github/workflows/daily-health.yml` now fails validation when
+  `VPS_SSH_HOST_KEY` is missing instead of falling back to `accept-new`.

--- a/ops/receipts/2026-05-05/PROJ-110/security-best-practices-summary.md
+++ b/ops/receipts/2026-05-05/PROJ-110/security-best-practices-summary.md
@@ -5,6 +5,17 @@ Date: 2026-05-05
 Scope: incident response plus nearby secure-by-default controls for the
 TypeScript/Node/Fastify service and browser frontend.
 
+Related incident documents:
+
+- `ops/receipts/2026-05-05/PROJ-110/secret-exposure-response.md`
+- `ops/receipts/2026-05-05/PROJ-110/validation-summary.md`
+
+Incident timeline:
+
+- Detection: `2026-05-05T08:35Z`, during live production env inspection.
+- Initial containment: `2026-05-05T08:35Z`, database credential and export salt rotated.
+- Full credential containment: `2026-05-05T08:54Z`, post-scrub hosted Daily Health Check passed.
+
 ## Findings
 
 ### SBP-1: Receipt Sanitizer Did Not Catch Dotenv Secrets
@@ -30,8 +41,12 @@ app passwords, but did not give a key-name-only inspection pattern.
 Impact: responders could use `cat`, `grep`, or broad shell snippets that expose
 values while trying to inventory configuration.
 
-Fix: added a key-name-only command and receipt-verification requirement to
-`docs/SECURITY.md`.
+Fix: added this key-name-only command and receipt-verification requirement to
+`docs/SECURITY.md`:
+
+```sh
+sudo awk -F= '/^[A-Za-z_][A-Za-z0-9_]*=/ {print $1}' /opt/bluesky-feed/.env
+```
 
 ### SBP-3: CI SSH Health Gate Was Failing And Host-Key Pin Was Missing
 
@@ -41,11 +56,20 @@ Evidence: latest scheduled Daily Health Check runs before this response failed,
 and `.github/workflows/daily-health.yml` used `StrictHostKeyChecking=accept-new`
 when `VPS_SSH_HOST_KEY` was absent.
 
-Impact: production health evidence was stale/red, and future SSH probes could
-trust a first-seen host key.
+Impact: production health evidence was stale/red. The `accept-new` fallback also
+meant an attacker who intercepted the first connection, or a case where ephemeral
+runner storage lost the known-hosts cache, could impersonate the VPS and inject
+false health evidence or capture SSH-authenticated workflow activity.
 
 Fix: rotated repo-level `VPS_SSH_KEY`, added repo-level `VPS_SSH_HOST_KEY`, and
-proved two successful hosted Daily Health Check runs.
+proved two successful hosted Daily Health Check runs:
+
+- `https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366648561`
+- `https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366964265`
+
+Follow-up hardening in this PR made `.github/workflows/daily-health.yml` fail
+the `Validate required secrets` step when `VPS_SSH_HOST_KEY` is missing and
+removed the `accept-new` branch from `Configure SSH access`.
 
 ### SBP-4: Bot Credential Is Intentionally Disabled Pending Secure Re-Enrollment
 
@@ -59,7 +83,29 @@ Impact: bot posting is unavailable until a new app password is generated and
 installed through a non-leaking path.
 
 Fix: leave bot disabled rather than creating/copying a new app password through
-browser screenshots, shell history, chat, or receipts.
+browser screenshots, shell history, chat, or receipts. The approved re-enrollment
+path is:
+
+1. Generate the new Bluesky app password in the account UI.
+2. Store it directly in a password manager or vault without screenshots.
+3. Deploy `BOT_APP_PASSWORD`, `BSKY_APP_PASSWORD`, and `BOT_ENABLED` via an
+   encrypted secret path such as a CI secret store, HashiCorp Vault, Ansible
+   Vault, or an encrypted `scp` handoff that does not persist in shell history.
+4. Verify service health and bot behavior.
+5. Record only key names, timestamps, and success/failure receipts.
+
+### SBP-5: Frontend Axios Audit Debt Blocked Hosted Verification
+
+Severity: High.
+
+Evidence: hosted `frontend-verify` failed on `npm audit --audit-level=moderate`
+for `axios 1.15.0`, and local `cd web && npm audit --audit-level=moderate`
+reproduced the same high-severity advisory set.
+
+Impact: the PR could not satisfy fail-closed frontend security verification.
+
+Fix: updated the `web` dependency and lockfile to `axios 1.16.0`; local frontend
+lint, build, and audit passed after the update.
 
 ## Positive Controls Observed
 
@@ -76,4 +122,6 @@ browser screenshots, shell history, chat, or receipts.
 - Create and install a fresh Bluesky app password out of band if bot posting or
   feed publish scripts are needed.
 - Keep the sanitizer in `npm run docs:verify`.
-- Track repeated Jetstream queue-saturation warnings separately if they persist.
+- Track Jetstream queue-saturation warnings separately under operations if they
+  persist; they were observed during post-restart logs, but readiness, public
+  health, and hosted Daily Health Check all passed.

--- a/ops/receipts/2026-05-05/PROJ-110/security-best-practices-summary.md
+++ b/ops/receipts/2026-05-05/PROJ-110/security-best-practices-summary.md
@@ -1,0 +1,79 @@
+# Security Best-Practices Summary
+
+Date: 2026-05-05
+
+Scope: incident response plus nearby secure-by-default controls for the
+TypeScript/Node/Fastify service and browser frontend.
+
+## Findings
+
+### SBP-1: Receipt Sanitizer Did Not Catch Dotenv Secrets
+
+Severity: High.
+
+Evidence: before the May 5 patch, `scripts/sanitize-receipts.mjs` redacted
+provider IDs, disk identifiers, UUIDs, and action IDs, but not `.env` assignment
+lines or credential-bearing URLs.
+
+Impact: an operator mistake could become a committed receipt with live secrets.
+
+Fix: added sanitizer coverage for dotenv-style secret assignments and basic-auth
+URLs; added regression tests in `tests/sanitize-receipts.test.ts`.
+
+### SBP-2: Operator Runbook Allowed Ambiguous Env Inspection
+
+Severity: Medium.
+
+Evidence: `docs/SECURITY.md` warned never to commit `.env` and to rotate leaked
+app passwords, but did not give a key-name-only inspection pattern.
+
+Impact: responders could use `cat`, `grep`, or broad shell snippets that expose
+values while trying to inventory configuration.
+
+Fix: added a key-name-only command and receipt-verification requirement to
+`docs/SECURITY.md`.
+
+### SBP-3: CI SSH Health Gate Was Failing And Host-Key Pin Was Missing
+
+Severity: High.
+
+Evidence: latest scheduled Daily Health Check runs before this response failed,
+and `.github/workflows/daily-health.yml` used `StrictHostKeyChecking=accept-new`
+when `VPS_SSH_HOST_KEY` was absent.
+
+Impact: production health evidence was stale/red, and future SSH probes could
+trust a first-seen host key.
+
+Fix: rotated repo-level `VPS_SSH_KEY`, added repo-level `VPS_SSH_HOST_KEY`, and
+proved two successful hosted Daily Health Check runs.
+
+### SBP-4: Bot Credential Is Intentionally Disabled Pending Secure Re-Enrollment
+
+Severity: Medium.
+
+Evidence: the exposed Bluesky app password was revoked and deployed env now has
+`BOT_ENABLED=false`, empty `BOT_APP_PASSWORD`, and a placeholder
+`BSKY_APP_PASSWORD`.
+
+Impact: bot posting is unavailable until a new app password is generated and
+installed through a non-leaking path.
+
+Fix: leave bot disabled rather than creating/copying a new app password through
+browser screenshots, shell history, chat, or receipts.
+
+## Positive Controls Observed
+
+- Public health response includes CSP, HSTS, frame protections, nosniff, and
+  rate-limit headers.
+- Startup logs show PostgreSQL, migrations, and Redis checks passed before
+  `READY=1`.
+- Daily Health Check verifies epoch status, disk, local readiness, feed
+  freshness, and public health from hosted CI.
+- Security ownership map found no orphaned sensitive code in the last 12 months.
+
+## Remaining Actions
+
+- Create and install a fresh Bluesky app password out of band if bot posting or
+  feed publish scripts are needed.
+- Keep the sanitizer in `npm run docs:verify`.
+- Track repeated Jetstream queue-saturation warnings separately if they persist.

--- a/ops/receipts/2026-05-05/PROJ-110/security-ownership-summary.json
+++ b/ops/receipts/2026-05-05/PROJ-110/security-ownership-summary.json
@@ -1,0 +1,33 @@
+{
+  "generated_at": "2026-05-05T08:55:03.038143+00:00",
+  "repo": "/private/tmp/proj110-bluesky-health",
+  "window": "12 months ago",
+  "orphaned_sensitive_code": [],
+  "hidden_owners": [
+    {
+      "person": "anno3007@colorado.edu",
+      "name": "AndrewNordstrom",
+      "controls": "100% of auth code",
+      "category": "auth",
+      "share": 1.0
+    }
+  ],
+  "bus_factor_hotspots": [
+    {
+      "path": "src/auth/admin.ts",
+      "bus_factor": 1,
+      "last_touch": "2026-03-07T00:24:12-07:00",
+      "sensitivity_tags": [
+        "auth"
+      ],
+      "top_owner": "anno3007@colorado.edu"
+    }
+  ],
+  "stats": {
+    "commits": 336,
+    "people": 2,
+    "files": 450,
+    "edges": 1269,
+    "cochange_edges": 443
+  }
+}

--- a/ops/receipts/2026-05-05/PROJ-110/security-ownership-summary.json
+++ b/ops/receipts/2026-05-05/PROJ-110/security-ownership-summary.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2026-05-05T08:55:03.038143+00:00",
-  "repo": "/private/tmp/proj110-bluesky-health",
+  "repo": "bluesky-community-feed",
   "window": "12 months ago",
   "orphaned_sensitive_code": [],
   "hidden_owners": [

--- a/ops/receipts/2026-05-05/PROJ-110/validation-summary.md
+++ b/ops/receipts/2026-05-05/PROJ-110/validation-summary.md
@@ -12,6 +12,12 @@ Date: 2026-05-05
 - `npm run build`: passed.
 - `npm audit --audit-level=moderate`: passed, `0` vulnerabilities.
 - `npm test -- --run` with non-secret dummy test env and normal localhost bind permissions: passed, `70` test files and `472` tests.
+- `cd web && npm run lint`: passed after the axios update.
+- `cd web && npm run build`: passed after the axios update.
+- `cd web && npm audit --audit-level=moderate`: passed after the axios update, `0` vulnerabilities.
+- `.github/workflows/daily-health.yml`: static inspection confirms
+  `VPS_SSH_HOST_KEY` is validated as required and `StrictHostKeyChecking=yes` is
+  always used for SSH health probes.
 
 ## Hosted Validation
 

--- a/ops/receipts/2026-05-05/PROJ-110/validation-summary.md
+++ b/ops/receipts/2026-05-05/PROJ-110/validation-summary.md
@@ -1,0 +1,31 @@
+# Validation Summary
+
+Date: 2026-05-05
+
+## Local Validation
+
+- `git diff --check`: passed.
+- `python3 -m json.tool ops/receipts/2026-05-05/PROJ-110/receipt_index.json`: passed.
+- `python3 -m json.tool ops/receipts/2026-05-05/PROJ-110/security-ownership-summary.json`: passed.
+- `npm test -- --run tests/sanitize-receipts.test.ts`: passed, `32` tests.
+- `npm run docs:verify`: passed, `13` tracked docs and `23` markdown files scanned; receipt sanitizer checked `27` receipt files.
+- `npm run build`: passed.
+- `npm audit --audit-level=moderate`: passed, `0` vulnerabilities.
+- `npm test -- --run` with non-secret dummy test env and normal localhost bind permissions: passed, `70` test files and `472` tests.
+
+## Hosted Validation
+
+- `Daily Health Check` after SSH credential rotation:
+  `https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366648561`,
+  conclusion `success`.
+- `Daily Health Check` after Bluesky app-password revocation and deployed env scrub:
+  `https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366964265`,
+  conclusion `success`.
+
+## Live Runtime Validation
+
+- `bluesky-feed.service`: `ActiveState=active`, `SubState=running`, `NRestarts=0`.
+- `http://127.0.0.1:3001/health/ready`: `{"status":"ready"}`.
+- `http://127.0.0.1:3001/health/live`: `{"status":"live"}`.
+- `http://127.0.0.1:3001/health`: `{"status":"ok"}` after startup scoring completed.
+- `https://feed.corgi.network/health`: HTTP `200`, body `{"status":"ok"}`.

--- a/ops/receipts/2026-06-04/PROJ-110/coderabbit-exemptable-timeout.md
+++ b/ops/receipts/2026-06-04/PROJ-110/coderabbit-exemptable-timeout.md
@@ -1,0 +1,69 @@
+---
+bypass: true
+bypass_reason: "audited CodeRabbit exemptable sticky reviewDecision path, PR #201, zero live current-head CodeRabbit threads"
+bypass_actor: "Codex/GPT-5"
+---
+
+# PROJ-110 CodeRabbit Exemptable Timeout Receipt
+
+Generated: 2026-06-04T08:34:00Z
+
+Issue: PROJ-110
+Project: bluesky-feed
+Repository: andrewnordstrom-eng/bluesky-community-feed
+PR: https://github.com/andrewnordstrom-eng/bluesky-community-feed/pull/201
+Current head before this audit receipt commit: `55e6870a703a97ba731b77f70e3ef2b9c551b62a`
+Decision: apply the audited `coderabbit:exempt` path and dismiss stale/off-head CodeRabbit change-request reviews after live current-head thread truth is clear.
+
+## CodeRabbit Gate Snapshot
+
+- `python3 .github/ops/flow.py wait-coderabbit --project bluesky-feed --repo andrewnordstrom-eng/bluesky-community-feed --branch dev/PROJ-110-restore-feed-health --pr 201 --refresh-on-skipped --timeout-seconds 600 --poll-seconds 30 --json`
+  returned terminal `state=exemptable`, `retry_count=2`, `threads_open=0`, and
+  `next_action=Apply the audited CodeRabbit exempt/dismiss path and record sticky reviewDecision evidence`.
+- The same wait result reported the current head SHA as
+  `55e6870a703a97ba731b77f70e3ef2b9c551b62a`, the stale review SHA as
+  `055afd7eb3feb00d312c25ef410247990b63eb3e`, `review_state=CHANGES_REQUESTED`,
+  and `github_review_decision=CHANGES_REQUESTED`.
+- `python3 .github/ops/flow.py coderabbit-truth-gate --repo andrewnordstrom-eng/bluesky-community-feed --pr 201 --mode threads --json`
+  passed with `0` live current-head CodeRabbit threads, `0` stale residue
+  threads, and `1` superseded residue thread.
+- `python3 .github/ops/flow.py coderabbit-truth-gate --repo andrewnordstrom-eng/bluesky-community-feed --pr 201 --mode freshness --json`
+  failed before this audit path because GitHub's review decision remained sticky
+  `CHANGES_REQUESTED` from an off-head CodeRabbit review.
+- `gh api repos/andrewnordstrom-eng/bluesky-community-feed/pulls/201/reviews`
+  showed two stale CodeRabbit `CHANGES_REQUESTED` reviews:
+  `4226653523` on commit `226fad9565d7300ec07fe5cda2c022772b2cd8a6` and
+  `4226732072` on commit `055afd7eb3feb00d312c25ef410247990b63eb3e`.
+
+## Why Refresh Attempts Were Insufficient
+
+- The controller used the bounded `wait-coderabbit --refresh-on-skipped` path
+  instead of direct ad hoc review comments.
+- CodeRabbit did not produce an approving current-head review during the bounded
+  wait, and its status reported review activity/rate-limit churn.
+- The live current-head thread truth was clear, so the remaining blocker was a
+  stale GitHub review decision rather than an unresolved current-head finding.
+- The exemption is narrow: it covers only CodeRabbit freshness convergence for
+  PR #201 while the audit block and label are present and not expired.
+
+## Deterministic Eval
+
+- `npm test -- tests/backfill-score-components-cli.test.ts tests/backfill-governance-weights-cli.test.ts --run --reporter=verbose` under Node `v20.19.0` with fake test env and unsandboxed local IPC passed: `2` files and `21` tests passed.
+- `npm run verify` under Node `v20.19.0` with fake test env and unsandboxed local IPC passed: TypeScript build passed, Vitest reported `74` files and `521` tests passed, CLI build passed, `src/mcp-local` build skipped because absent, web lint passed, and web build passed.
+- `npm run docs:verify` passed before this receipt: `13` tracked docs and `23` markdown files scanned; receipt sanitizer checked `29` receipt files.
+- `git diff --check` and `git diff --cached --check` passed.
+- Root `npm audit --omit=dev` passed with `found 0 vulnerabilities`.
+- Web `npm audit --omit=dev` passed with `found 0 vulnerabilities`.
+- The pre-commit hook ran `tsc --noEmit` over staged TypeScript/TSX files and passed before commit `55e6870a703a97ba731b77f70e3ef2b9c551b62a`.
+
+## Hosted PR Gates
+
+- On current head `55e6870a703a97ba731b77f70e3ef2b9c551b62a`, the following hosted checks were passing before this audit path: CodeQL, dependabot automerge, security-gate, linear-state-sync, aikido-thread-check, internal-tooling-hygiene, linear-policy, quality-gate, docs-verify, backend-verify, frontend-verify, and report-scripts-verify.
+- Hosted CodeRabbit freshness and thread workflow checks were failing only because the PR lacked a valid audit block plus `coderabbit:exempt` label while the vendor review state remained sticky/off-head.
+
+## Live Acceptance
+
+- This receipt justifies `coderabbit:exempt` for `bluesky-community-feed#201` under the documented exemptable timeout path.
+- This receipt also justifies dismissing stale CodeRabbit `CHANGES_REQUESTED` reviews `4226653523` and `4226732072` only after verifying zero live current-head CodeRabbit threads.
+- This receipt does not waive local tests, hosted CI, Linear closeout, current-head thread truth, or future CodeRabbit findings.
+- Remove `coderabbit:exempt` after merge, after CodeRabbit approves a later current head, or if a new live current-head CodeRabbit finding appears.

--- a/scripts/sanitize-receipts.mjs
+++ b/scripts/sanitize-receipts.mjs
@@ -24,6 +24,18 @@ const PROVIDER_JSON_ID_REGEX =
   /((?:"(?:\w*_id|id)"|\b(?:\w*_id|id)\b)\s*:\s*)(?:"(\d{8,})"|\b(\d{8,})\b)/gi;
 const DISALLOWED_RECEIPT_REGEX =
   /(UUID=|PARTUUID=|\/dev\/disk\/by-id\/|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|\b[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}\b|(\baction\s+|\/v2\/actions\/)\d{8,}\b|(?:"(?:\w*_id|id)"|\b(?:\w*_id|id)\b)\s*:\s*(?:"\d{8,}"|\b\d{8,}\b))/i;
+const SECRET_ENV_KEY_PATTERN =
+  String.raw`[A-Z0-9_]*(?:PASSWORD|TOKEN|SECRET|PRIVATE_KEY|ACCESS_KEY|API_KEY|APP_PASSWORD|ANONYMIZATION_SALT|DATABASE_URL|REDIS_URL|CONNECTION_STRING|SSH_KEY)[A-Z0-9_]*`;
+const SECRET_ENV_ASSIGNMENT_REGEX = new RegExp(
+  String.raw`^(\s*(?:export\s+)?${SECRET_ENV_KEY_PATTERN}\s*=\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\r\n]*)`,
+  'gim',
+);
+const SECRET_ENV_ASSIGNMENT_DIRTY_REGEX = new RegExp(
+  String.raw`^\s*(?:export\s+)?${SECRET_ENV_KEY_PATTERN}\s*=\s*(?!\[REDACTED\]\s*(?:$|#))(?:\"[^"\r\n]*\"|'[^'\r\n]*'|[^\r\n]+)`,
+  'im',
+);
+const CREDENTIAL_URL_REGEX = /\b([a-z][a-z0-9+.-]*:\/\/)([^:\s/@]+):([^@\s/]+)@/gi;
+const CREDENTIAL_URL_DIRTY_REGEX = /\b([a-z][a-z0-9+.-]*:\/\/)([^:\s/@]+):([^@\s/]+)@/i;
 const providerIdTokens = new Map();
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
@@ -84,6 +96,8 @@ function providerIdToken(rawValue) {
 
 export function sanitizeReceiptContent(content) {
   return content
+    .replace(SECRET_ENV_ASSIGNMENT_REGEX, '$1[REDACTED]')
+    .replace(CREDENTIAL_URL_REGEX, '$1[REDACTED]@')
     .replace(DEVICE_BY_ID_REGEX, '[REDACTED]')
     .replace(UUID_FIELD_REGEX, (_match, key) => `${key}:[REDACTED]`)
     .replace(CANONICAL_UUID_REGEX, '[REDACTED]')
@@ -93,6 +107,14 @@ export function sanitizeReceiptContent(content) {
       const rawValue = quotedValue || bareValue;
       return `${prefix}"${providerIdToken(rawValue)}"`;
     });
+}
+
+function containsDisallowedReceiptContent(content) {
+  return (
+    DISALLOWED_RECEIPT_REGEX.test(content) ||
+    SECRET_ENV_ASSIGNMENT_DIRTY_REGEX.test(content) ||
+    CREDENTIAL_URL_DIRTY_REGEX.test(content)
+  );
 }
 
 function main() {
@@ -134,11 +156,11 @@ function main() {
 
       const original = utf8Decoder.decode(originalBuffer);
       const sanitized = sanitizeReceiptContent(original);
-      const wasDirty = sanitized !== original || DISALLOWED_RECEIPT_REGEX.test(original);
+      const wasDirty = sanitized !== original || containsDisallowedReceiptContent(original);
       if (!wasDirty) {
         continue;
       }
-      if (DISALLOWED_RECEIPT_REGEX.test(sanitized)) {
+      if (containsDisallowedReceiptContent(sanitized)) {
         throw new Error('sanitized content still contains disallowed stable identifiers');
       }
 

--- a/tests/sanitize-receipts.test.ts
+++ b/tests/sanitize-receipts.test.ts
@@ -141,6 +141,40 @@ describe('sanitizeReceiptContent', () => {
     );
   });
 
+  it('redacts dotenv-style secret assignments while preserving key names', () => {
+    const content = [
+      'DATABASE_URL=postgresql://feed:db-password@example.internal:5432/feed',
+      'export BOT_APP_PASSWORD="bot-password"',
+      "BSKY_APP_PASSWORD='bsky-password'",
+      'EXPORT_ANONYMIZATION_SALT=random-export-salt',
+      'PUBLIC_BASE_URL=https://feed.corgi.network',
+    ].join('\n');
+
+    const sanitized = sanitizeReceiptContent(content);
+
+    expect(sanitized).toContain('DATABASE_URL=[REDACTED]');
+    expect(sanitized).toContain('export BOT_APP_PASSWORD=[REDACTED]');
+    expect(sanitized).toContain('BSKY_APP_PASSWORD=[REDACTED]');
+    expect(sanitized).toContain('EXPORT_ANONYMIZATION_SALT=[REDACTED]');
+    expect(sanitized).toContain('PUBLIC_BASE_URL=https://feed.corgi.network');
+    expect(sanitized).not.toContain('db-password');
+    expect(sanitized).not.toContain('bot-password');
+    expect(sanitized).not.toContain('bsky-password');
+    expect(sanitized).not.toContain('random-export-salt');
+  });
+
+  it('redacts credential-bearing URLs outside dotenv assignments', () => {
+    const content =
+      'psql postgresql://feed:db-password@example.internal:5432/feed && redis://default:redis-password@localhost:6379';
+
+    const sanitized = sanitizeReceiptContent(content);
+
+    expect(sanitized).toContain('postgresql://[REDACTED]@example.internal:5432/feed');
+    expect(sanitized).toContain('redis://[REDACTED]@localhost:6379');
+    expect(sanitized).not.toContain('feed:db-password');
+    expect(sanitized).not.toContain('default:redis-password');
+  });
+
   it('cli --check fails on dirty receipt files and reports the path', () => {
     const receiptsRoot = mkdtempSync(path.join(tmpdir(), 'receipt-sanitize-dirty-'));
     const receiptPath = path.join(receiptsRoot, 'dirty.txt');
@@ -169,6 +203,21 @@ describe('sanitizeReceiptContent', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('Receipt sanitizer found unredacted stable identifiers');
     expect(result.stderr).toContain('dirty-json.txt');
+  });
+
+  it('cli --check fails on dotenv-style secret assignments', () => {
+    const receiptsRoot = mkdtempSync(path.join(tmpdir(), 'receipt-sanitize-env-dirty-'));
+    const receiptPath = path.join(receiptsRoot, 'dirty-env.txt');
+    writeFileSync(receiptPath, 'DATABASE_URL=postgresql://feed:db-password@example.internal/feed\n');
+
+    const result = spawnSync(process.execPath, [sanitizeScriptPath, '--check'], {
+      encoding: 'utf8',
+      env: { ...process.env, RECEIPTS_ROOT: receiptsRoot },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Receipt sanitizer found unredacted stable identifiers');
+    expect(result.stderr).toContain('dirty-env.txt');
   });
 
   it('cli --check respects the provider JSON id digit boundary', () => {

--- a/tests/sanitize-receipts.test.ts
+++ b/tests/sanitize-receipts.test.ts
@@ -220,6 +220,29 @@ describe('sanitizeReceiptContent', () => {
     expect(result.stderr).toContain('dirty-env.txt');
   });
 
+  it('cli --check fails on dotenv-style secret assignment edge cases', () => {
+    const cases = [
+      ['empty-value.txt', 'DATABASE_URL=\n'],
+      ['inline-comment.txt', 'DATABASE_URL=secret # db\n'],
+      ['lowercase-key.txt', 'database_url=postgresql://feed:db-password@example.internal/feed\n'],
+      ['quoted-equals.txt', 'PASSWORD="pass=word"\n'],
+    ];
+
+    for (const [fileName, content] of cases) {
+      const receiptsRoot = mkdtempSync(path.join(tmpdir(), 'receipt-sanitize-env-edge-'));
+      writeFileSync(path.join(receiptsRoot, fileName), content);
+
+      const result = spawnSync(process.execPath, [sanitizeScriptPath, '--check'], {
+        encoding: 'utf8',
+        env: { ...process.env, RECEIPTS_ROOT: receiptsRoot },
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Receipt sanitizer found unredacted stable identifiers');
+      expect(result.stderr).toContain(fileName);
+    }
+  });
+
   it('cli --check respects the provider JSON id digit boundary', () => {
     const cleanReceiptsRoot = mkdtempSync(path.join(tmpdir(), 'receipt-sanitize-boundary-clean-'));
     writeFileSync(path.join(cleanReceiptsRoot, 'safe-json.txt'), '{"id":"1234567"}\n');

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.96.1",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "dompurify": "^3.4.2",
         "marked": "^17.0.5",
         "react": "^19.2.0",
@@ -1365,12 +1365,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.96.1",
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "dompurify": "^3.4.2",
     "marked": "^17.0.5",
     "react": "^19.2.0",


### PR DESCRIPTION
## Summary

- contains the May 5 production secret-exposure response receipts for `PROJ-110`
- hardens `scripts/sanitize-receipts.mjs` so dotenv-style secrets and credential-bearing URLs fail closed before receipt commit
- documents key-name-only env inspection in `docs/SECURITY.md`
- makes the Daily Health Check SSH probe fail closed on a pinned `VPS_SSH_HOST_KEY`
- clears the hosted frontend audit blocker with a targeted `web` axios lockfile update

## Security / Production Actions Already Completed

- rotated PostgreSQL password / `DATABASE_URL`
- rotated `EXPORT_ANONYMIZATION_SALT`
- rotated repo-level `VPS_SSH_KEY`
- added repo-level `VPS_SSH_HOST_KEY`
- revoked Bluesky app password label `Corgi`
- scrubbed deployed Bluesky app password values from active `.env`
- disabled bot login until a fresh app password is created out of band
- restarted `bluesky-feed.service`

No raw secret values are included in this PR.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `python3 -m json.tool ops/receipts/2026-05-05/PROJ-110/receipt_index.json`
- `python3 -m json.tool ops/receipts/2026-05-05/PROJ-110/security-ownership-summary.json`
- workflow YAML parse for `.github/workflows/daily-health.yml`
- `npm test -- --run tests/sanitize-receipts.test.ts`
- `npm run docs:verify`
- `npm run build`
- `npm audit --audit-level=moderate`
- `npm test -- --run` with non-secret dummy test env and normal localhost bind permissions
- `cd web && npm run lint`
- `cd web && npm run build`
- `cd web && npm audit --audit-level=moderate`
- `npm run verify` under Node `v20.19.0` with fake test env: `74` Vitest files and `521` tests passed
- `npm run docs:verify` after the audit receipt: `13` tracked docs and `23` markdown files scanned; receipt sanitizer checked `30` receipt files
- root and web `npm audit --omit=dev`: both reported `found 0 vulnerabilities`

Hosted proof:

- Daily Health Check after SSH credential rotation: https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366648561
- Daily Health Check after Bluesky app-password revocation and env scrub: https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/25366964265

Live proof:

- public `https://feed.corgi.network/health`: `200`, `{"status":"ok"}`
- `bluesky-feed.service`: active/running

## Boundaries

- no raw secrets, PEMs, app passwords, or tokens are recorded
- no PAT fallback
- no broad workflow permission changes
- no Bluesky app-password re-enrollment through browser screenshots, shell history, chat, or receipts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added incident receipts, a security best-practices summary, and an operator checklist with a safe `.env` inspection command and receipt verification step.
* **Bug Fixes**
  * Improved receipt sanitization to redact dotenv-style secrets and passwords in credential URLs.
* **Tests**
  * Added coverage and CLI checks for sanitizer behavior and edge-case dotenv formats.
* **Chores**
  * CI health-check now requires a pinned SSH host key; frontend dependency updated (axios -> 1.16.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## CodeRabbit Audit

- Status: exempt
- Reason: `wait-coderabbit --project bluesky-feed --repo andrewnordstrom-eng/bluesky-community-feed --branch dev/PROJ-110-restore-feed-health --pr 201 --refresh-on-skipped --timeout-seconds 600 --poll-seconds 30 --json` returned `state=exemptable`, `retry_count=2`, and `threads_open=0`; `coderabbit-truth-gate --mode threads` passed with zero live current-head CodeRabbit threads; local verify/docs/audit gates and non-CodeRabbit hosted checks passed. The current branch head is `e9503b91a9f872fa7e9ebe7c081c1d36e5480764`; the stale CodeRabbit change-request reviews are on old commits `226fad9565d7300ec07fe5cda2c022772b2cd8a6` and `055afd7eb3feb00d312c25ef410247990b63eb3e`.
- Follow-up: Remove `coderabbit:exempt` after merge, after CodeRabbit approves a later current head, or if any new live current-head CodeRabbit finding appears. Audit receipt: `ops/receipts/2026-06-04/PROJ-110/coderabbit-exemptable-timeout.md`.
- Expires: 2026-06-05
