### PR TITLE
[PROJ-824] Advance frontend-verify axios pin literal to 1.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
 
             const packageJson = JSON.parse(fs.readFileSync("web/package.json", "utf8"));
             const axiosVersion = packageJson.dependencies?.axios;
-            if (axiosVersion !== "1.15.2") {
-              throw new Error(`web/package.json must pin axios to exact 1.15.2; found ${axiosVersion ?? "missing"}`);
+            if (axiosVersion !== "1.16.0") {
+              throw new Error(`web/package.json must pin axios to exact 1.16.0; found ${axiosVersion ?? "missing"}`);
             }
           '
 


### PR DESCRIPTION
## Summary

- Restore the PROJ-311 contract by advancing the literal in `.github/workflows/ci.yml` "Validate frontend Axios pin" step from `"1.15.2"` to `"1.16.0"` — matching what Dependabot PR #198 already landed in `web/package.json`.
- One-line change. One file. Same exact-pin contract, just at the newer version.
- Resolves [PROJ-824](https://linear.app/andrewnord/issue/PROJ-824). Pairs with [#228](https://github.com/andrewnordstrom-eng/bluesky-community-feed/pull/228) ([PROJ-823](https://linear.app/andrewnord/issue/PROJ-823)) — both must land to unblock `npm run verify` on PRs #222–#226.

## Why Option 2 (advance pin) over Option 1 (revert to 1.15.2)

- axios 1.16.0 is already on `main` (PR #198, afa31c5). Reverting would be backward motion.
- All axios CVEs prior to 1.15.1 are patched in both 1.15.2 and 1.16.0 (GitHub Security Advisory Database — see research records on the Linear issue). No security delta.
- Option 2 is one literal change in one file. Option 1 would require revert + regen lockfile + Dependabot ignore config.

## Test plan

- [x] `node --input-type=module -e '...'` simulation of the workflow check passes locally with `axios: "1.16.0"`
- [x] `python3 -c "import yaml; yaml.safe_load(open('ci.yml'))"` — YAML still valid
- [x] Diff is exactly two lines (the literal in the check, and the literal in the error string)
- [ ] CI: `frontend-verify` turns green on this PR (was red on `main` baseline)

## Inherited blocker NOT addressed here

`cd web && npm run lint` produces 16 `react-hooks/set-state-in-effect` errors on `main` after `eslint-plugin-react-hooks` bumped to `^7.1.1`. Separate packet chipped. Once that lands plus this + #228, all 5 in-flight Bluesky Corgi PRs become mergeable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow dependency validation to require a specific version of a frontend dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrewnordstrom-eng/bluesky-community-feed/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->