### PR TITLE
[PROJ-1215] bluesky stale-triage scheduled workflow starts and completes green

### DIFF
--- a/.github/workflows/stale-triage.yml
+++ b/.github/workflows/stale-triage.yml
@@ -6,9 +6,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   stale-triage:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: andrewnordstrom-eng/.github-public/.github/workflows/stale-triage.yml@3eb398cf25fba2dd97a05508678fe48b0b4e0532


### PR DESCRIPTION
Closes PROJ-1215

## What
The weekly stale-triage workflow has hit `startup_failure` 3 consecutive Mondays (runs 26409049990, 26768872045, 27151533829) + a workflow_dispatch reproduction today (27237554872) — dying before any job starts, silently.

## Root cause
Not the Actions allowlist (both the reusable-workflow pin and its inner `actions/stale` pin are allowlisted; verified). The caller's `permissions:` block grants only `{issues, pull-requests}`, while the called reusable workflow declares workflow-level `permissions: contents: read` — a grant the caller never passes. Reusable-workflow permission validation happens at startup, producing `startup_failure` with no logs. The working project-template caller grants `contents: read` and runs green weekly.

## Fix
Mirror the proven caller shape: top-level `contents: read`, job-level `{contents: read, issues: write, pull-requests: write}`. Pin unchanged (`@3eb398cf`, allowlisted, blob-identical to .github-public head — verified by blob SHA `4238e37c`).

## Validation
Post-merge: `gh workflow run stale-triage.yml` must complete with conclusion `success`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined GitHub Actions workflow permissions configuration to follow principle of least privilege, restricting top-level permissions while granting specific permissions only where needed for job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->