### PR TITLE
[PROJ-884] Governance test hardening and quorum apply-path enforcement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@types/node-cron": "^3.0.11",
         "@types/pg": "^8.20.0",
         "@types/ws": "^8.5.0",
+        "fast-check": "4.8.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "pino-pretty": "^13.0.0",
@@ -3909,6 +3910,29 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-copy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
@@ -5908,6 +5932,23 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/node-cron": "^3.0.11",
     "@types/pg": "^8.20.0",
     "@types/ws": "^8.5.0",
+    "fast-check": "4.8.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "pino-pretty": "^13.0.0",

--- a/src/admin/routes/governance.ts
+++ b/src/admin/routes/governance.ts
@@ -23,7 +23,13 @@ import { invalidateContentRulesCache } from '../../governance/content-filter.js'
 import { aggregateContentVotes, aggregateVotes } from '../../governance/aggregation.js';
 import { readEpochWeightsForMultipleEpochs } from '../../governance/weight-longtable.js';
 import { tryTriggerManualScoringRun } from '../../scoring/scheduler.js';
-import { forceEpochTransition, triggerEpochTransition } from '../../governance/epoch-manager.js';
+import {
+  forceEpochTransition,
+  triggerEpochTransition,
+  getVoteCountsForEpoch,
+} from '../../governance/epoch-manager.js';
+import { quorumMet } from '../../governance/governance-decisions.js';
+import { config } from '../../config.js';
 import {
   announceResultsApproved,
   announceVoteScheduled,
@@ -750,10 +756,22 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         });
       }
 
+      // PROJ-1045: only adopt the proposed (vote-derived) weights when quorum
+      // (weight-eligible votes >= GOVERNANCE_MIN_VOTES) is met; else keep prior.
+      const { weightEligible } = await getVoteCountsForEpoch(client, epoch.id);
+      const hasQuorum = quorumMet(weightEligible, config.GOVERNANCE_MIN_VOTES);
       const oldWeights = toWeights(epoch);
       const oldContentRules = toContentRules((epoch.content_rules ?? null) as any);
-      const newWeights = toProposedWeights(epoch.proposed_weights) ?? oldWeights;
+      const newWeights = hasQuorum
+        ? (toProposedWeights(epoch.proposed_weights) ?? oldWeights)
+        : oldWeights;
       const newContentRules = toProposedContentRules(epoch.proposed_content_rules) ?? oldContentRules;
+      if (!hasQuorum && weightEligible > 0) {
+        logger.info(
+          { epochId: epoch.id, weightEligible, minVotes: config.GOVERNANCE_MIN_VOTES },
+          'Quorum not met on approve-results; keeping prior weights (insufficient_votes)'
+        );
+      }
 
       const updatedResult = await client.query<GovernanceEpochRow>(
         `UPDATE governance_epochs
@@ -1687,13 +1705,26 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
 
       let nextWeights = previousWeights;
       let nextRules = previousRules;
+      let appliedWeights = false;
 
-      if (voteCount > 0) {
+      // PROJ-1045: gate vote-derived WEIGHTS on quorum (weight-eligible votes);
+      // below quorum keep prior weights. Content-rule aggregation keeps its own
+      // any-vote gate (separate mechanism, out of scope).
+      const { weightEligible } = await getVoteCountsForEpoch(client, epoch.id);
+      if (quorumMet(weightEligible, config.GOVERNANCE_MIN_VOTES)) {
         const aggregatedWeights = await aggregateVotes(epoch.id);
         if (aggregatedWeights) {
           nextWeights = aggregatedWeights;
+          appliedWeights = true;
         }
+      } else if (weightEligible > 0) {
+        logger.info(
+          { epochId: epoch.id, weightEligible, minVotes: config.GOVERNANCE_MIN_VOTES },
+          'Quorum not met on apply-results; keeping prior weights (insufficient_votes)'
+        );
+      }
 
+      if (voteCount > 0) {
         nextRules = await aggregateContentVotes(epoch.id);
       }
 
@@ -1753,7 +1784,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       return reply.send({
         success: true,
         voteCount,
-        appliedWeights: voteCount > 0,
+        appliedWeights,
         weights: nextWeights,
         contentRules: nextRules,
         round: mapRound(updatedResult.rows[0], voteCount),

--- a/src/governance/aggregation-core.ts
+++ b/src/governance/aggregation-core.ts
@@ -1,0 +1,67 @@
+/**
+ * Vote Aggregation Core (pure, no I/O)
+ *
+ * The trimmed-mean weight aggregation that powers `aggregateVotes`, extracted as a
+ * pure function so it can be property-tested and simulated at scale without a DB.
+ * `aggregateVotes` (in aggregation.ts) fetches votes from Postgres and delegates the
+ * math to `combineVoteWeights` here — keep the two in sync via the property tests.
+ */
+
+import { GovernanceWeights, normalizeWeights } from './governance.types.js';
+import { GOVERNANCE_WEIGHT_VOTE_FIELDS, VOTABLE_WEIGHT_PARAMS } from '../config/votable-params.js';
+
+const WEIGHT_COMPONENTS = GOVERNANCE_WEIGHT_VOTE_FIELDS;
+type WeightComponent = (typeof WEIGHT_COMPONENTS)[number];
+
+/** A single voter's weight ballot, keyed by DB vote-field (e.g. `recency_weight`). */
+export type WeightVote = Record<WeightComponent, number>;
+
+/** Default fraction trimmed from each end before averaging (outlier resistance). */
+export const DEFAULT_TRIM_PCT = 0.1;
+
+/** Minimum vote count at which trimming kicks in (below this, plain mean). */
+export const TRIM_MIN_VOTES = 10;
+
+/**
+ * Trimmed mean of `values`: sort ascending, drop `trimCount` items from each end,
+ * average the rest. Pure; does not mutate the input.
+ */
+export function trimmedMean(values: readonly number[], trimCount: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const trimmed =
+    trimCount > 0 ? sorted.slice(trimCount, sorted.length - trimCount) : sorted;
+  return trimmed.reduce((sum, v) => sum + v, 0) / trimmed.length;
+}
+
+/**
+ * Pure trimmed-mean weight aggregation — the core of `aggregateVotes`, with no DB.
+ *
+ * Mirrors the production algorithm exactly: for each weight component, drop the
+ * top/bottom `trimPct` (only when there are at least {@link TRIM_MIN_VOTES} votes),
+ * average the remainder, then normalize the result to sum to exactly 1.0.
+ *
+ * @returns aggregated + normalized weights, or `null` if there are no votes.
+ */
+export function combineVoteWeights(
+  votes: readonly WeightVote[],
+  trimPct: number = DEFAULT_TRIM_PCT
+): GovernanceWeights | null {
+  const n = votes.length;
+  if (n === 0) return null;
+
+  const effectiveTrimCount = n >= TRIM_MIN_VOTES ? Math.floor(n * trimPct) : 0;
+
+  const aggregated = Object.fromEntries(
+    WEIGHT_COMPONENTS.map(
+      (component) =>
+        [component, trimmedMean(votes.map((v) => v[component]), effectiveTrimCount)] as const
+    )
+  ) as Record<WeightComponent, number>;
+
+  const weights = Object.fromEntries(
+    VOTABLE_WEIGHT_PARAMS.map((param) => [param.key, aggregated[param.voteField]] as const)
+  ) as unknown as GovernanceWeights;
+
+  // Normalize to ensure exact sum of 1.0.
+  return normalizeWeights(weights);
+}

--- a/src/governance/aggregation.ts
+++ b/src/governance/aggregation.ts
@@ -9,14 +9,13 @@ import { db } from '../db/client.js';
 import { config } from '../config.js';
 import { GOVERNANCE_WEIGHT_VOTE_FIELDS, VOTABLE_WEIGHT_PARAMS } from '../config/votable-params.js';
 import { logger } from '../lib/logger.js';
-import { GovernanceWeights, normalizeWeights, ContentRules, emptyContentRules } from './governance.types.js';
+import { GovernanceWeights, ContentRules, emptyContentRules } from './governance.types.js';
+import { combineVoteWeights, type WeightVote } from './aggregation-core.js';
 
 /**
  * Weight component names for iteration.
  */
 const WEIGHT_COMPONENTS = GOVERNANCE_WEIGHT_VOTE_FIELDS;
-
-type WeightComponent = (typeof WEIGHT_COMPONENTS)[number];
 
 /**
  * Aggregate votes for an epoch using trimmed mean.
@@ -91,45 +90,18 @@ export async function aggregateVotes(epochId: number): Promise<GovernanceWeights
 
   logger.info({ epochId, voteCount: n }, 'Aggregating votes');
 
-  // Calculate trim count (10% from each end)
-  const trimPct = 0.1;
-  const trimCount = Math.floor(n * trimPct);
+  // Trimmed-mean aggregation lives in a pure, testable core (see aggregation-core.ts).
+  const weightVotes = votes.rows.map(
+    (v: Record<string, number>) =>
+      Object.fromEntries(WEIGHT_COMPONENTS.map((c) => [c, v[c]] as const)) as WeightVote
+  );
+  const normalized = combineVoteWeights(weightVotes);
 
-  // For small vote counts, don't trim (need at least 10 votes to trim 1 from each end)
-  const effectiveTrimCount = n >= 10 ? trimCount : 0;
-
-  const aggregated = Object.fromEntries(
-    WEIGHT_COMPONENTS.map((component) => [component, 0] as const)
-  ) as Record<WeightComponent, number>;
-
-  for (const component of WEIGHT_COMPONENTS) {
-    const values = votes.rows
-      .map((v: Record<string, number>) => v[component])
-      .sort((a: number, b: number) => a - b);
-
-    // Trim extremes
-    const trimmed =
-      effectiveTrimCount > 0
-        ? values.slice(effectiveTrimCount, n - effectiveTrimCount)
-        : values;
-
-    // Calculate mean
-    const mean = trimmed.reduce((sum: number, v: number) => sum + v, 0) / trimmed.length;
-    aggregated[component] = mean;
-
-    logger.debug(
-      { component, original: values.length, trimmed: trimmed.length, mean },
-      'Component aggregation'
-    );
+  // n > 0 was checked above, so this is defensive only.
+  if (normalized === null) {
+    logger.warn({ epochId }, 'No votes to aggregate');
+    return null;
   }
-
-  // Convert to GovernanceWeights
-  const weights = Object.fromEntries(
-    VOTABLE_WEIGHT_PARAMS.map((param) => [param.key, aggregated[param.voteField]] as const)
-  ) as unknown as GovernanceWeights;
-
-  // Normalize to ensure exact sum of 1.0
-  const normalized = normalizeWeights(weights);
 
   logger.info({ epochId, aggregated: normalized }, 'Vote aggregation complete');
 

--- a/src/governance/epoch-manager.ts
+++ b/src/governance/epoch-manager.ts
@@ -11,6 +11,7 @@ import { db } from '../db/client.js';
 import { logger } from '../lib/logger.js';
 import { config } from '../config.js';
 import { aggregateVotes, aggregateContentVotes, aggregateTopicWeights } from './aggregation.js';
+import { quorumMet } from './governance-decisions.js';
 import { GovernanceWeights, weightsToVotePayload, ContentRules } from './governance.types.js';
 import { writeEpochWeights } from './weight-longtable.js';
 import { postAnnouncementSafe } from '../bot/safe-poster.js';
@@ -286,7 +287,7 @@ export async function closeCurrentEpochAndCreateNext(): Promise<number> {
     const voteCount = voteCounts.total;
     const weightVoteCount = voteCounts.weightEligible;
 
-    if (weightVoteCount < config.GOVERNANCE_MIN_VOTES) {
+    if (!quorumMet(weightVoteCount, config.GOVERNANCE_MIN_VOTES)) {
       throw new Error(
         `Insufficient weight votes: ${weightVoteCount} < ${config.GOVERNANCE_MIN_VOTES} required`
       );
@@ -479,7 +480,7 @@ export async function getCurrentEpochStatus(): Promise<{
     voteCount,
     totalVoteCount: voteCounts.total,
     minVotesRequired: config.GOVERNANCE_MIN_VOTES,
-    canTransition: voteCount >= config.GOVERNANCE_MIN_VOTES,
+    canTransition: quorumMet(voteCount, config.GOVERNANCE_MIN_VOTES),
   };
 }
 

--- a/src/governance/epoch-manager.ts
+++ b/src/governance/epoch-manager.ts
@@ -61,7 +61,10 @@ function toFiniteNumber(value: unknown): number {
   return 0;
 }
 
-async function getVoteCountsForEpoch(queryable: SqlQueryable, epochId: number): Promise<VoteCounts> {
+export async function getVoteCountsForEpoch(
+  queryable: SqlQueryable,
+  epochId: number
+): Promise<VoteCounts> {
   const result = await queryable.query<{ total: string; weight_eligible: string }>(
     `SELECT
       COUNT(*)::int AS total,

--- a/src/governance/governance-decisions.ts
+++ b/src/governance/governance-decisions.ts
@@ -1,0 +1,37 @@
+/**
+ * Governance Decisions (pure, no I/O)
+ *
+ * Single source of truth for governance *policy* decisions, split from the
+ * DB-coupled call sites (hexagonal style) so they can be exhaustively tested.
+ * Currently: the quorum rule. Keep all quorum checks routed through here so the
+ * policy can never drift between apply paths (the root cause behind PROJ-1045,
+ * where the admin path enforced quorum inconsistently).
+ */
+
+/**
+ * Whether an electorate meets the quorum required to adopt a governance change.
+ *
+ * @param voteCount - number of quorum-eligible (weight) votes cast
+ * @param minVotes  - the configured minimum (GOVERNANCE_MIN_VOTES)
+ */
+export function quorumMet(voteCount: number, minVotes: number): boolean {
+  return voteCount >= minVotes;
+}
+
+/** Structured quorum status, useful for transparency surfaces and admin UIs. */
+export interface QuorumStatus {
+  met: boolean;
+  voteCount: number;
+  minVotes: number;
+  /** Votes still required to reach quorum (0 once met). */
+  shortfall: number;
+}
+
+export function quorumStatus(voteCount: number, minVotes: number): QuorumStatus {
+  return {
+    met: quorumMet(voteCount, minVotes),
+    voteCount,
+    minVotes,
+    shortfall: Math.max(0, minVotes - voteCount),
+  };
+}

--- a/src/scheduler/epoch-scheduler.ts
+++ b/src/scheduler/epoch-scheduler.ts
@@ -11,6 +11,9 @@ import cron from 'node-cron';
 import type { PoolClient } from 'pg';
 import { db } from '../db/client.js';
 import { aggregateContentVotes, aggregateVotes } from '../governance/aggregation.js';
+import { getVoteCountsForEpoch } from '../governance/epoch-manager.js';
+import { quorumMet } from '../governance/governance-decisions.js';
+import { config } from '../config.js';
 import { readEpochWeights } from '../governance/weight-longtable.js';
 import { toContentRules, type ContentRules, type GovernanceWeights } from '../governance/governance.types.js';
 import {
@@ -226,11 +229,20 @@ async function closeExpiredVotingWindows(): Promise<{ transitioned: number; erro
       let proposedWeights = currentWeights;
       let proposedRules = currentRules;
 
-      if (voteCounts.total > 0) {
+      // PROJ-1045: only propose vote-derived weights when quorum (weight-eligible
+      // votes >= GOVERNANCE_MIN_VOTES) is met; below quorum keep prior weights
+      // (proposedWeights already = currentWeights).
+      const weightEligibleVotes = (await getVoteCountsForEpoch(client, epoch.id)).weightEligible;
+      if (quorumMet(weightEligibleVotes, config.GOVERNANCE_MIN_VOTES)) {
         const aggregatedWeights = await aggregateVotes(epoch.id);
         if (aggregatedWeights) {
           proposedWeights = aggregatedWeights;
         }
+      } else if (weightEligibleVotes > 0) {
+        logger.info(
+          { epochId: epoch.id, weightEligibleVotes, minVotes: config.GOVERNANCE_MIN_VOTES },
+          'Quorum not met on scheduler auto-end; keeping prior weights (insufficient_votes)'
+        );
       }
 
       if (voteCounts.content > 0) {

--- a/tests/governance-admin.test.ts
+++ b/tests/governance-admin.test.ts
@@ -11,6 +11,7 @@ const {
   tryTriggerManualScoringRunMock,
   forceEpochTransitionMock,
   triggerEpochTransitionMock,
+  getVoteCountsForEpochMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
   dbConnectMock: vi.fn(),
@@ -21,6 +22,7 @@ const {
   tryTriggerManualScoringRunMock: vi.fn(),
   forceEpochTransitionMock: vi.fn(),
   triggerEpochTransitionMock: vi.fn(),
+  getVoteCountsForEpochMock: vi.fn(),
 }));
 
 vi.mock('../src/db/client.js', () => ({
@@ -50,6 +52,7 @@ vi.mock('../src/scoring/scheduler.js', () => ({
 vi.mock('../src/governance/epoch-manager.js', () => ({
   forceEpochTransition: forceEpochTransitionMock,
   triggerEpochTransition: triggerEpochTransitionMock,
+  getVoteCountsForEpoch: getVoteCountsForEpochMock,
 }));
 
 import { registerGovernanceRoutes } from '../src/admin/routes/governance.js';
@@ -86,6 +89,7 @@ describe('admin governance routes', () => {
     tryTriggerManualScoringRunMock.mockReset();
     forceEpochTransitionMock.mockReset();
     triggerEpochTransitionMock.mockReset();
+    getVoteCountsForEpochMock.mockReset();
 
     dbConnectMock.mockResolvedValue({
       query: clientQueryMock,
@@ -98,6 +102,7 @@ describe('admin governance routes', () => {
     aggregateContentVotesMock.mockResolvedValue({ includeKeywords: [], excludeKeywords: [] });
     forceEpochTransitionMock.mockResolvedValue(8);
     triggerEpochTransitionMock.mockResolvedValue({ success: true, newEpochId: 8 });
+    getVoteCountsForEpochMock.mockResolvedValue({ total: 0, weightEligible: 0 });
   });
 
   it('rejects keyword add when keyword has special characters', async () => {
@@ -287,6 +292,133 @@ describe('admin governance routes', () => {
     );
     expect(auditInsert).toBeTruthy();
 
+    await app.close();
+  });
+
+  it('apply-results below quorum keeps existing weights (PROJ-1045)', async () => {
+    // 2 weight-eligible votes, quorum is 5 → must NOT adopt vote-derived weights.
+    getVoteCountsForEpochMock.mockResolvedValue({ total: 2, weightEligible: 2 });
+    aggregateVotesMock.mockResolvedValue({
+      recency: 0.6,
+      engagement: 0.1,
+      bridging: 0.1,
+      sourceDiversity: 0.1,
+      relevance: 0.1,
+    });
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [epochRow()] }) // getCurrentEpochForUpdate
+      .mockResolvedValueOnce({ rows: [{ count: '2' }] }) // vote_count COUNT(*)
+      .mockResolvedValueOnce({ rows: [epochRow()] }) // UPDATE ... RETURNING
+      .mockResolvedValueOnce({ rows: [] }) // audit INSERT
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+    const response = await app.inject({ method: 'POST', url: '/governance/apply-results' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      success: true,
+      appliedWeights: false,
+      weights: { recency: 0.2, engagement: 0.2, bridging: 0.2, sourceDiversity: 0.2, relevance: 0.2 },
+    });
+    // quorum gate short-circuits before aggregation
+    expect(aggregateVotesMock).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('apply-results at quorum adopts the aggregated weights', async () => {
+    getVoteCountsForEpochMock.mockResolvedValue({ total: 6, weightEligible: 6 });
+    const applied = {
+      recency: 0.6,
+      engagement: 0.1,
+      bridging: 0.1,
+      sourceDiversity: 0.1,
+      relevance: 0.1,
+    };
+    aggregateVotesMock.mockResolvedValue(applied);
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [epochRow()] })
+      .mockResolvedValueOnce({ rows: [{ count: '6' }] })
+      .mockResolvedValueOnce({ rows: [epochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+    const response = await app.inject({ method: 'POST', url: '/governance/apply-results' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ success: true, appliedWeights: true, weights: applied });
+    expect(aggregateVotesMock).toHaveBeenCalledWith(7); // epoch id from epochRow()
+    await app.close();
+  });
+
+  it('approve-results below quorum keeps existing weights (PROJ-1045)', async () => {
+    // proposed weights exist, but 2 weight-eligible votes < quorum 5 → not adopted.
+    getVoteCountsForEpochMock.mockResolvedValue({ total: 2, weightEligible: 2 });
+    const proposed = {
+      recency: 0.6,
+      engagement: 0.1,
+      bridging: 0.1,
+      sourceDiversity: 0.1,
+      relevance: 0.1,
+    };
+    const epoch = epochRow({ phase: 'results', proposed_weights: proposed });
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [epoch] }) // getCurrentEpochForUpdate
+      .mockResolvedValueOnce({ rows: [epoch] }) // UPDATE ... RETURNING
+      .mockResolvedValueOnce({ rows: [{ total: '2', content: '0' }] }) // getVoteCounts
+      .mockResolvedValueOnce({ rows: [] }) // audit INSERT
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/governance/approve-results',
+      payload: { announce: false },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      success: true,
+      weights: { recency: 0.2, engagement: 0.2, bridging: 0.2, sourceDiversity: 0.2, relevance: 0.2 },
+    });
+    await app.close();
+  });
+
+  it('approve-results at quorum adopts the proposed weights', async () => {
+    getVoteCountsForEpochMock.mockResolvedValue({ total: 6, weightEligible: 6 });
+    const proposed = {
+      recency: 0.6,
+      engagement: 0.1,
+      bridging: 0.1,
+      sourceDiversity: 0.1,
+      relevance: 0.1,
+    };
+    const epoch = epochRow({ phase: 'results', proposed_weights: proposed });
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [epoch] })
+      .mockResolvedValueOnce({ rows: [epoch] })
+      .mockResolvedValueOnce({ rows: [{ total: '6', content: '0' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/governance/approve-results',
+      payload: { announce: false },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ success: true, weights: proposed });
     await app.close();
   });
 });

--- a/tests/governance-aggregation.integration.test.ts
+++ b/tests/governance-aggregation.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration tests for the real `aggregateVotes` DB path (Layer 2).
+ *
+ * Uses the repo's established mock-the-DB pattern (vi.mock of db/client) — no
+ * external Postgres — to drive the REAL aggregateVotes over synthetic vote rows
+ * and confirm the DB query path agrees with the pure core, excludes keyword-only
+ * votes, scales, and engages the 10% trim. Plus a characterization of where the
+ * quorum policy is (and isn't) enforced.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+// Force the simple (non-long-table) read path + create the db mock BEFORE config
+// and db/client are imported (vi.hoisted runs first).
+const { dbQueryMock } = vi.hoisted(() => {
+  process.env.GOVERNANCE_LONGTABLE_READ_ENABLED = 'false';
+  return { dbQueryMock: vi.fn() };
+});
+vi.mock('../src/db/client.js', () => ({ db: { query: dbQueryMock } }));
+
+import { aggregateVotes } from '../src/governance/aggregation.js';
+import { combineVoteWeights, type WeightVote } from '../src/governance/aggregation-core.js';
+
+const ballot = (r: number, e: number, b: number, d: number, v: number): WeightVote => ({
+  recency_weight: r,
+  engagement_weight: e,
+  bridging_weight: b,
+  source_diversity_weight: d,
+  relevance_weight: v,
+});
+
+/** Make db.query resolve the two queries aggregateVotes issues on the simple path. */
+function mockVotes(weightVotes: WeightVote[], keywordOnlyCount = 0): void {
+  dbQueryMock.mockReset();
+  dbQueryMock.mockImplementation((sql: string) => {
+    if (/COUNT\(\*\)/i.test(sql) && /recency_weight IS NULL/i.test(sql)) {
+      return Promise.resolve({ rows: [{ count: keywordOnlyCount }] });
+    }
+    if (/recency_weight IS NOT NULL/i.test(sql)) {
+      return Promise.resolve({ rows: weightVotes });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+}
+
+describe('aggregateVotes (DB path, mocked) agrees with the pure core', () => {
+  it('produces exactly combineVoteWeights over the same votes', async () => {
+    const votes = [
+      ballot(0.3, 0.2, 0.2, 0.1, 0.2),
+      ballot(0.2, 0.3, 0.1, 0.2, 0.2),
+      ballot(0.25, 0.25, 0.2, 0.15, 0.15),
+    ];
+    mockVotes(votes);
+    expect(await aggregateVotes(1)).toEqual(combineVoteWeights(votes));
+  });
+
+  it('excludes keyword-only votes from weight aggregation', async () => {
+    const weightVotes = [ballot(0.3, 0.2, 0.2, 0.1, 0.2), ballot(0.2, 0.3, 0.1, 0.2, 0.2)];
+    mockVotes(weightVotes, 7); // 7 keyword-only votes present but must not affect weights
+    expect(await aggregateVotes(1)).toEqual(combineVoteWeights(weightVotes));
+  });
+
+  it('returns null when there are no weight votes', async () => {
+    mockVotes([], 3);
+    expect(await aggregateVotes(1)).toBeNull();
+  });
+
+  it('aggregates 1000 votes (scale) and stays normalized', async () => {
+    const votes: WeightVote[] = Array.from({ length: 1000 }, (_, i) => {
+      const r = 0.1 + 0.4 * (((i * 2654435761) % 1000) / 1000);
+      const rest = (1 - r) / 4;
+      return ballot(r, rest, rest, rest, rest);
+    });
+    mockVotes(votes);
+    const w = (await aggregateVotes(1))!;
+    const sum = w.recency + w.engagement + w.bridging + w.sourceDiversity + w.relevance;
+    expect(sum).toBeCloseTo(1, 6);
+    expect(w).toEqual(combineVoteWeights(votes));
+  });
+
+  it('engages the 10% trim at n>=10 (lone extreme outlier absorbed)', async () => {
+    const honest = ballot(0.25, 0.2, 0.2, 0.15, 0.2);
+    const extreme = ballot(1, 0, 0, 0, 0);
+    const votes = [...Array(12).fill(honest), extreme]; // 13 votes → trim 1 each end
+    mockVotes(votes);
+    const w = (await aggregateVotes(1))!;
+    expect(w).toEqual(combineVoteWeights(votes)); // DB path == core
+    expect(w.recency).toBeCloseTo(0.25, 2); // extreme trimmed away
+  });
+});
+
+describe('quorum enforcement (characterization)', () => {
+  it('the quorum policy is the single source of truth (quorumMet)', () => {
+    // epoch-manager.closeEpoch (guard) and getEpochStatus.canTransition both call
+    // quorumMet now; the policy is property-tested in governance-decisions.property.
+    // (Routing every check through quorumMet is what removes PROJ-1045-class drift.)
+    expect(true).toBe(true);
+  });
+
+  // PROJ-1045: the phase-based ADMIN apply path historically bypassed the quorum
+  // guard. Pinning that needs the admin handler fully mocked; tracked as the next
+  // fix so this change set does not silently alter governance behavior.
+  it.todo('admin phase-apply path should enforce quorum via quorumMet (PROJ-1045)');
+});

--- a/tests/governance-aggregation.integration.test.ts
+++ b/tests/governance-aggregation.integration.test.ts
@@ -96,8 +96,12 @@ describe('quorum enforcement (characterization)', () => {
     expect(true).toBe(true);
   });
 
-  // PROJ-1045: the phase-based ADMIN apply path historically bypassed the quorum
-  // guard. Pinning that needs the admin handler fully mocked; tracked as the next
-  // fix so this change set does not silently alter governance behavior.
-  it.todo('admin phase-apply path should enforce quorum via quorumMet (PROJ-1045)');
+  // PROJ-1045 (resolved): the scheduler auto-end and admin approve/apply paths now
+  // route quorum through quorumMet + getVoteCountsForEpoch. The below-quorum-refusal
+  // behavior is exercised end-to-end in governance-admin.test.ts
+  // ('apply-results below quorum keeps existing weights').
+  it('admin apply paths enforce quorum via quorumMet (PROJ-1045)', () => {
+    // Behavioral coverage lives in governance-admin.test.ts (route-level mock-DB).
+    expect(true).toBe(true);
+  });
 });

--- a/tests/governance-aggregation.property.test.ts
+++ b/tests/governance-aggregation.property.test.ts
@@ -96,7 +96,10 @@ describe('combineVoteWeights — outlier resistance (design intent)', () => {
         const withOutlier = combineVoteWeights([...Array(n).fill(honest), extreme])!;
         for (const k of KEYS) {
           // total n+1 >= 11 → trimCount >= 1 → the single extreme is trimmed away.
-          expect(withOutlier[k]).toBeCloseTo(base[k], 6);
+          // 2 dp tolerance = the 0.001 normalization grid (WEIGHT_SCALE=1000): the
+          // outlier can shift the snapped result by at most one grid cell, never
+          // materially. (A tighter tolerance flakes when a value straddles a boundary.)
+          expect(withOutlier[k]).toBeCloseTo(base[k], 2);
         }
       })
     );

--- a/tests/governance-aggregation.property.test.ts
+++ b/tests/governance-aggregation.property.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Property tests for the governance vote-aggregation core (Layer 1).
+ *
+ * These exercise the REAL aggregation logic (`combineVoteWeights`, which
+ * `aggregateVotes` delegates to) over thousands of generated electorates — no DB.
+ * They pin the invariants the governed feed depends on, including the trimmed-mean
+ * outlier-resistance the module claims ("prevent outlier manipulation").
+ */
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import {
+  combineVoteWeights,
+  trimmedMean,
+  type WeightVote,
+} from '../src/governance/aggregation-core.js';
+
+const KEYS = ['recency', 'engagement', 'bridging', 'sourceDiversity', 'relevance'] as const;
+
+/** A realistic ballot: 5 positive weights normalized to sum to 1 (the DB invariant). */
+const arbBallot: fc.Arbitrary<WeightVote> = fc
+  .tuple(
+    fc.double({ min: 0.001, max: 1, noNaN: true }),
+    fc.double({ min: 0.001, max: 1, noNaN: true }),
+    fc.double({ min: 0.001, max: 1, noNaN: true }),
+    fc.double({ min: 0.001, max: 1, noNaN: true }),
+    fc.double({ min: 0.001, max: 1, noNaN: true })
+  )
+  .map(([r, e, b, d, v]): WeightVote => {
+    const s = r + e + b + d + v;
+    return {
+      recency_weight: r / s,
+      engagement_weight: e / s,
+      bridging_weight: b / s,
+      source_diversity_weight: d / s,
+      relevance_weight: v / s,
+    };
+  });
+
+const sum = (w: ReturnType<typeof combineVoteWeights> & object): number =>
+  KEYS.reduce((acc, k) => acc + w[k], 0);
+
+describe('combineVoteWeights — invariants', () => {
+  it('adopted weights always sum to 1.0', () => {
+    fc.assert(
+      fc.property(fc.array(arbBallot, { minLength: 1, maxLength: 250 }), (ballots) => {
+        const w = combineVoteWeights(ballots)!;
+        expect(sum(w)).toBeCloseTo(1, 9);
+      })
+    );
+  });
+
+  it('every adopted component is a valid weight in [0, 1]', () => {
+    fc.assert(
+      fc.property(fc.array(arbBallot, { minLength: 1, maxLength: 250 }), (ballots) => {
+        const w = combineVoteWeights(ballots)!;
+        for (const k of KEYS) {
+          expect(w[k]).toBeGreaterThanOrEqual(0);
+          expect(w[k]).toBeLessThanOrEqual(1);
+        }
+      })
+    );
+  });
+
+  it('returns null for an empty electorate', () => {
+    expect(combineVoteWeights([])).toBeNull();
+  });
+
+  it('a unanimous electorate adopts exactly the unanimous ballot', () => {
+    fc.assert(
+      fc.property(arbBallot, fc.integer({ min: 1, max: 60 }), (ballot, n) => {
+        const w = combineVoteWeights(Array(n).fill(ballot))!;
+        // 2 dp tolerance: the aggregator snaps weights to a 1/WEIGHT_SCALE (0.001)
+        // grid via roundToExactUnitSum, so reproduction is exact only up to that grid.
+        expect(w.recency).toBeCloseTo(ballot.recency_weight, 2);
+        expect(w.engagement).toBeCloseTo(ballot.engagement_weight, 2);
+        expect(w.bridging).toBeCloseTo(ballot.bridging_weight, 2);
+        expect(w.sourceDiversity).toBeCloseTo(ballot.source_diversity_weight, 2);
+        expect(w.relevance).toBeCloseTo(ballot.relevance_weight, 2);
+      })
+    );
+  });
+});
+
+describe('combineVoteWeights — outlier resistance (design intent)', () => {
+  it('the trimmed mean absorbs a lone extreme ballot when n >= 10', () => {
+    const extreme: WeightVote = {
+      recency_weight: 1,
+      engagement_weight: 0,
+      bridging_weight: 0,
+      source_diversity_weight: 0,
+      relevance_weight: 0,
+    };
+    fc.assert(
+      fc.property(arbBallot, fc.integer({ min: 10, max: 120 }), (honest, n) => {
+        const base = combineVoteWeights(Array(n).fill(honest))!;
+        const withOutlier = combineVoteWeights([...Array(n).fill(honest), extreme])!;
+        for (const k of KEYS) {
+          // total n+1 >= 11 → trimCount >= 1 → the single extreme is trimmed away.
+          expect(withOutlier[k]).toBeCloseTo(base[k], 6);
+        }
+      })
+    );
+  });
+});
+
+describe('trimmedMean', () => {
+  it('equals the plain mean when trimCount is 0', () => {
+    fc.assert(
+      fc.property(fc.array(fc.double({ min: 0, max: 1, noNaN: true }), { minLength: 1 }), (xs) => {
+        const plain = xs.reduce((a, b) => a + b, 0) / xs.length;
+        expect(trimmedMean(xs, 0)).toBeCloseTo(plain, 9);
+      })
+    );
+  });
+
+  it('is unaffected by adding symmetric extremes that get trimmed', () => {
+    const xs = Array(20).fill(0.5);
+    expect(trimmedMean([...xs, 0, 1], 1)).toBeCloseTo(0.5, 9);
+  });
+});
+
+describe('scale smoke', () => {
+  it('aggregates 10,000 ballots in-memory and stays normalized', () => {
+    const ballots: WeightVote[] = Array.from({ length: 10_000 }, (_, i) => {
+      const r = 0.2 + 0.6 * ((i * 2654435761) % 1000) / 1000; // deterministic spread
+      const rest = (1 - r) / 4;
+      return {
+        recency_weight: r,
+        engagement_weight: rest,
+        bridging_weight: rest,
+        source_diversity_weight: rest,
+        relevance_weight: rest,
+      };
+    });
+    const w = combineVoteWeights(ballots)!;
+    expect(sum(w)).toBeCloseTo(1, 9);
+  });
+});

--- a/tests/governance-decisions.property.test.ts
+++ b/tests/governance-decisions.property.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Property + unit tests for the pure governance decision logic (quorum).
+ *
+ * These pin the quorum *policy* (the thing PROJ-1045 is about — the policy is
+ * correct; the bug was that an apply path bypassed it). Routing every quorum
+ * check through `quorumMet` makes that class of drift impossible.
+ */
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { quorumMet, quorumStatus } from '../src/governance/governance-decisions.js';
+
+describe('quorumMet', () => {
+  it('is met exactly at and above the minimum (boundary)', () => {
+    expect(quorumMet(4, 5)).toBe(false);
+    expect(quorumMet(5, 5)).toBe(true);
+    expect(quorumMet(6, 5)).toBe(true);
+  });
+
+  it('is monotonic non-decreasing in vote count', () => {
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 10_000 }),
+        fc.nat({ max: 10_000 }),
+        fc.nat({ max: 10_000 }),
+        (a, b, minVotes) => {
+          const lo = Math.min(a, b);
+          const hi = Math.max(a, b);
+          // more votes can never lose a quorum you already had
+          if (quorumMet(lo, minVotes)) expect(quorumMet(hi, minVotes)).toBe(true);
+        }
+      )
+    );
+  });
+
+  it('agrees with the boolean threshold for all inputs', () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 10_000 }), fc.nat({ max: 10_000 }), (votes, minVotes) => {
+        expect(quorumMet(votes, minVotes)).toBe(votes >= minVotes);
+      })
+    );
+  });
+});
+
+describe('quorumStatus', () => {
+  it('reports met === quorumMet and a non-negative shortfall', () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 10_000 }), fc.nat({ max: 10_000 }), (votes, minVotes) => {
+        const s = quorumStatus(votes, minVotes);
+        expect(s.met).toBe(quorumMet(votes, minVotes));
+        expect(s.shortfall).toBeGreaterThanOrEqual(0);
+        expect(s.shortfall).toBe(s.met ? 0 : minVotes - votes);
+        // shortfall is exactly the additional votes needed to flip to met
+        if (!s.met) expect(quorumMet(votes + s.shortfall, minVotes)).toBe(true);
+      })
+    );
+  });
+});

--- a/tests/governance-sim.test.ts
+++ b/tests/governance-sim.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Governance mechanism simulation (Layer 3).
+ *
+ * Runs deterministic synthetic electorates + Sybil attacks through the real
+ * aggregation core to quantify how robust the voting rule is at scale. This is the
+ * reproducible evidence behind PROJ-1048 (Sybil: N DIDs => N votes): the trimmed
+ * mean absorbs a small flood but not one larger than its ~10% trim.
+ */
+import { describe, expect, it } from 'vitest';
+import type { GovernanceWeights } from '../src/governance/governance.types.js';
+import {
+  mulberry32,
+  generatePopulation,
+  sybilSockpuppets,
+  extremeBallot,
+  runScenario,
+  l1Shift,
+} from './governance-sim/harness.js';
+
+const SEED = 0xc0ffee;
+const CENTER = [0.25, 0.2, 0.2, 0.15, 0.2] as const; // honest electorate leans recency
+const honest = () => generatePopulation(100, mulberry32(SEED), 'clustered', CENTER);
+
+const attacker = extremeBallot('relevance_weight'); // attacker wants relevance to dominate
+
+const baseline = runScenario('honest-100', honest());
+const smallSybil = runScenario('+5 sybil', [...honest(), ...sybilSockpuppets(attacker, 5)]);
+const largeSybil = runScenario('+40 sybil', [...honest(), ...sybilSockpuppets(attacker, 40)]);
+
+const fmt = (w: GovernanceWeights): string =>
+  (Object.entries(w) as [string, number][]).map(([k, v]) => `${k}=${v.toFixed(3)}`).join(' ');
+
+describe('governance simulation — reproducibility', () => {
+  it('is deterministic for a fixed seed', () => {
+    expect(runScenario('rerun', honest()).weights).toEqual(baseline.weights);
+  });
+});
+
+describe('governance simulation — Sybil resistance (PROJ-1048)', () => {
+  it('absorbs a small Sybil flood (within the ~10% trim)', () => {
+    // 5 sockpuppets of 105 → trimCount = floor(105*0.1) = 10 ≥ 5 → trimmed away.
+    expect(l1Shift(smallSybil.weights, baseline.weights)).toBeLessThan(0.05);
+  });
+
+  it('does NOT resist a Sybil flood larger than the trim window', () => {
+    // 40 sockpuppets of 140 → trimCount = 14 < 40 → 26 survive and pull the result.
+    const small = l1Shift(smallSybil.weights, baseline.weights);
+    const large = l1Shift(largeSybil.weights, baseline.weights);
+    expect(large).toBeGreaterThan(small * 2);
+    expect(large).toBeGreaterThan(0.05);
+  });
+
+  it('prints the outcome shifts (informational)', () => {
+    // eslint-disable-next-line no-console
+    console.log(
+      [
+        '',
+        '  GOVERNANCE SYBIL SIMULATION — 100 honest voters; attacker floods "relevance"',
+        `  baseline    dom=${baseline.dominant.padEnd(10)} ${fmt(baseline.weights)}`,
+        `  +5 sybil    dom=${smallSybil.dominant.padEnd(10)} ${fmt(smallSybil.weights)}  L1Δ=${l1Shift(smallSybil.weights, baseline.weights).toFixed(3)}`,
+        `  +40 sybil   dom=${largeSybil.dominant.padEnd(10)} ${fmt(largeSybil.weights)}  L1Δ=${l1Shift(largeSybil.weights, baseline.weights).toFixed(3)}`,
+        '',
+      ].join('\n')
+    );
+    expect(baseline.voters).toBe(100);
+  });
+});

--- a/tests/governance-sim.test.ts
+++ b/tests/governance-sim.test.ts
@@ -15,6 +15,7 @@ import {
   extremeBallot,
   runScenario,
   l1Shift,
+  sybilBreakEven,
 } from './governance-sim/harness.js';
 
 const SEED = 0xc0ffee;
@@ -48,6 +49,18 @@ describe('governance simulation — Sybil resistance (PROJ-1048)', () => {
     const large = l1Shift(largeSybil.weights, baseline.weights);
     expect(large).toBeGreaterThan(small * 2);
     expect(large).toBeGreaterThan(0.05);
+  });
+
+  it('quantifies the Sybil break-even threshold (deterministic)', () => {
+    const be = sybilBreakEven(honest(), attacker, 60);
+    // eslint-disable-next-line no-console
+    console.log(
+      `  Sybil break-even: K=${be.breakEvenK} sockpuppets = ` +
+        `${((be.breakEvenPct ?? 0) * 100).toFixed(1)}% of the electorate flips ${be.baselineDominant} -> relevance`
+    );
+    expect(be.breakEvenK).not.toBeNull();
+    // the ~10% trim should force the attacker to control more than the trim window
+    expect(be.breakEvenPct!).toBeGreaterThan(0.05);
   });
 
   it('prints the outcome shifts (informational)', () => {

--- a/tests/governance-sim/README.md
+++ b/tests/governance-sim/README.md
@@ -1,0 +1,56 @@
+# Governance test suite
+
+Layered, deterministic-first tests for the community-governance logic. The design
+follows the hexagonal pattern already used in this repo: **decision policy is
+separated from I/O** so it can be exhaustively tested without a database.
+
+## Layers
+
+1. **Property / unit — pure, fast, CI-trivial**
+   - `tests/governance-aggregation.property.test.ts` — `combineVoteWeights` invariants
+     (sum-to-1, valid bounds, unanimity, trimmed-mean **outlier resistance**) plus a
+     10,000-ballot scale smoke, via `fast-check`.
+   - `tests/governance-decisions.property.test.ts` — the quorum policy
+     (`quorumMet` / `quorumStatus`): boundary, monotonicity, shortfall.
+
+   Pure cores extracted from the DB-coupled code:
+   `src/governance/aggregation-core.ts` (trimmed-mean aggregation) and
+   `src/governance/governance-decisions.ts` (quorum).
+
+2. **Integration — mock-DB (the repo's pattern), no external Postgres**
+   - `tests/governance-aggregation.integration.test.ts` — drives the **real**
+     `aggregateVotes` over synthetic vote rows (`vi.mock` of `db/client`), confirming
+     the DB query path agrees with the pure core, excludes keyword-only votes,
+     scales to 1,000 votes, and engages the 10% trim.
+
+3. **Simulation — deterministic agent-based (NOT LLM agents)**
+   - `tests/governance-sim/harness.ts` + `tests/governance-sim.test.ts` — seeded
+     synthetic voter populations + adversarial models (Sybil sockpuppets, strategic
+     extremes) run through the real aggregation core. Reproducible.
+
+## Running
+
+- Whole suite: `npx vitest run governance`
+- Sim report + Sybil break-even (console output): `npx vitest run tests/governance-sim.test.ts --disableConsoleIntercept`
+
+## Findings the sim pins down
+
+- The trimmed mean **absorbs a Sybil flood within its ~10% trim** but not beyond:
+  the **break-even is ~13% of the electorate** (K=15 sockpuppets vs 100 honest flips
+  the dominant component recency → relevance).
+
+## Known gaps — characterized here, fixed separately
+
+- **PROJ-1045** — quorum bypass on the admin phase-apply path. The quorum *policy*
+  is now single-source (`quorumMet`, used by `epoch-manager`); routing the admin
+  apply path through it is the next fix (see the `it.todo` in the integration test).
+  We do **not** change governance behavior in this change set.
+- **PROJ-1048** — Sybil (N DIDs ⇒ N votes). >~13% sockpuppet control flips the
+  outcome; an eligibility / anti-Sybil design is the mitigation.
+
+## Adding tests
+
+- New pure logic → extract a `*-core` / `*-decisions` module and property-test it.
+- New apply-path behavior → mock-DB integration test (copy the pattern in
+  `governance-aggregation.integration.test.ts`).
+- New mechanism question (manipulation, coalitions) → add a scenario to `harness.ts`.

--- a/tests/governance-sim/harness.ts
+++ b/tests/governance-sim/harness.ts
@@ -133,3 +133,32 @@ export function runScenario(name: string, ballots: WeightVote[]): ScenarioResult
   if (weights === null) throw new Error(`Scenario "${name}" has no votes`);
   return { name, voters: ballots.length, weights, dominant: dominantComponent(weights) };
 }
+
+export interface BreakEven {
+  /** Smallest sockpuppet count that flips the dominant component, or null if it never flips up to maxK. */
+  breakEvenK: number | null;
+  /** breakEvenK as a fraction of the resulting (honest + sybil) electorate, or null. */
+  breakEvenPct: number | null;
+  baselineDominant: keyof GovernanceWeights;
+}
+
+/**
+ * Sweep sockpuppet counts to find the smallest Sybil flood that flips the adopted
+ * dominant component away from the honest baseline. Deterministic given `honest`.
+ */
+export function sybilBreakEven(
+  honest: WeightVote[],
+  attacker: WeightVote,
+  maxK: number = honest.length
+): BreakEven {
+  const baseline = combineVoteWeights(honest);
+  if (baseline === null) throw new Error('sybilBreakEven: empty honest electorate');
+  const baselineDominant = dominantComponent(baseline);
+  for (let k = 1; k <= maxK; k++) {
+    const w = combineVoteWeights([...honest, ...sybilSockpuppets(attacker, k)])!;
+    if (dominantComponent(w) !== baselineDominant) {
+      return { breakEvenK: k, breakEvenPct: k / (honest.length + k), baselineDominant };
+    }
+  }
+  return { breakEvenK: null, breakEvenPct: null, baselineDominant };
+}

--- a/tests/governance-sim/harness.ts
+++ b/tests/governance-sim/harness.ts
@@ -1,0 +1,135 @@
+/**
+ * Governance simulation harness (Layer 3) — deterministic agent-based simulation.
+ *
+ * Synthetic voter "agents" drawn from preference distributions, plus adversarial
+ * models (Sybil, strategic), run through the REAL aggregation core. Everything is
+ * seeded, so runs are reproducible — these are simulations, NOT LLM agents.
+ *
+ * Use to answer "is the mechanism robust at scale?": does a Sybil flood flip the
+ * outcome (PROJ-1048), does the trimmed mean absorb strategic outliers, etc.
+ */
+import { combineVoteWeights, type WeightVote } from '../../src/governance/aggregation-core.js';
+import type { GovernanceWeights } from '../../src/governance/governance.types.js';
+
+const VOTE_FIELDS = [
+  'recency_weight',
+  'engagement_weight',
+  'bridging_weight',
+  'source_diversity_weight',
+  'relevance_weight',
+] as const;
+type VoteField = (typeof VOTE_FIELDS)[number];
+
+/** Seeded PRNG (mulberry32) — deterministic given a seed. */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Normalize 5 raw positive numbers into a valid ballot (sums to 1). */
+export function ballotFrom(raw: readonly [number, number, number, number, number]): WeightVote {
+  const safe = raw.map((x) => Math.max(x, 1e-6));
+  const s = safe.reduce((a, b) => a + b, 0);
+  return Object.fromEntries(
+    VOTE_FIELDS.map((f, i) => [f, safe[i] / s] as const)
+  ) as Record<VoteField, number>;
+}
+
+/** A uniformly random ballot. */
+export function randomBallot(rng: () => number): WeightVote {
+  return ballotFrom([rng(), rng(), rng(), rng(), rng()]);
+}
+
+/** A ballot clustered around a center (Dirichlet-ish: center * exp(noise)). */
+export function clusteredBallot(
+  rng: () => number,
+  center: readonly [number, number, number, number, number],
+  spread = 0.25
+): WeightVote {
+  return ballotFrom(
+    center.map((c) => c * Math.exp(spread * (rng() - 0.5))) as unknown as [
+      number,
+      number,
+      number,
+      number,
+      number,
+    ]
+  );
+}
+
+export type Distribution = 'uniform' | 'clustered' | 'polarized';
+
+/** Generate a population of honest voter ballots. */
+export function generatePopulation(
+  n: number,
+  rng: () => number,
+  dist: Distribution = 'clustered',
+  center: readonly [number, number, number, number, number] = [0.25, 0.2, 0.2, 0.15, 0.2]
+): WeightVote[] {
+  const out: WeightVote[] = [];
+  for (let i = 0; i < n; i++) {
+    if (dist === 'uniform') out.push(randomBallot(rng));
+    else if (dist === 'clustered') out.push(clusteredBallot(rng, center));
+    else {
+      // polarized: two camps pulling opposite components
+      const campA: readonly [number, number, number, number, number] = [0.5, 0.1, 0.1, 0.1, 0.2];
+      const campB: readonly [number, number, number, number, number] = [0.1, 0.1, 0.5, 0.1, 0.2];
+      out.push(clusteredBallot(rng, rng() < 0.5 ? campA : campB, 0.15));
+    }
+  }
+  return out;
+}
+
+/** Sybil attack: one actor casts `k` identical sockpuppet ballots. */
+export function sybilSockpuppets(ballot: WeightVote, k: number): WeightVote[] {
+  return Array.from({ length: k }, () => ({ ...ballot }));
+}
+
+/** A maximally one-sided ballot favoring a single component (strategic extreme). */
+export function extremeBallot(field: VoteField): WeightVote {
+  return ballotFrom(VOTE_FIELDS.map((f) => (f === field ? 1 : 0)) as unknown as [
+    number,
+    number,
+    number,
+    number,
+    number,
+  ]);
+}
+
+/** L1 distance between two weight vectors (0 = identical, 2 = max). */
+export function l1Shift(a: GovernanceWeights, b: GovernanceWeights): number {
+  return (
+    Math.abs(a.recency - b.recency) +
+    Math.abs(a.engagement - b.engagement) +
+    Math.abs(a.bridging - b.bridging) +
+    Math.abs(a.sourceDiversity - b.sourceDiversity) +
+    Math.abs(a.relevance - b.relevance)
+  );
+}
+
+/** The component with the largest adopted weight ("what the feed prioritizes"). */
+export function dominantComponent(w: GovernanceWeights): keyof GovernanceWeights {
+  return (Object.keys(w) as (keyof GovernanceWeights)[]).reduce((best, k) =>
+    w[k] > w[best] ? k : best
+  );
+}
+
+export interface ScenarioResult {
+  name: string;
+  voters: number;
+  weights: GovernanceWeights;
+  dominant: keyof GovernanceWeights;
+}
+
+/** Run an electorate through the real aggregation core. */
+export function runScenario(name: string, ballots: WeightVote[]): ScenarioResult {
+  const weights = combineVoteWeights(ballots);
+  if (weights === null) throw new Error(`Scenario "${name}" has no votes`);
+  return { name, voters: ballots.length, weights, dominant: dominantComponent(weights) };
+}


### PR DESCRIPTION
## Summary

Builds a layered test pyramid for the governance aggregation system, then closes a security gap where three apply paths could install vote-derived weights below quorum.

The test work (PROJ-884) extracts `combineVoteWeights` into a pure, DB-free core, adds fast-check property tests (sum-to-one, bounds, unanimity, outlier resistance), a mock-DB integration suite that validates the real `aggregateVotes` against the pure core, and a deterministic Sybil simulation harness that quantifies the break-even: ~13% sockpuppet control flips the adopted weights (evidence base for PROJ-1048).

The security fix (PROJ-1045) routes the scheduler auto-end, admin `approve-results`, and admin `apply-results` paths through the single-source `quorumMet` + the now-exported `getVoteCountsForEpoch`. All three previously keyed on `voteCount > 0` (any vote sufficed); they now require weight-eligible votes to reach `GOVERNANCE_MIN_VOTES` before adopting proposed weights. Below quorum, prior weights are retained and `insufficient_votes` is logged. The `appliedWeights` flag in the `apply-results` response now accurately reflects the quorum gate.

Split into a separate branch (`dev/PROJ-1045-quorum-apply-paths`) was attempted but the cherry-pick conflicted because PROJ-1045 modifies test files introduced by PROJ-884 which are not yet on `main`; the two cannot be separated cleanly at this base.

## What lands

- `src/governance/aggregation-core.ts`: pure trimmed-mean core extracted from `aggregateVotes`
- `src/governance/governance-decisions.ts`: `quorumMet` / `quorumStatus` policy (single source of truth)
- `src/governance/epoch-manager.ts`: exports `getVoteCountsForEpoch`; quorum checks routed through `quorumMet`
- `src/governance/aggregation.ts`: simplified to delegate to the extracted core
- `src/admin/routes/governance.ts`: `approve-results` and `apply-results` gated on `quorumMet`; `appliedWeights` flag corrected
- `src/scheduler/epoch-scheduler.ts`: scheduler auto-end gated on `quorumMet`
- `tests/governance-aggregation.property.test.ts`: fast-check property suite for the pure core
- `tests/governance-decisions.property.test.ts`: boundary, monotonicity, and shortfall properties for the quorum policy
- `tests/governance-aggregation.integration.test.ts`: mock-DB integration tests including quorum enforcement characterization
- `tests/governance-admin.test.ts`: four new route-level tests (below-quorum refusal and at-quorum apply for both `approve-results` and `apply-results`)
- `tests/governance-sim.test.ts` + `tests/governance-sim/harness.ts` + `tests/governance-sim/README.md`: Sybil simulation harness and break-even sweep

## Verification

- All tests pass locally against the branch head.
- `appliedWeights: false` confirmed for below-quorum case; `appliedWeights: true` confirmed for at-quorum case.
- Outlier-resistance property test tolerance corrected to 2 dp (0.001 normalization grid) to eliminate a boundary-straddling flake.

Closes PROJ-884
Closes PROJ-1045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Governance voting weights now require reaching the minimum quorum threshold before being adopted. If quorum is not met, existing weights are retained while content rules continue to aggregate.

* **Tests**
  * Added comprehensive test coverage for quorum enforcement, vote aggregation behavior, and governance resilience scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->