### PR TITLE
[PROJ-311] Pin Bluesky web Axios dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,18 @@ jobs:
       - name: Install frontend dependencies
         run: cd web && npm ci
 
+      - name: Validate frontend Axios pin
+        run: |
+          node --input-type=module -e '
+            import fs from "node:fs";
+
+            const packageJson = JSON.parse(fs.readFileSync("web/package.json", "utf8"));
+            const axiosVersion = packageJson.dependencies?.axios;
+            if (axiosVersion !== "1.15.2") {
+              throw new Error(`web/package.json must pin axios to exact 1.15.2; found ${axiosVersion ?? "missing"}`);
+            }
+          '
+
       - name: Lint frontend
         run: cd web && npm run lint
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+min-release-age=3

--- a/cli/.npmrc
+++ b/cli/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+min-release-age=3

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+min-release-age=3

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.96.1",
-        "axios": "^1.15.0",
+        "axios": "1.15.2",
         "dompurify": "^3.4.2",
         "marked": "^17.0.5",
         "react": "^19.2.0",
@@ -1365,9 +1365,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.96.1",
-    "axios": "^1.15.0",
+    "axios": "1.15.2",
     "dompurify": "^3.4.2",
     "marked": "^17.0.5",
     "react": "^19.2.0",


### PR DESCRIPTION
## Summary

- Pins `web` direct Axios to exact `1.15.2`.
- Adds npm policy files with `save-exact=true` and `min-release-age=3`.
- Keeps the branch scoped to dependency supply-chain assurance and audit cleanliness.

## Scope Boundary

- No runtime logic changes.
- No credential, production, host, OAuth, webhook, or systemd changes.
- No broad secret rotation: the PROJ-311 incident receipts in the companion `.github` PR found no defined compromise indicators.

## Dependency Changes

- `web/package.json`: `axios` exact `1.15.2`.
- `web/package-lock.json`: lockfile refreshed for Axios `1.15.2`.
- `.npmrc`, `cli/.npmrc`, `web/.npmrc`: `save-exact=true`, `min-release-age=3`.

## Validation

- `web`: `npm ci --ignore-scripts`
- `web`: `npm audit signatures`
- `web`: `npm audit --audit-level=moderate`
- `web`: `npm run lint`
- `web`: `npm run build`
- root: `npm ci --ignore-scripts`
- root: `npm audit signatures`
- root: `npm audit --audit-level=moderate`
- root: `npm run build`
- root: `npm test -- --run`
- root: `npm run docs:verify`
- root: `npm run build:mcp-local`
- `cli`: `npm ci --ignore-scripts`
- `cli`: `npm audit signatures`
- `cli`: `npm audit --audit-level=moderate`
- `cli`: `npm run build`
- `git --no-pager diff --check`
- JSON parse for changed lockfiles
- PROJ-311 scanner run against this worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforce exact dependency installs and a minimum release age for dependencies to improve stability.
  * Pin axios to version 1.15.2.
  * Add CI validation to ensure the frontend dependency remains pinned to the required axios version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->