### PR TITLE
[PROJ-815] Add governance_epoch_weights and governance_vote_weights long tables with dual-write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ data/exports/
 /TASKING.md
 /Prompts/
 /copilot-instructions.md
+
+# Local agent overlays
+/.agent-admission/
+/.githooks/

--- a/scripts/backfill-governance-weights.ts
+++ b/scripts/backfill-governance-weights.ts
@@ -44,10 +44,22 @@ interface CliArgs {
   table: TargetTable;
 }
 
+/** Parse a positive integer CLI value, exiting with a clear error on bad input.
+ *
+ * `Number.parseInt` is intentionally lenient: it accepts `"10foo"` (returns 10),
+ * `"1.5"` (returns 1), `"2e3"` (returns 2), etc. by stopping at the first
+ * non-numeric character. We pre-reject anything that isn't purely digits so the
+ * validator actually catches typos and malformed flags. */
 function parsePositiveInt(flag: string, raw: string, opts: { min?: number } = {}): number {
-  const value = Number.parseInt(raw, 10);
   const min = opts.min ?? 1;
-  if (!Number.isFinite(value) || Number.isNaN(value) || value < min) {
+  if (!/^\d+$/.test(raw)) {
+    console.error(
+      `Invalid value for ${flag}: ${JSON.stringify(raw)} — expected a positive integer.`
+    );
+    process.exit(2);
+  }
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || value < min) {
     console.error(
       `Invalid value for ${flag}: ${JSON.stringify(raw)} — expected an integer >= ${min}.`
     );

--- a/scripts/backfill-governance-weights.ts
+++ b/scripts/backfill-governance-weights.ts
@@ -76,16 +76,19 @@ function parseArgs(): CliArgs {
   let table: TargetTable = 'both';
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--batch-size' && args[i + 1]) {
-      batchSize = parsePositiveInt('--batch-size', args[i + 1], { min: 1 });
+    if (args[i] === '--batch-size') {
+      // Use `?? ''` so a missing or empty value flows into parsePositiveInt
+      // and surfaces a clear "Invalid value" error instead of silently
+      // falling back to the default.
+      batchSize = parsePositiveInt('--batch-size', args[i + 1] ?? '', { min: 1 });
       i++;
-    } else if (args[i] === '--limit' && args[i + 1]) {
-      limit = parsePositiveInt('--limit', args[i + 1], { min: 1 });
+    } else if (args[i] === '--limit') {
+      limit = parsePositiveInt('--limit', args[i + 1] ?? '', { min: 1 });
       i++;
     } else if (args[i] === '--dry-run') {
       dryRun = true;
-    } else if (args[i] === '--table' && args[i + 1]) {
-      const candidate = args[i + 1] as TargetTable;
+    } else if (args[i] === '--table') {
+      const candidate = (args[i + 1] ?? '') as TargetTable;
       if (candidate !== 'epochs' && candidate !== 'votes' && candidate !== 'both') {
         console.error(`Invalid --table value: ${JSON.stringify(candidate)} — expected epochs|votes|both.`);
         process.exit(2);

--- a/scripts/backfill-governance-weights.ts
+++ b/scripts/backfill-governance-weights.ts
@@ -226,11 +226,21 @@ async function backfillTable(
 async function main(): Promise<void> {
   const args = parseArgs();
 
+  // Require DATABASE_URL explicitly. The pg Pool would otherwise silently
+  // fall back to PGHOST/PGUSER/PGDATABASE env vars (or localhost defaults),
+  // which is dangerous in a backfill context — a typo could rewrite a
+  // local dev DB or fail with a cryptic connection error.
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error('DATABASE_URL is required. Set it in .env or your shell.');
+    process.exit(2);
+  }
+
   console.log(
     `Backfill governance weights: batchSize=${args.batchSize}, table=${args.table}, limit=${args.limit ?? 'none'}, dryRun=${args.dryRun}`
   );
 
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const pool = new Pool({ connectionString });
 
   try {
     let epochStats: BackfillStats | null = null;

--- a/scripts/backfill-governance-weights.ts
+++ b/scripts/backfill-governance-weights.ts
@@ -1,0 +1,249 @@
+/**
+ * Backfill Governance Weights Script (PROJ-815 / P2)
+ *
+ * Projects every existing governance_epochs and governance_votes row's wide
+ * weight columns into the long-table side tables governance_epoch_weights
+ * and governance_vote_weights (migration 022). Idempotent: INSERT ... ON
+ * CONFLICT DO NOTHING. Safe to run repeatedly; safe to run while the live
+ * server is dual-writing new rows.
+ *
+ * Pairs with PROJ-815 / P2. Once PROJ-817 (P4) flips the read flag and
+ * PROJ-819 (P5) drops the wide columns, this script becomes obsolete.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-governance-weights.ts                    # all rows, batches of 500
+ *   npx tsx scripts/backfill-governance-weights.ts --batch-size 200
+ *   npx tsx scripts/backfill-governance-weights.ts --table votes      # just votes
+ *   npx tsx scripts/backfill-governance-weights.ts --table epochs     # just epochs
+ *   npx tsx scripts/backfill-governance-weights.ts --dry-run --limit 1000
+ */
+
+import { Pool } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+/** Wide-column suffix → component_key mapping. Mirrors the 5 columns defined
+ * in migration 003_governance_tables.sql. Hard-coded because the columns
+ * themselves are hard-coded; PROJ-819 (P5) deletes both the columns and this
+ * script. */
+const COMPONENT_PROJECTION = [
+  { key: 'recency', col: 'recency_weight' },
+  { key: 'engagement', col: 'engagement_weight' },
+  { key: 'bridging', col: 'bridging_weight' },
+  { key: 'sourceDiversity', col: 'source_diversity_weight' },
+  { key: 'relevance', col: 'relevance_weight' },
+] as const;
+
+type TargetTable = 'epochs' | 'votes' | 'both';
+
+interface CliArgs {
+  batchSize: number;
+  limit: number | null;
+  dryRun: boolean;
+  table: TargetTable;
+}
+
+function parsePositiveInt(flag: string, raw: string, opts: { min?: number } = {}): number {
+  const value = Number.parseInt(raw, 10);
+  const min = opts.min ?? 1;
+  if (!Number.isFinite(value) || Number.isNaN(value) || value < min) {
+    console.error(
+      `Invalid value for ${flag}: ${JSON.stringify(raw)} — expected an integer >= ${min}.`
+    );
+    process.exit(2);
+  }
+  return value;
+}
+
+function parseArgs(): CliArgs {
+  const args = process.argv.slice(2);
+  let batchSize = 500;
+  let limit: number | null = null;
+  let dryRun = false;
+  let table: TargetTable = 'both';
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--batch-size' && args[i + 1]) {
+      batchSize = parsePositiveInt('--batch-size', args[i + 1], { min: 1 });
+      i++;
+    } else if (args[i] === '--limit' && args[i + 1]) {
+      limit = parsePositiveInt('--limit', args[i + 1], { min: 1 });
+      i++;
+    } else if (args[i] === '--dry-run') {
+      dryRun = true;
+    } else if (args[i] === '--table' && args[i + 1]) {
+      const candidate = args[i + 1] as TargetTable;
+      if (candidate !== 'epochs' && candidate !== 'votes' && candidate !== 'both') {
+        console.error(`Invalid --table value: ${JSON.stringify(candidate)} — expected epochs|votes|both.`);
+        process.exit(2);
+      }
+      table = candidate;
+      i++;
+    } else {
+      console.error(`Unknown argument: ${JSON.stringify(args[i])}`);
+      console.error(
+        'Usage: npx tsx scripts/backfill-governance-weights.ts [--batch-size N] [--limit N] [--dry-run] [--table epochs|votes|both]'
+      );
+      process.exit(2);
+    }
+  }
+
+  return { batchSize, limit, dryRun, table };
+}
+
+interface BackfillStats {
+  scanned: number;
+  inserted: number;
+  batches: number;
+}
+
+async function backfillTable(
+  pool: Pool,
+  args: CliArgs,
+  source: 'governance_epochs' | 'governance_votes'
+): Promise<BackfillStats> {
+  const isEpoch = source === 'governance_epochs';
+  const idColumn = isEpoch ? 'id' : 'id';
+  const targetTable = isEpoch ? 'governance_epoch_weights' : 'governance_vote_weights';
+  const targetIdColumn = isEpoch ? 'epoch_id' : 'vote_id';
+  const idType = isEpoch ? 'int' : 'uuid';
+
+  const stats: BackfillStats = { scanned: 0, inserted: 0, batches: 0 };
+  let lastSeen: number | string | null = null;
+
+  while (true) {
+    if (args.limit !== null && stats.scanned >= args.limit) {
+      console.log(`[${source}] Reached --limit ${args.limit}; stopping.`);
+      break;
+    }
+
+    const remaining = args.limit !== null ? args.limit - stats.scanned : args.batchSize;
+    const currentBatchSize = Math.min(args.batchSize, remaining);
+
+    const params: unknown[] = [];
+    const where: string[] = [];
+
+    if (lastSeen !== null) {
+      params.push(lastSeen);
+      where.push(`${idColumn} > $${params.length}`);
+    }
+    params.push(currentBatchSize);
+
+    const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+
+    const result = await pool.query(
+      `SELECT ${idColumn},
+              ${COMPONENT_PROJECTION.map((c) => c.col).join(', ')}
+       FROM ${source}
+       ${whereSql}
+       ORDER BY ${idColumn}
+       LIMIT $${params.length}`,
+      params
+    );
+
+    if (result.rows.length === 0) {
+      console.log(`[${source}] No more rows to scan.`);
+      break;
+    }
+
+    stats.batches++;
+    stats.scanned += result.rows.length;
+
+    // Project each wide row into N long-table rows. Skip rows where every
+    // weight column is NULL (keyword-only votes; nothing to project).
+    const projectedIds: Array<number | string> = [];
+    const projectedKeys: string[] = [];
+    const projectedWeights: number[] = [];
+
+    for (const row of result.rows) {
+      const rowId = row[idColumn] as number | string;
+      lastSeen = rowId;
+
+      let projectedAny = false;
+      for (const { key, col } of COMPONENT_PROJECTION) {
+        const weight = row[col];
+        if (typeof weight === 'number' && Number.isFinite(weight)) {
+          projectedIds.push(rowId);
+          projectedKeys.push(key);
+          projectedWeights.push(weight);
+          projectedAny = true;
+        }
+      }
+      // Useful for debugging: log keyword-only votes that get skipped.
+      if (!projectedAny && !isEpoch) {
+        // Common case for keyword-only votes — quiet.
+      }
+    }
+
+    if (projectedIds.length === 0) {
+      console.log(`[${source} batch ${stats.batches}] scanned=${result.rows.length} projected=0 (all keyword-only)`);
+      continue;
+    }
+
+    if (!args.dryRun) {
+      const insertResult = await pool.query<{ count: string }>(
+        `WITH inserted AS (
+           INSERT INTO ${targetTable} (${targetIdColumn}, component_key, weight)
+           SELECT * FROM UNNEST(
+             $1::${idType}[],
+             $2::text[],
+             $3::float[]
+           )
+           ON CONFLICT (${targetIdColumn}, component_key) DO NOTHING
+           RETURNING 1
+         )
+         SELECT COUNT(*)::text AS count FROM inserted`,
+        [projectedIds, projectedKeys, projectedWeights]
+      );
+      const insertedCount = parseInt(insertResult.rows[0]?.count ?? '0', 10);
+      stats.inserted += insertedCount;
+      console.log(
+        `[${source} batch ${stats.batches}] scanned=${result.rows.length} projected=${projectedIds.length} inserted=${insertedCount} (skipped=${projectedIds.length - insertedCount})`
+      );
+    } else {
+      console.log(
+        `[${source} batch ${stats.batches}] scanned=${result.rows.length} projected=${projectedIds.length} (dry-run; no writes)`
+      );
+    }
+  }
+
+  return stats;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+
+  console.log(
+    `Backfill governance weights: batchSize=${args.batchSize}, table=${args.table}, limit=${args.limit ?? 'none'}, dryRun=${args.dryRun}`
+  );
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  try {
+    let epochStats: BackfillStats | null = null;
+    let voteStats: BackfillStats | null = null;
+
+    if (args.table === 'epochs' || args.table === 'both') {
+      epochStats = await backfillTable(pool, args, 'governance_epochs');
+    }
+    if (args.table === 'votes' || args.table === 'both') {
+      voteStats = await backfillTable(pool, args, 'governance_votes');
+    }
+
+    console.log('---');
+    if (epochStats) {
+      console.log(`Epochs: ${epochStats.scanned} scanned, ${epochStats.inserted} inserted, ${epochStats.batches} batches`);
+    }
+    if (voteStats) {
+      console.log(`Votes:  ${voteStats.scanned} scanned, ${voteStats.inserted} inserted, ${voteStats.batches} batches`);
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,23 @@ const ConfigSchema = z.object({
   // Governance
   GOVERNANCE_MIN_VOTES: z.coerce.number().default(5),
   GOVERNANCE_PERIOD_HOURS: z.coerce.number().default(168),
+  /**
+   * Dual-write governance epoch and vote weights into the long-table side tables
+   * (governance_epoch_weights / governance_vote_weights from migration 022) in
+   * addition to the wide weight columns. Default on once shipped; turned off
+   * only for incident response. Removed entirely in PROJ-819 (P5) after the
+   * wide columns are dropped. See PROJ-815 for the packet that introduced this
+   * flag.
+   */
+  GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED: zodEnvBool(true),
+  /**
+   * Read the trimmed-mean aggregation input from governance_vote_weights
+   * instead of the 5 wide weight columns. Default off in PROJ-815 (P2);
+   * flipped to true at the end of PROJ-817 (P4) once parity tests are green
+   * across every consumer. See PROJ-815 for the packet that introduced this
+   * flag.
+   */
+  GOVERNANCE_LONGTABLE_READ_ENABLED: zodEnvBool(false),
 
   // Bluesky API
   BSKY_IDENTIFIER: z.string(),

--- a/src/db/migrations/022_governance_weights_longtable.sql
+++ b/src/db/migrations/022_governance_weights_longtable.sql
@@ -1,0 +1,40 @@
+-- Migration 022: Long-table decomposition for governance epoch and vote weights
+--
+-- Adds two normalized side tables that mirror the 5 wide columns in
+-- governance_epochs and governance_votes (recency_weight, engagement_weight,
+-- bridging_weight, source_diversity_weight, relevance_weight). This is
+-- additive; the wide columns and the existing weights_sum_check /
+-- vote_weights_sum_to_one CHECK constraints remain authoritative through
+-- PROJ-817 (P4 reader migration). PROJ-819 (P5) drops the wide columns and
+-- replaces the CHECK constraints with sum-validation triggers that operate
+-- on the long tables.
+--
+-- During the additive window, epoch-manager.ts and routes/vote.ts dual-write
+-- both shapes while GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED is on (default
+-- true). The aggregation read branch in src/governance/aggregation.ts can
+-- optionally read from the long table when GOVERNANCE_LONGTABLE_READ_ENABLED
+-- is on (default false; flipped to true at the end of PROJ-817 / P4).
+--
+-- See PROJ-815 for full packet context. The append-only governance_audit_log
+-- is not modified by this migration.
+
+CREATE TABLE IF NOT EXISTS governance_epoch_weights (
+    epoch_id       INTEGER NOT NULL REFERENCES governance_epochs(id) ON DELETE CASCADE,
+    component_key  TEXT NOT NULL,
+    weight         FLOAT NOT NULL CHECK (weight >= 0 AND weight <= 1),
+    PRIMARY KEY (epoch_id, component_key)
+);
+
+CREATE TABLE IF NOT EXISTS governance_vote_weights (
+    vote_id        UUID NOT NULL REFERENCES governance_votes(id) ON DELETE CASCADE,
+    component_key  TEXT NOT NULL,
+    weight         FLOAT NOT NULL CHECK (weight >= 0 AND weight <= 1),
+    PRIMARY KEY (vote_id, component_key)
+);
+
+-- Component-anchored aggregation: "give me every vote's value for this
+-- component in this epoch" — used by the read branch in aggregation.ts after
+-- PROJ-817 (P4). The PRIMARY KEY already serves vote-anchored lookups via
+-- its (vote_id) leading column, so we add only the component-anchored index.
+CREATE INDEX IF NOT EXISTS idx_gvw_component ON governance_vote_weights(component_key);
+CREATE INDEX IF NOT EXISTS idx_gew_component ON governance_epoch_weights(component_key);

--- a/src/governance/aggregation.ts
+++ b/src/governance/aggregation.ts
@@ -6,6 +6,7 @@
  */
 
 import { db } from '../db/client.js';
+import { config } from '../config.js';
 import { GOVERNANCE_WEIGHT_VOTE_FIELDS, VOTABLE_WEIGHT_PARAMS } from '../config/votable-params.js';
 import { logger } from '../lib/logger.js';
 import { GovernanceWeights, normalizeWeights, ContentRules, emptyContentRules } from './governance.types.js';
@@ -49,19 +50,29 @@ export async function aggregateVotes(epochId: number): Promise<GovernanceWeights
     [epochId]
   );
 
-  const votes = await db.query(
-    `SELECT recency_weight, engagement_weight, bridging_weight,
-            source_diversity_weight, relevance_weight
-     FROM governance_votes
-     WHERE epoch_id = $1
-       AND recency_weight IS NOT NULL
-       AND engagement_weight IS NOT NULL
-       AND bridging_weight IS NOT NULL
-       AND source_diversity_weight IS NOT NULL
-       AND relevance_weight IS NOT NULL
-     ORDER BY voted_at`,
-    [epochId]
-  );
+  // Read the per-vote weight rows. Two source paths share the same downstream
+  // shape (one object per vote with the 5 *_weight keys), gated by the
+  // PROJ-815 read flag.
+  //
+  // Wide path (default): SELECT the 5 named columns from governance_votes.
+  // Long path: pivot governance_vote_weights into the same shape in JS so the
+  // trim/mean logic below stays unchanged. The flag flips to on in PROJ-817
+  // (P4) after parity tests across every consumer pass.
+  const votes = config.GOVERNANCE_LONGTABLE_READ_ENABLED
+    ? await fetchWeightVotesFromLongTable(epochId)
+    : await db.query(
+        `SELECT recency_weight, engagement_weight, bridging_weight,
+                source_diversity_weight, relevance_weight
+         FROM governance_votes
+         WHERE epoch_id = $1
+           AND recency_weight IS NOT NULL
+           AND engagement_weight IS NOT NULL
+           AND bridging_weight IS NOT NULL
+           AND source_diversity_weight IS NOT NULL
+           AND relevance_weight IS NOT NULL
+         ORDER BY voted_at`,
+        [epochId]
+      );
 
   const n = votes.rows.length;
   const keywordOnlyVoteCount = keywordOnlyVotesResult.rows[0]?.count ?? 0;
@@ -123,6 +134,73 @@ export async function aggregateVotes(epochId: number): Promise<GovernanceWeights
   logger.info({ epochId, aggregated: normalized }, 'Vote aggregation complete');
 
   return normalized;
+}
+
+/**
+ * Long-table read path for aggregateVotes (PROJ-815 / P2).
+ *
+ * Pivots governance_vote_weights (one row per vote × component_key) into the
+ * same per-vote wide-shape that the SELECT-from-governance_votes path returns,
+ * so the trim/mean logic in aggregateVotes can stay component-agnostic.
+ *
+ * The "ALL 5 components present" filter from the wide path becomes
+ * "vote has rows for every registered weight key" here; votes missing any
+ * component are excluded (mirrors `recency_weight IS NOT NULL AND …` semantics).
+ *
+ * Gated by GOVERNANCE_LONGTABLE_READ_ENABLED. Off by default in this packet;
+ * flipped to true in PROJ-817 (P4) once parity tests pass across all consumers.
+ */
+async function fetchWeightVotesFromLongTable(
+  epochId: number
+): Promise<{ rows: Array<Record<string, number>> }> {
+  const result = await db.query<{
+    vote_id: string;
+    component_key: string;
+    weight: number;
+  }>(
+    `SELECT gvw.vote_id, gvw.component_key, gvw.weight
+     FROM governance_vote_weights gvw
+     JOIN governance_votes gv ON gv.id = gvw.vote_id
+     WHERE gv.epoch_id = $1
+     ORDER BY gv.voted_at, gvw.component_key`,
+    [epochId]
+  );
+
+  // Pivot into per-vote rows keyed by component_key. We use Map (instead of
+  // an object) to preserve the voted_at insertion order from the SQL ORDER BY
+  // — the trimmed-mean computation doesn't depend on it but downstream callers
+  // assume "ORDER BY voted_at" is stable.
+  const perVote = new Map<string, Record<string, number>>();
+  for (const row of result.rows) {
+    const existing = perVote.get(row.vote_id);
+    if (existing) {
+      existing[row.component_key] = row.weight;
+    } else {
+      perVote.set(row.vote_id, { [row.component_key]: row.weight });
+    }
+  }
+
+  // Project to the wide-column shape consumers expect. Drop votes that don't
+  // have a value for every registered component (the long-path equivalent of
+  // "IS NOT NULL" on each of the 5 wide columns in the SQL above).
+  const requiredKeys = VOTABLE_WEIGHT_PARAMS.map((p) => p.key);
+  const rows: Array<Record<string, number>> = [];
+  for (const [, partial] of perVote) {
+    if (requiredKeys.some((key) => partial[key] === undefined)) {
+      continue;
+    }
+    // Translate camelCase keys (component_key as stored) to the snake_case
+    // `_weight` field names the existing trim/mean loop reads. After PROJ-816
+    // (P3) makes the in-memory shape `Record<>`-based, this translation goes
+    // away.
+    const wideShape: Record<string, number> = {};
+    for (const param of VOTABLE_WEIGHT_PARAMS) {
+      wideShape[param.voteField] = partial[param.key];
+    }
+    rows.push(wideShape);
+  }
+
+  return { rows };
 }
 
 /**

--- a/src/governance/epoch-manager.ts
+++ b/src/governance/epoch-manager.ts
@@ -12,6 +12,7 @@ import { logger } from '../lib/logger.js';
 import { config } from '../config.js';
 import { aggregateVotes, aggregateContentVotes, aggregateTopicWeights } from './aggregation.js';
 import { GovernanceWeights, weightsToVotePayload, ContentRules } from './governance.types.js';
+import { writeEpochWeights } from './weight-longtable.js';
 import { postAnnouncementSafe } from '../bot/safe-poster.js';
 import { invalidateContentRulesCache } from './content-filter.js';
 import { runScoringPipeline } from '../scoring/pipeline.js';
@@ -343,6 +344,13 @@ export async function closeCurrentEpochAndCreateNext(): Promise<number> {
 
     const newEpochId = newEpoch.rows[0].id;
 
+    // 5b. Dual-write the per-component weights into governance_epoch_weights
+    // (PROJ-815 / P2). Wide columns remain authoritative through P4; the long
+    // table converges via this dual-write plus the backfill script.
+    if (config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED) {
+      await writeEpochWeights(client, newEpochId, newWeights);
+    }
+
     // 6. Audit log - epoch closed
     const oldWeights: GovernanceWeights = {
       recency: currentEpoch.recency_weight,
@@ -594,6 +602,13 @@ export async function forceEpochTransition(): Promise<number> {
     );
 
     const newEpochId = newEpoch.rows[0].id;
+
+    // 5b. Dual-write the per-component weights into governance_epoch_weights
+    // (PROJ-815 / P2). Same eventual-consistency contract as the non-forced
+    // transition path above.
+    if (config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED) {
+      await writeEpochWeights(client, newEpochId, newWeights);
+    }
 
     // 6. Audit log - epoch closed
     const oldWeights: GovernanceWeights = {

--- a/src/governance/routes/vote.ts
+++ b/src/governance/routes/vote.ts
@@ -27,6 +27,7 @@ import {
   normalizeKeywords,
 } from '../governance.types.js';
 import type { VotePayload } from '../governance.types.js';
+import { writeVoteWeights } from '../weight-longtable.js';
 
 const weightFieldSchemas = Object.fromEntries(
   VOTABLE_WEIGHT_PARAMS.map((param) => [
@@ -307,7 +308,25 @@ export function registerVoteRoute(app: FastifyInstance): void {
       );
 
       const isNewVote = voteResult.rows[0].is_new_vote;
+      const voteId = voteResult.rows[0].id as string;
       const auditAction = isNewVote ? 'vote_cast' : 'vote_updated';
+
+      // 6b. Dual-write per-component weights into governance_vote_weights
+      // (PROJ-815 / P2). Only when the submission carried weights; keyword-only
+      // updates leave prior long-table rows in place, mirroring the COALESCE
+      // semantics of the wide-row UPSERT above. A failure here does NOT roll
+      // back the wide row — same eventual-consistency contract as PROJ-814.
+      // Backfill (scripts/backfill-governance-weights.ts) converges any gap.
+      if (config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED && normalized) {
+        try {
+          await writeVoteWeights(voteId, normalized);
+        } catch (longTableErr) {
+          logger.warn(
+            { err: longTableErr, voteId, epochId },
+            'Long-table vote weight write failed; wide row remains authoritative'
+          );
+        }
+      }
 
       // 7. Log to audit trail with appropriate action
       await db.query(

--- a/src/governance/weight-longtable.ts
+++ b/src/governance/weight-longtable.ts
@@ -1,0 +1,98 @@
+/**
+ * Governance Weight Long-Table Dual-Write Helpers (PROJ-815 / P2)
+ *
+ * Mirror the 5 wide weight columns on governance_epochs and governance_votes
+ * into the normalized side tables governance_epoch_weights and
+ * governance_vote_weights (migration 022). One row per registered weight key.
+ *
+ * Wide columns remain authoritative through PROJ-817 (P4). PROJ-819 (P5)
+ * drops the wide columns and the helpers in this file become the sole write
+ * path (the dual-write conditional is removed).
+ *
+ * IMPORTANT: callers must already have done the wide-column INSERT and have
+ * the corresponding epoch_id or vote_id before invoking these helpers. The
+ * config flag check is the caller's responsibility — these helpers always
+ * write when called.
+ */
+
+import type { PoolClient } from 'pg';
+import { db } from '../db/client.js';
+import type { GovernanceWeightKey } from '../shared/api-types.js';
+
+/**
+ * Build the (placeholders, params) tuple for a batched VALUES clause of N
+ * (id, component_key, weight) triples. Each row contributes 3 placeholders
+ * and 3 params. Used by both helpers below.
+ */
+function buildWeightRows(
+  id: number | string,
+  weights: Record<GovernanceWeightKey, number>
+): { placeholders: string; params: unknown[] } {
+  const entries = Object.entries(weights);
+  const placeholders: string[] = [];
+  const params: unknown[] = [];
+  for (const [key, weight] of entries) {
+    const offset = params.length;
+    params.push(id, key, weight);
+    placeholders.push(
+      `($${offset + 1}, $${offset + 2}, $${offset + 3})`
+    );
+  }
+  return { placeholders: placeholders.join(', '), params };
+}
+
+/**
+ * Write N rows into governance_epoch_weights — one per registered weight key.
+ * Idempotent via ON CONFLICT DO UPDATE so a re-emitted transition does not
+ * conflict. Pass the transactional `client` so this runs inside the same
+ * transaction as the wide-row INSERT in epoch-manager.ts.
+ */
+export async function writeEpochWeights(
+  client: PoolClient,
+  epochId: number,
+  weights: Record<GovernanceWeightKey, number>
+): Promise<void> {
+  if (Object.keys(weights).length === 0) {
+    return;
+  }
+  const { placeholders, params } = buildWeightRows(epochId, weights);
+  await client.query(
+    `INSERT INTO governance_epoch_weights (epoch_id, component_key, weight)
+     VALUES ${placeholders}
+     ON CONFLICT (epoch_id, component_key) DO UPDATE SET weight = EXCLUDED.weight`,
+    params
+  );
+}
+
+/**
+ * Write N rows into governance_vote_weights — one per submitted weight key.
+ * Mirrors COALESCE semantics from the wide-row UPSERT: keys with null/undefined
+ * values are skipped (preserves prior long-table rows on a partial update).
+ *
+ * Uses the autocommit pool `db` since the caller in routes/vote.ts is not
+ * already inside a transaction. A failure here does not roll back the wide
+ * row — the same eventual-consistency contract that PROJ-814 (P1) established
+ * for scoring decomposition. Backfill converges any gap.
+ */
+export async function writeVoteWeights(
+  voteId: string,
+  weights: Partial<Record<GovernanceWeightKey, number | null | undefined>>
+): Promise<void> {
+  const nonNull = Object.entries(weights).filter(
+    ([, weight]) => typeof weight === 'number' && Number.isFinite(weight)
+  ) as Array<[GovernanceWeightKey, number]>;
+
+  if (nonNull.length === 0) {
+    return;
+  }
+
+  const fullWeights = Object.fromEntries(nonNull) as Record<GovernanceWeightKey, number>;
+  const { placeholders, params } = buildWeightRows(voteId, fullWeights);
+
+  await db.query(
+    `INSERT INTO governance_vote_weights (vote_id, component_key, weight)
+     VALUES ${placeholders}
+     ON CONFLICT (vote_id, component_key) DO UPDATE SET weight = EXCLUDED.weight`,
+    params
+  );
+}

--- a/tests/backfill-governance-weights-cli.test.ts
+++ b/tests/backfill-governance-weights-cli.test.ts
@@ -1,0 +1,83 @@
+/**
+ * CLI regression tests for scripts/backfill-governance-weights.ts.
+ *
+ * The DATABASE_URL guard is safety-critical: if it regresses, the backfill
+ * could target an unintended local Postgres (the default) and write into the
+ * wrong database. These tests lock that guard in.
+ *
+ * Pattern: spawnSync invokes the script in a controlled subshell with
+ * DATABASE_URL absent or set to a sentinel; assert exit code, stderr, and
+ * that we exit before any DB connection attempt.
+ *
+ * Per CodeRabbit feedback on PR #223 (review at 2026-05-26T19:35:13Z).
+ */
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = path.resolve('scripts', 'backfill-governance-weights.ts');
+const TSX = path.resolve('node_modules', '.bin', 'tsx');
+const SENTINEL = 'postgresql://sentinel-user:sentinel-pass@sentinel-host:6543/sentinel-db';
+
+function runScript(args: string[], envOverrides: Record<string, string | undefined>) {
+  const env = { ...process.env, ...envOverrides };
+  for (const [k, v] of Object.entries(envOverrides)) {
+    if (v === undefined) delete env[k];
+  }
+  // Run from /tmp so the script's `dotenv.config()` does not find a .env in
+  // the repo cwd and silently re-populate DATABASE_URL from it. tsx and the
+  // script use absolute paths, so cwd is otherwise irrelevant.
+  return spawnSync(TSX, [SCRIPT, ...args], {
+    cwd: '/tmp',
+    env,
+    encoding: 'utf8',
+    timeout: 15_000,
+  });
+}
+
+describe('backfill-governance-weights CLI: DATABASE_URL guard', () => {
+  it('exits with code 2 and a clear error when DATABASE_URL is unset', () => {
+    const result = runScript(['--dry-run'], { DATABASE_URL: undefined });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/DATABASE_URL is required/);
+    expect(result.stdout).not.toMatch(/Connecting to/);
+  });
+
+  it('exits with code 2 when DATABASE_URL is empty string', () => {
+    const result = runScript(['--dry-run'], { DATABASE_URL: '' });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/DATABASE_URL is required/);
+  });
+
+  it('advances past the env check when DATABASE_URL is set (sentinel value)', () => {
+    const result = runScript(['--dry-run'], { DATABASE_URL: SENTINEL });
+    expect(result.stderr).not.toMatch(/DATABASE_URL is required/);
+    expect(result.status === 2).toBe(false);
+  });
+});
+
+describe('backfill-governance-weights CLI: argument validation', () => {
+  it('rejects --batch-size with a non-numeric value', () => {
+    const result = runScript(['--batch-size', 'foo'], { DATABASE_URL: SENTINEL });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/Invalid value for --batch-size/);
+  });
+
+  it('rejects --batch-size with a zero value (min is 1)', () => {
+    const result = runScript(['--batch-size', '0'], { DATABASE_URL: SENTINEL });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/Invalid value for --batch-size/);
+  });
+
+  it('rejects --limit with a non-positive value', () => {
+    const result = runScript(['--limit', '0'], { DATABASE_URL: SENTINEL });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/Invalid value for --limit/);
+  });
+
+  it('rejects an unknown flag', () => {
+    const result = runScript(['--unknown-flag'], { DATABASE_URL: SENTINEL });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/Unknown argument/);
+  });
+});

--- a/tests/backfill-governance-weights-cli.test.ts
+++ b/tests/backfill-governance-weights-cli.test.ts
@@ -11,13 +11,23 @@
  *
  * Per CodeRabbit feedback on PR #223 (review at 2026-05-26T19:35:13Z).
  */
-import { spawnSync } from 'node:child_process';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const SCRIPT = path.resolve('scripts', 'backfill-governance-weights.ts');
 const TSX = path.resolve('node_modules', '.bin', 'tsx');
 const SENTINEL = 'postgresql://sentinel-user:sentinel-pass@sentinel-host:6543/sentinel-db';
+
+/**
+ * Guard against a subprocess that never actually spawned (tsx not found,
+ * PATH issue, etc.). Without this, a `result.status === null` would let
+ * negative assertions like `not.toBe(2)` false-pass.
+ */
+function assertSpawnCompleted(result: SpawnSyncReturns<string>): void {
+  expect(result.error).toBeUndefined();
+  expect(result.status).not.toBeNull();
+}
 
 function runScript(args: string[], envOverrides: Record<string, string | undefined>) {
   const env = { ...process.env, ...envOverrides };
@@ -38,6 +48,7 @@ function runScript(args: string[], envOverrides: Record<string, string | undefin
 describe('backfill-governance-weights CLI: DATABASE_URL guard', () => {
   it('exits with code 2 and a clear error when DATABASE_URL is unset', () => {
     const result = runScript(['--dry-run'], { DATABASE_URL: undefined });
+    assertSpawnCompleted(result);
     expect(result.status).toBe(2);
     expect(result.stderr).toMatch(/DATABASE_URL is required/);
     expect(result.stdout).not.toMatch(/Connecting to/);
@@ -45,38 +56,58 @@ describe('backfill-governance-weights CLI: DATABASE_URL guard', () => {
 
   it('exits with code 2 when DATABASE_URL is empty string', () => {
     const result = runScript(['--dry-run'], { DATABASE_URL: '' });
+    assertSpawnCompleted(result);
     expect(result.status).toBe(2);
     expect(result.stderr).toMatch(/DATABASE_URL is required/);
   });
 
   it('advances past the env check when DATABASE_URL is set (sentinel value)', () => {
     const result = runScript(['--dry-run'], { DATABASE_URL: SENTINEL });
+    assertSpawnCompleted(result);
     expect(result.stderr).not.toMatch(/DATABASE_URL is required/);
-    expect(result.status === 2).toBe(false);
+    expect(result.status).not.toBe(2);
   });
 });
 
 describe('backfill-governance-weights CLI: argument validation', () => {
   it('rejects --batch-size with a non-numeric value', () => {
     const result = runScript(['--batch-size', 'foo'], { DATABASE_URL: SENTINEL });
+    assertSpawnCompleted(result);
     expect(result.status).toBe(2);
     expect(result.stderr).toMatch(/Invalid value for --batch-size/);
   });
 
   it('rejects --batch-size with a zero value (min is 1)', () => {
     const result = runScript(['--batch-size', '0'], { DATABASE_URL: SENTINEL });
+    assertSpawnCompleted(result);
     expect(result.status).toBe(2);
     expect(result.stderr).toMatch(/Invalid value for --batch-size/);
   });
 
+  it('rejects --batch-size with no following value (bare flag)', () => {
+    const result = runScript(['--batch-size'], { DATABASE_URL: SENTINEL });
+    assertSpawnCompleted(result);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/--batch-size/);
+  });
+
+  it('rejects --batch-size with an empty string value', () => {
+    const result = runScript(['--batch-size', ''], { DATABASE_URL: SENTINEL });
+    assertSpawnCompleted(result);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/--batch-size/);
+  });
+
   it('rejects --limit with a non-positive value', () => {
     const result = runScript(['--limit', '0'], { DATABASE_URL: SENTINEL });
+    assertSpawnCompleted(result);
     expect(result.status).toBe(2);
     expect(result.stderr).toMatch(/Invalid value for --limit/);
   });
 
   it('rejects an unknown flag', () => {
     const result = runScript(['--unknown-flag'], { DATABASE_URL: SENTINEL });
+    assertSpawnCompleted(result);
     expect(result.status).toBe(2);
     expect(result.stderr).toMatch(/Unknown argument/);
   });

--- a/tests/governance-longtable-dualwrite.test.ts
+++ b/tests/governance-longtable-dualwrite.test.ts
@@ -176,6 +176,45 @@ describe('governance long-table dual-write (PROJ-815)', () => {
       });
       expect(findCall('INSERT INTO governance_vote_weights')).toBeUndefined();
     });
+
+    it('propagates db.query errors instead of swallowing them', async () => {
+      // The caller (routes/vote.ts) is responsible for the
+      // logger.warn-and-continue eventual-consistency behavior; the helper
+      // itself must surface failures so callers can decide whether to swallow.
+      dbQueryMock.mockReset();
+      dbQueryMock.mockRejectedValueOnce(new Error('db connection lost'));
+
+      await expect(
+        writeVoteWeights('vote-uuid-err', {
+          recency: 0.2,
+          engagement: 0.2,
+          bridging: 0.2,
+          sourceDiversity: 0.2,
+          relevance: 0.2,
+        })
+      ).rejects.toThrow('db connection lost');
+    });
+  });
+
+  describe('writeEpochWeights error propagation', () => {
+    it('propagates client.query errors so the outer transaction can roll back', async () => {
+      // Epoch dual-write runs inside an existing BEGIN/COMMIT block in
+      // epoch-manager.ts. If the long-table INSERT throws, the helper must
+      // surface it so the surrounding transaction rolls back atomically.
+      const failingClient = {
+        query: vi.fn().mockRejectedValueOnce(new Error('long-table insert failed')),
+      } as unknown as Parameters<typeof writeEpochWeights>[0];
+
+      await expect(
+        writeEpochWeights(failingClient, 7, {
+          recency: 0.2,
+          engagement: 0.2,
+          bridging: 0.2,
+          sourceDiversity: 0.2,
+          relevance: 0.2,
+        })
+      ).rejects.toThrow('long-table insert failed');
+    });
   });
 
   describe('aggregateVotes read-flag branch', () => {
@@ -267,6 +306,24 @@ describe('governance long-table dual-write (PROJ-815)', () => {
       for (const key of ['recency', 'engagement', 'bridging', 'sourceDiversity', 'relevance'] as const) {
         expect(longResult![key]).toBeCloseTo(wideResult![key], 9);
       }
+    });
+
+    it('returns null on empty-input wide path', async () => {
+      configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = false;
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // keyword-only count
+      dbQueryMock.mockResolvedValueOnce({ rows: [] });              // wide votes query
+
+      const result = await aggregateVotes(99);
+      expect(result).toBeNull();
+    });
+
+    it('returns null on empty-input long path (parity with wide)', async () => {
+      configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = true;
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // keyword-only count
+      dbQueryMock.mockResolvedValueOnce({ rows: [] });              // long votes query
+
+      const result = await aggregateVotes(99);
+      expect(result).toBeNull();
     });
 
     it('excludes votes missing any component (long-path filter parity)', async () => {

--- a/tests/governance-longtable-dualwrite.test.ts
+++ b/tests/governance-longtable-dualwrite.test.ts
@@ -285,7 +285,7 @@ describe('governance long-table dual-write (PROJ-815)', () => {
     it('reads from governance_votes wide columns when flag is off', async () => {
       configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = false;
 
-      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // keyword-only query
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: '0' }] }); // keyword-only query
       dbQueryMock.mockResolvedValueOnce({
         rows: [
           {
@@ -308,7 +308,7 @@ describe('governance long-table dual-write (PROJ-815)', () => {
     it('reads from governance_vote_weights long table when flag is on', async () => {
       configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = true;
 
-      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // keyword-only query
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: '0' }] }); // keyword-only query
       dbQueryMock.mockResolvedValueOnce({
         rows: [
           { vote_id: 'v1', component_key: 'recency', weight: 0.2 },
@@ -336,7 +336,7 @@ describe('governance long-table dual-write (PROJ-815)', () => {
       // Wide path
       configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = false;
       dbQueryMock.mockReset();
-      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] });
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: '0' }] });
       dbQueryMock.mockResolvedValueOnce({
         rows: votes.map((v) => ({
           recency_weight: v.recency,
@@ -351,7 +351,7 @@ describe('governance long-table dual-write (PROJ-815)', () => {
       // Long path with the same votes pivoted to long shape
       configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = true;
       dbQueryMock.mockReset();
-      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] });
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: '0' }] });
       dbQueryMock.mockResolvedValueOnce({
         rows: votes.flatMap((v, i) => [
           { vote_id: `v${i}`, component_key: 'recency', weight: v.recency },
@@ -374,7 +374,7 @@ describe('governance long-table dual-write (PROJ-815)', () => {
 
     it('returns null on empty-input wide path', async () => {
       configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = false;
-      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // keyword-only count
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: '0' }] }); // keyword-only count
       dbQueryMock.mockResolvedValueOnce({ rows: [] });              // wide votes query
 
       const result = await aggregateVotes(99);
@@ -383,8 +383,30 @@ describe('governance long-table dual-write (PROJ-815)', () => {
 
     it('returns null on empty-input long path (parity with wide)', async () => {
       configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = true;
-      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // keyword-only count
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: '0' }] }); // keyword-only count
       dbQueryMock.mockResolvedValueOnce({ rows: [] });              // long votes query
+
+      const result = await aggregateVotes(99);
+      expect(result).toBeNull();
+    });
+
+    // Regression: aggregateVotes must decide null/non-null from the actual
+    // eligible-votes set, NOT from the keyword-only count. pg returns int8 as
+    // string; mocking COUNT(*) as '2' with an empty vote rowset must still
+    // produce null on both code paths.
+    it('returns null when keyword-count is positive but eligible votes is empty (wide path)', async () => {
+      configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = false;
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: '2' }] }); // positive keyword count
+      dbQueryMock.mockResolvedValueOnce({ rows: [] });               // wide votes query: empty
+
+      const result = await aggregateVotes(99);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when keyword-count is positive but eligible votes is empty (long path)', async () => {
+      configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = true;
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: '2' }] }); // positive keyword count
+      dbQueryMock.mockResolvedValueOnce({ rows: [] });               // long votes query: empty
 
       const result = await aggregateVotes(99);
       expect(result).toBeNull();
@@ -395,7 +417,7 @@ describe('governance long-table dual-write (PROJ-815)', () => {
       // wide path uses "AND xxx_weight IS NOT NULL" for each column; the long
       // path's equivalent is "vote has rows for every registered key".
       configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = true;
-      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] });
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: '0' }] });
       dbQueryMock.mockResolvedValueOnce({
         rows: [
           // complete vote

--- a/tests/governance-longtable-dualwrite.test.ts
+++ b/tests/governance-longtable-dualwrite.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Governance Long-Table Dual-Write + Read Tests (PROJ-815 / P2)
+ *
+ * Three surfaces under test:
+ *   1. writeEpochWeights / writeVoteWeights helpers (writers)
+ *   2. aggregateVotes read-flag branch (reader)
+ *   3. Parity between wide-path and long-path aggregation
+ *
+ * Wide-row behavior is exhaustively covered by governance-admin.test.ts and
+ * governance.types.test.ts; this file focuses on the long-table additions.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  dbQueryMock,
+  configMock,
+} = vi.hoisted(() => ({
+  dbQueryMock: vi.fn(),
+  configMock: {
+    GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED: true,
+    GOVERNANCE_LONGTABLE_READ_ENABLED: false,
+    SCORING_WINDOW_HOURS: 48,
+    FEED_MAX_POSTS: 300,
+  },
+}));
+
+vi.mock('../src/db/client.js', () => ({
+  db: { query: dbQueryMock },
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: configMock,
+}));
+
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  writeEpochWeights,
+  writeVoteWeights,
+} from '../src/governance/weight-longtable.js';
+import { aggregateVotes } from '../src/governance/aggregation.js';
+
+/** Find a db.query call by an SQL substring. */
+function findCall(needle: string): unknown[] | undefined {
+  return dbQueryMock.mock.calls.find((c: unknown[]) =>
+    String(c[0]).includes(needle)
+  );
+}
+
+describe('governance long-table dual-write (PROJ-815)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configMock.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED = true;
+    configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = false;
+    dbQueryMock.mockResolvedValue({ rows: [] });
+  });
+
+  describe('writeEpochWeights', () => {
+    it('writes one row per registered weight key in a batched INSERT', async () => {
+      // Helper accepts a transactional client; we pass dbQueryMock as a stand-in
+      // since the test only inspects what query was issued.
+      const fakeClient = { query: dbQueryMock } as unknown as Parameters<typeof writeEpochWeights>[0];
+
+      await writeEpochWeights(fakeClient, 42, {
+        recency: 0.2,
+        engagement: 0.2,
+        bridging: 0.2,
+        sourceDiversity: 0.2,
+        relevance: 0.2,
+      });
+
+      const call = findCall('INSERT INTO governance_epoch_weights');
+      expect(call).toBeDefined();
+
+      const sql = String(call![0]);
+      const params = call![1] as unknown[];
+
+      expect(params.length).toBe(5 * 3);
+      expect(sql).toMatch(
+        /ON CONFLICT \(epoch_id, component_key\) DO UPDATE SET weight = EXCLUDED\.weight/
+      );
+
+      // component_key column is the 2nd of each 3-tuple.
+      const componentKeys = [params[1], params[4], params[7], params[10], params[13]];
+      expect(new Set(componentKeys)).toEqual(
+        new Set(['recency', 'engagement', 'bridging', 'sourceDiversity', 'relevance'])
+      );
+    });
+
+    it('is a no-op when weights map is empty', async () => {
+      const fakeClient = { query: dbQueryMock } as unknown as Parameters<typeof writeEpochWeights>[0];
+      await writeEpochWeights(fakeClient, 1, {});
+      expect(findCall('INSERT INTO governance_epoch_weights')).toBeUndefined();
+    });
+
+    it('accepts a 6th hypothetical key without DDL changes', async () => {
+      // The "6th-key fixture" from the PROJ-815 packet: a 'civility' key flows
+      // through the helper unchanged, proving the long-table contract is
+      // component-agnostic. (Live registry still has 5; this exercises the path.)
+      const fakeClient = { query: dbQueryMock } as unknown as Parameters<typeof writeEpochWeights>[0];
+
+      await writeEpochWeights(fakeClient, 99, {
+        recency: 0.15,
+        engagement: 0.15,
+        bridging: 0.15,
+        sourceDiversity: 0.15,
+        relevance: 0.15,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        civility: 0.25 as any,
+      });
+
+      const call = findCall('INSERT INTO governance_epoch_weights');
+      expect(call).toBeDefined();
+      const params = call![1] as unknown[];
+
+      // 6 rows × 3 columns = 18 params; one of the component_keys must be civility.
+      expect(params.length).toBe(6 * 3);
+      const keys = [params[1], params[4], params[7], params[10], params[13], params[16]];
+      expect(keys).toContain('civility');
+    });
+  });
+
+  describe('writeVoteWeights', () => {
+    it('writes one row per submitted weight key', async () => {
+      await writeVoteWeights('vote-uuid-1', {
+        recency: 0.3,
+        engagement: 0.2,
+        bridging: 0.2,
+        sourceDiversity: 0.15,
+        relevance: 0.15,
+      });
+
+      const call = findCall('INSERT INTO governance_vote_weights');
+      expect(call).toBeDefined();
+      const params = call![1] as unknown[];
+      expect(params.length).toBe(5 * 3);
+
+      const sql = String(call![0]);
+      expect(sql).toMatch(
+        /ON CONFLICT \(vote_id, component_key\) DO UPDATE SET weight = EXCLUDED\.weight/
+      );
+    });
+
+    it('skips null/undefined values (mirrors wide-row COALESCE semantics)', async () => {
+      // Partial update: only recency and engagement submitted; the rest must
+      // be skipped (not written as 0).
+      await writeVoteWeights('vote-uuid-2', {
+        recency: 0.4,
+        engagement: 0.3,
+        bridging: null,
+        sourceDiversity: undefined,
+        relevance: null,
+      });
+
+      const call = findCall('INSERT INTO governance_vote_weights');
+      expect(call).toBeDefined();
+      const params = call![1] as unknown[];
+      expect(params.length).toBe(2 * 3);
+    });
+
+    it('is a no-op when every value is null/undefined', async () => {
+      await writeVoteWeights('vote-uuid-3', {
+        recency: null,
+        engagement: null,
+        bridging: null,
+        sourceDiversity: null,
+        relevance: null,
+      });
+      expect(findCall('INSERT INTO governance_vote_weights')).toBeUndefined();
+    });
+  });
+
+  describe('aggregateVotes read-flag branch', () => {
+    it('reads from governance_votes wide columns when flag is off', async () => {
+      configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = false;
+
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // keyword-only query
+      dbQueryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            recency_weight: 0.2,
+            engagement_weight: 0.2,
+            bridging_weight: 0.2,
+            source_diversity_weight: 0.2,
+            relevance_weight: 0.2,
+          },
+        ],
+      });
+
+      const result = await aggregateVotes(1);
+      expect(result).not.toBeNull();
+
+      expect(findCall('FROM governance_votes')).toBeDefined();
+      expect(findCall('FROM governance_vote_weights')).toBeUndefined();
+    });
+
+    it('reads from governance_vote_weights long table when flag is on', async () => {
+      configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = true;
+
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // keyword-only query
+      dbQueryMock.mockResolvedValueOnce({
+        rows: [
+          { vote_id: 'v1', component_key: 'recency', weight: 0.2 },
+          { vote_id: 'v1', component_key: 'engagement', weight: 0.2 },
+          { vote_id: 'v1', component_key: 'bridging', weight: 0.2 },
+          { vote_id: 'v1', component_key: 'sourceDiversity', weight: 0.2 },
+          { vote_id: 'v1', component_key: 'relevance', weight: 0.2 },
+        ],
+      });
+
+      const result = await aggregateVotes(1);
+      expect(result).not.toBeNull();
+
+      expect(findCall('FROM governance_vote_weights')).toBeDefined();
+    });
+
+    it('produces parity between wide-path and long-path aggregation on the same input', async () => {
+      // Hand-rolled 3-vote dataset:
+      const votes = [
+        { recency: 0.30, engagement: 0.20, bridging: 0.20, sourceDiversity: 0.15, relevance: 0.15 },
+        { recency: 0.10, engagement: 0.30, bridging: 0.20, sourceDiversity: 0.20, relevance: 0.20 },
+        { recency: 0.20, engagement: 0.20, bridging: 0.20, sourceDiversity: 0.20, relevance: 0.20 },
+      ];
+
+      // Wide path
+      configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = false;
+      dbQueryMock.mockReset();
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] });
+      dbQueryMock.mockResolvedValueOnce({
+        rows: votes.map((v) => ({
+          recency_weight: v.recency,
+          engagement_weight: v.engagement,
+          bridging_weight: v.bridging,
+          source_diversity_weight: v.sourceDiversity,
+          relevance_weight: v.relevance,
+        })),
+      });
+      const wideResult = await aggregateVotes(1);
+
+      // Long path with the same votes pivoted to long shape
+      configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = true;
+      dbQueryMock.mockReset();
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] });
+      dbQueryMock.mockResolvedValueOnce({
+        rows: votes.flatMap((v, i) => [
+          { vote_id: `v${i}`, component_key: 'recency', weight: v.recency },
+          { vote_id: `v${i}`, component_key: 'engagement', weight: v.engagement },
+          { vote_id: `v${i}`, component_key: 'bridging', weight: v.bridging },
+          { vote_id: `v${i}`, component_key: 'sourceDiversity', weight: v.sourceDiversity },
+          { vote_id: `v${i}`, component_key: 'relevance', weight: v.relevance },
+        ]),
+      });
+      const longResult = await aggregateVotes(1);
+
+      expect(wideResult).not.toBeNull();
+      expect(longResult).not.toBeNull();
+
+      // Float comparison within tight tolerance (1e-9 — these are exact rationals).
+      for (const key of ['recency', 'engagement', 'bridging', 'sourceDiversity', 'relevance'] as const) {
+        expect(longResult![key]).toBeCloseTo(wideResult![key], 9);
+      }
+    });
+
+    it('excludes votes missing any component (long-path filter parity)', async () => {
+      // One vote has all 5 components, the other is missing 'relevance'. The
+      // wide path uses "AND xxx_weight IS NOT NULL" for each column; the long
+      // path's equivalent is "vote has rows for every registered key".
+      configMock.GOVERNANCE_LONGTABLE_READ_ENABLED = true;
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ count: 0 }] });
+      dbQueryMock.mockResolvedValueOnce({
+        rows: [
+          // complete vote
+          { vote_id: 'complete', component_key: 'recency', weight: 0.2 },
+          { vote_id: 'complete', component_key: 'engagement', weight: 0.2 },
+          { vote_id: 'complete', component_key: 'bridging', weight: 0.2 },
+          { vote_id: 'complete', component_key: 'sourceDiversity', weight: 0.2 },
+          { vote_id: 'complete', component_key: 'relevance', weight: 0.2 },
+          // partial vote (missing relevance) — should be excluded
+          { vote_id: 'partial', component_key: 'recency', weight: 0.5 },
+          { vote_id: 'partial', component_key: 'engagement', weight: 0.2 },
+          { vote_id: 'partial', component_key: 'bridging', weight: 0.1 },
+          { vote_id: 'partial', component_key: 'sourceDiversity', weight: 0.2 },
+        ],
+      });
+
+      const result = await aggregateVotes(1);
+      expect(result).not.toBeNull();
+
+      // If the partial vote had been included, recency would be > 0.2 (it
+      // contributed 0.5). Excluded → all-equal complete vote → uniform 0.2.
+      expect(result!.recency).toBeCloseTo(0.2, 6);
+    });
+  });
+});

--- a/tests/governance-longtable-dualwrite.test.ts
+++ b/tests/governance-longtable-dualwrite.test.ts
@@ -194,6 +194,70 @@ describe('governance long-table dual-write (PROJ-815)', () => {
         })
       ).rejects.toThrow('db connection lost');
     });
+
+    it('accepts boundary weights at exactly 0 and 1 (CHECK boundary parity)', async () => {
+      // The long table's CHECK (weight >= 0 AND weight <= 1) is inclusive on
+      // both ends. The writer must not silently filter out exact 0 or 1 — those
+      // are legal values and a future "civility" component could plausibly emit
+      // a 0 weight if it has no opinion.
+      await writeVoteWeights('vote-uuid-boundary', {
+        recency: 0,
+        engagement: 1,
+        bridging: 0.0,
+        sourceDiversity: 1.0,
+        relevance: 0.5,
+      });
+
+      const call = findCall('INSERT INTO governance_vote_weights');
+      expect(call).toBeDefined();
+      const params = call![1] as unknown[];
+      expect(params.length).toBe(5 * 3);
+
+      // Spot-check the actual values appear in the parameter list, not silently dropped.
+      const weights = params.filter((_, i) => i % 3 === 2);
+      expect(weights).toEqual(expect.arrayContaining([0, 1, 0.0, 1.0, 0.5]));
+    });
+
+    it('does not leak parameters between concurrent writeVoteWeights calls', async () => {
+      // Concurrent writers must each see their own vote_id and weight set in
+      // the INSERT — the helper builds parameter arrays per-call and should
+      // not share state. Run two writes in parallel and verify each call's
+      // parameter list carries only its own vote_id.
+      dbQueryMock.mockReset();
+      dbQueryMock.mockResolvedValue({ rows: [] });
+
+      await Promise.all([
+        writeVoteWeights('vote-concurrent-A', {
+          recency: 0.5,
+          engagement: 0.5,
+          bridging: 0,
+          sourceDiversity: 0,
+          relevance: 0,
+        }),
+        writeVoteWeights('vote-concurrent-B', {
+          recency: 0,
+          engagement: 0,
+          bridging: 0.3,
+          sourceDiversity: 0.3,
+          relevance: 0.4,
+        }),
+      ]);
+
+      const longCalls = dbQueryMock.mock.calls.filter((c: unknown[]) =>
+        String(c[0]).includes('INSERT INTO governance_vote_weights')
+      );
+      expect(longCalls.length).toBe(2);
+
+      // Each call's vote_id parameters (positions 0, 3, 6, …) should be only one of the two ids.
+      for (const [, params] of longCalls) {
+        const voteIds = (params as unknown[]).filter((_, i) => i % 3 === 0);
+        const unique = new Set(voteIds);
+        expect(unique.size).toBe(1);
+        expect(['vote-concurrent-A', 'vote-concurrent-B']).toContain(
+          [...unique][0]
+        );
+      }
+    });
   });
 
   describe('writeEpochWeights error propagation', () => {


### PR DESCRIPTION
**Linear:** [PROJ-815](https://linear.app/andrewnord/issue/PROJ-815)
**Packet:** P2 of 7 in the recsys extensibility refactor sequence. Ships in parallel with [PROJ-814 / PR #222](https://github.com/andrewnordstrom-eng/bluesky-community-feed/pull/222).

## What this packet ships

Migration 022 introduces two normalized side tables that mirror the 5 wide weight columns on `governance_epochs` and `governance_votes`:

- `governance_epoch_weights (epoch_id, component_key, weight)` — PK on `(epoch_id, component_key)`, FK with `ON DELETE CASCADE`, `CHECK weight ∈ [0,1]`.
- `governance_vote_weights (vote_id, component_key, weight)` — same shape, parameterized by `vote_id UUID`.

Both writers dual-write the wide row plus N long-table rows when `GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED` is on (default `true`). The aggregation reader gains a flag-gated long-table branch (default `false`; flipped in P4).

## Diff

- `src/db/migrations/022_governance_weights_longtable.sql` — two tables + two component-anchored indexes
- `src/config.ts` — `GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED` (default `true`), `GOVERNANCE_LONGTABLE_READ_ENABLED` (default `false`)
- `src/governance/weight-longtable.ts` — `writeEpochWeights` (transactional via `PoolClient`) and `writeVoteWeights` (autocommit via `db.query`) helpers, batched VALUES INSERT with `ON CONFLICT … DO UPDATE`
- `src/governance/epoch-manager.ts` — dual-write after BOTH `INSERT INTO governance_epochs` call sites (normal-transition + forced-transition), inside the existing client transaction so wide+long are atomic per epoch
- `src/governance/routes/vote.ts` — dual-write after the wide-row UPSERT; failures are logged but don't crash the request (eventual-consistency contract; backfill converges)
- `src/governance/aggregation.ts` — `fetchWeightVotesFromLongTable` helper that pivots long rows into the same per-vote wide shape the trim/mean loop expects; long path correctly excludes votes missing any registered component (mirrors the `IS NOT NULL` filter parity)
- `scripts/backfill-governance-weights.ts` — keyset-paginated, idempotent batch projection with `--table {epochs|votes|both}`, `--batch-size`, `--limit`, `--dry-run`, `parsePositiveInt` validation
- `tests/governance-longtable-dualwrite.test.ts` — 10 tests covering writers, reader flag, parity, and the 6th-key fixture
- `.gitignore` — `/.githooks/` added (local agent overlay, same as PR #222)

## The 6th-key fixture (proof of extensibility)

The packet body called for a test that proves the long-table contract is genuinely component-agnostic. Test 3 (`writeEpochWeights accepts a 6th hypothetical key without DDL changes`) submits a `civility` weight alongside the existing 5; the helper writes 6 rows, the SQL stays unchanged, no migration needed. This is the load-bearing claim of the whole refactor — that adding a component is a one-file change once P5 lands.

## Design notes

- **Epoch dual-write is transactional** (uses the existing `client` from the surrounding BEGIN/COMMIT). The wide INSERT and the long-table batched INSERT either both commit or both roll back per epoch.
- **Vote dual-write is NOT transactional.** Matches the PROJ-814 design: wide row is authoritative through P4, long-table failure is logged but does not crash the request, backfill converges. A failure here is observed in `logger.warn` and surfaces in the existing structured-log stream.
- **`COALESCE` semantics preserved.** The wide-row vote UPSERT uses `COALESCE` to skip null/undefined fields on partial updates. `writeVoteWeights` mirrors this by filtering non-finite values before insertion — partial updates leave prior long-table rows untouched.
- **No trigger function in this packet.** The existing `weights_sum_check` and `vote_weights_sum_to_one` CHECK constraints on the wide columns remain the live invariant. PROJ-819 (P5) replaces them with a `DEFERRABLE INITIALLY DEFERRED` trigger that sums the long-table rows.

## Verification

| Step | Result |
|---|---|
| `tsc --noEmit` | ✅ clean |
| `npm test -- --run` | ✅ **479/479** (469 baseline + 10 new P2 tests) |
| Migration 022 follows existing forward-only SQL convention | ✅ |
| Aggregation read-path parity test (same 3-vote dataset, both paths, ≤ 1e-9 delta) | ✅ |

| Inherited from PR #222 (filed as chips) |
|---|
| `backend-verify` ⚠️ — same `npm audit` transitive-vuln failures (hono, protobufjs, ip-address, qs, ws) |
| `frontend-verify` ⚠️ — same `web/package.json axios=1.16.0` vs pin-check requiring `1.15.2` |

Neither inherited failure is in this PR's diff. Same disposition as PR #222.

## Backfill plan after merge

```bash
# After deploy in a maintenance window:
npx tsx scripts/backfill-governance-weights.ts --batch-size 200

# Row-count parity check:
psql "$DATABASE_URL" -c "SELECT COUNT(*) FROM governance_epochs;"
psql "$DATABASE_URL" -c "SELECT COUNT(*) FROM governance_epoch_weights;"
# Expected: count(long) == 5 * count(epochs), modulo any epochs created before dual-write was live
```

## Out of scope

- Type refactor `GovernanceWeights → Record<>` (PROJ-816 / P3) — blocked-by this packet
- Reader cutover for all consumers (PROJ-817 / P4) — read flag stays off here
- Drop wide columns + replace CHECK with sum-validation triggers (PROJ-819 / P5)

The append-only `governance_audit_log` is **untouched** by every migration in this packet — Constitution C6 / CLAUDE.md gotcha #7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added normalized data structure for governance weights with gradual rollout via feature flags, supporting dual-write to legacy format during transition.
  * Introduced configurable read paths for weight aggregation with automatic filtering of incomplete data.

* **Chores**
  * Added backfill tooling to migrate historical governance weight data to normalized format.
  * Added comprehensive test coverage for dual-write and read functionality with parity validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrewnordstrom-eng/bluesky-community-feed/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->