### PR TITLE
[PROJ-1482] A1: headless governance simulation core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,11 +39,14 @@
         "zod-to-json-schema": "^3.25.2"
       },
       "devDependencies": {
+        "@testcontainers/postgresql": "12.0.3",
+        "@testcontainers/redis": "12.0.3",
         "@types/archiver": "^7.0.0",
         "@types/node": "^25.9.2",
         "@types/node-cron": "^3.0.11",
         "@types/pg": "^8.20.0",
         "@types/ws": "^8.5.0",
+        "fast-check": "4.8.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "pino-pretty": "^13.0.0",
@@ -360,6 +363,13 @@
       "engines": {
         "node": ">=22"
       }
+    },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@corgi-example/civility-component": {
       "resolved": "examples/civility-component",
@@ -1150,6 +1160,58 @@
         "yaml": "^2.4.1"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -1665,6 +1727,52 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/file-exists/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@kwsites/file-exists/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2422,6 +2530,26 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@testcontainers/postgresql": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-12.0.3.tgz",
+      "integrity": "sha512-y0l/ItWxNfdMU783EOZ66lMq90uuuXPqE+fo1jNSRfMbtfUq/9Ez/wluDxxaS+D/i3I0juep+jmz/WVuip8i9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^12.0.3"
+      }
+    },
+    "node_modules/@testcontainers/redis": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@testcontainers/redis/-/redis-12.0.3.tgz",
+      "integrity": "sha512-hN3YedOSb6quFzG1IM4j/r/M635GcaYOxzbTuiSN7676BZHrx1VPl+xll3ojk8ds6TvenrfO37lrEVJYN2URlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^12.0.3"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -2460,6 +2588,29 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2505,6 +2656,43 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-streams": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+      "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2968,6 +3156,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2982,6 +3180,13 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -3139,6 +3344,68 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.5",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
@@ -3215,6 +3482,26 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3271,6 +3558,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -3349,6 +3643,39 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -3475,6 +3802,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/crc-32": {
@@ -3620,6 +3962,138 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT"
+    },
+    "node_modules/docker-compose": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
+      "integrity": "sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/docker-modem/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/docker-modem/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/docker-modem/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.1.tgz",
+      "integrity": "sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.7",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4"
+      },
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
+    "node_modules/dockerode/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -3780,6 +4254,16 @@
         "@esbuild/win32-arm64": "0.28.0",
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -3946,6 +4430,29 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-copy": {
@@ -4186,6 +4693,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4208,6 +4722,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -4245,6 +4769,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-proto": {
@@ -5074,6 +5611,13 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/log-update": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -5322,6 +5866,29 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5333,6 +5900,14 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
       "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
       "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -5864,6 +6439,43 @@
       ],
       "license": "MIT"
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/properties-reader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/properties?sponsor=1"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
@@ -5920,6 +6532,23 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.1.tgz",
+      "integrity": "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.2",
@@ -6054,6 +6683,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6087,6 +6726,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -6586,6 +7235,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -6600,6 +7256,46 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ssh-remote-port-forward": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+      "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^0.5.48",
+        "ssh2": "^1.4.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+      "version": "0.5.52",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -6727,6 +7423,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
@@ -6747,6 +7458,55 @@
       "dependencies": {
         "streamx": "^2.12.5"
       }
+    },
+    "node_modules/testcontainers": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-12.0.3.tgz",
+      "integrity": "sha512-6vfiL9CWIX0rWhTJitzrzHcv4Q/sUfUdBV12jMz6HZ58Lz6ZtXVecO6jljd1O3ookEWQHNICiYoYNEPpDLzuRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@types/dockerode": "^4.0.1",
+        "archiver": "^7.0.1",
+        "async-lock": "^1.4.1",
+        "byline": "^5.0.0",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.4.2",
+        "dockerode": "^5.0.0",
+        "get-port": "^7.2.0",
+        "proper-lockfile": "^4.1.2",
+        "properties-reader": "^3.0.1",
+        "ssh-remote-port-forward": "^1.0.4",
+        "tar-fs": "^3.1.2",
+        "tmp": "^0.2.7",
+        "undici": "^8.3.0"
+      }
+    },
+    "node_modules/testcontainers/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/testcontainers/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
@@ -6819,6 +7579,16 @@
         "tlds": "bin.js"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/toad-cache": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
@@ -6861,6 +7631,13 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
@@ -6908,6 +7685,16 @@
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -7309,6 +8096,16 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -7322,6 +8119,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zip-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -380,9 +380,9 @@
       "link": true
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2126,14 +2126,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -2172,9 +2172,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2261,9 +2261,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -2278,9 +2278,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -2295,9 +2295,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -2312,9 +2312,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -2329,9 +2329,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -2346,13 +2346,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2363,13 +2366,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2380,13 +2386,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2397,13 +2406,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2414,13 +2426,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2431,13 +2446,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2448,9 +2466,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -2465,9 +2483,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -2475,18 +2493,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -2501,9 +2519,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -2518,9 +2536,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2551,9 +2569,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4924,9 +4942,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6772,14 +6790,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -6788,21 +6806,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -7743,17 +7761,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7769,7 +7787,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "receipts:verify": "node scripts/sanitize-receipts.mjs --check",
     "seed-topics": "tsx scripts/seed-topics.ts",
     "backfill-topics": "tsx scripts/backfill-topics.ts",
-    "sim:core": "vitest run --config vitest.harness.config.ts tests/harness/simulation.integration.sim.ts",
+    "sim:core": "vitest run --config vitest.harness.config.ts",
     "report:pdf": "python3 scripts/generate-report-pdf.py",
     "build:mcp-local": "if [ -f src/mcp-local/tsconfig.json ]; then cd src/mcp-local && npx tsc -p tsconfig.json; else echo 'src/mcp-local not present; skipping build:mcp-local'; fi",
     "sdk:build": "cd packages/feed-sdk && tsc -p tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "receipts:verify": "node scripts/sanitize-receipts.mjs --check",
     "seed-topics": "tsx scripts/seed-topics.ts",
     "backfill-topics": "tsx scripts/backfill-topics.ts",
+    "sim:core": "vitest run --config vitest.harness.config.ts tests/harness/simulation.integration.sim.ts",
     "report:pdf": "python3 scripts/generate-report-pdf.py",
     "build:mcp-local": "if [ -f src/mcp-local/tsconfig.json ]; then cd src/mcp-local && npx tsc -p tsconfig.json; else echo 'src/mcp-local not present; skipping build:mcp-local'; fi",
     "sdk:build": "cd packages/feed-sdk && tsc -p tsconfig.json",
@@ -61,11 +62,14 @@
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
+    "@testcontainers/postgresql": "12.0.3",
+    "@testcontainers/redis": "12.0.3",
     "@types/archiver": "^7.0.0",
     "@types/node": "^25.9.2",
     "@types/node-cron": "^3.0.11",
     "@types/pg": "^8.20.0",
     "@types/ws": "^8.5.0",
+    "fast-check": "4.8.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "pino-pretty": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -98,12 +98,12 @@
   "overrides": {
     "ajv": "8.18.0",
     "@hono/node-server": "1.19.14",
-    "hono": "4.12.23",
+    "hono": "4.12.27",
     "lodash": "4.18.1",
     "postcss": "8.5.13",
     "protobufjs": "7.6.1",
     "tar": "7.5.11",
-    "vite": "8.0.8",
+    "vite": "8.0.16",
     "qs": "6.15.2",
     "ip-address": "10.1.1",
     "brace-expansion@5": "5.0.6"

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Simulation Harness — Public API
+ *
+ * This is the ONLY file outside `src/harness/**` should import from. Every
+ * other file in this directory is an internal implementation detail; the
+ * exports below are the harness's stable, versioned contract (PROJ-1482 /
+ * A1 — headless simulation core).
+ */
+
+export { ScenarioV1Schema, PopulationConfigSchema, parseScenario } from './scenario.js';
+export type { Scenario, ScenarioV1, PopulationConfig, ParseScenarioResult } from './scenario.js';
+
+export { Simulation } from './simulation.js';
+export type {
+  SimulationDeps,
+  SimulationResult,
+  SimulationEvent,
+  TopScoredPost,
+  QueryableDb,
+} from './simulation.js';
+
+export { runScenario } from './run.js';
+export type { RunScenarioOptions, RunScenarioResult } from './run.js';
+
+export { measure, toArtifacts, writeArtifacts, RunMetricsSchema, RunArtifactsSchema } from './metrics.js';
+export type { RunMetrics, RunArtifacts, WrittenArtifactPaths } from './metrics.js';
+
+export { createRng, SeededClock } from './rng.js';
+export type { Rng, Clock } from './rng.js';
+
+export { generatePopulation } from './population.js';
+export type { Population, SubscriberSeed, PostSeed, VoteSeed } from './population.js';
+
+export {
+  assertEphemeralPostgresUrl,
+  assertEphemeralRedisUrl,
+  assertEphemeralTarget,
+  ProdGuardError,
+} from './prod-guard.js';
+export type { GuardOptions } from './prod-guard.js';

--- a/src/harness/metrics.ts
+++ b/src/harness/metrics.ts
@@ -1,0 +1,177 @@
+/**
+ * Metrics
+ *
+ * Pure measurement over a completed `SimulationResult` — never drives the
+ * simulated system itself (that's `Simulation`'s job). Every run's output is
+ * a schema-validated, serializable artifact keyed by scenario + seed + code
+ * version, not console noise: this is what makes a run diffable/greppable
+ * and gives golden-snapshot tests something stable to assert against.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+import type { SimulationResult, SimulationEvent } from './simulation.js';
+
+const GovernanceWeightsSchema = z.record(z.string(), z.number());
+
+export const RunMetricsSchema = z.object({
+  scenarioKind: z.string(),
+  scenarioVersion: z.number().int(),
+  seed: z.number().int(),
+  codeVersion: z.string(),
+  population: z.object({
+    subscriberCount: z.number().int(),
+    postCount: z.number().int(),
+    voteCount: z.number().int(),
+  }),
+  aggregation: z.object({
+    epochId: z.number().int(),
+    weights: GovernanceWeightsSchema,
+    weightSum: z.number(),
+  }),
+  transition: z.object({
+    fromEpochId: z.number().int(),
+    toEpochId: z.number().int(),
+  }),
+  scoring: z.object({
+    epochId: z.number().int(),
+    scoredPostCount: z.number().int(),
+    topPosts: z.array(
+      z.object({
+        uri: z.string(),
+        rank: z.number().int(),
+        totalScore: z.number(),
+      })
+    ),
+  }),
+});
+export type RunMetrics = z.infer<typeof RunMetricsSchema>;
+
+const SimulationEventSchema = z.object({
+  at: z.string(),
+  type: z.string(),
+  data: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const RunArtifactsSchema = z.object({
+  runId: z.string(),
+  /** Wall-clock generation time. Informational only — never part of the
+   *  deterministic surface a golden-snapshot test should assert on. */
+  generatedAt: z.string(),
+  metrics: RunMetricsSchema,
+  events: z.array(SimulationEventSchema),
+});
+export type RunArtifacts = z.infer<typeof RunArtifactsSchema>;
+
+/** Round to reduce float noise from Postgres round-trips; inputs are already deterministic. */
+function round(value: number, decimals = 6): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function readCodeVersion(): string {
+  return process.env.npm_package_version ?? '0.0.0-unknown';
+}
+
+/** Pure measurement: turns a completed run into a schema-validated RunMetrics snapshot. */
+export function measure(result: SimulationResult): RunMetrics {
+  const weightSum = Object.values(result.aggregatedWeights).reduce((sum, value) => sum + value, 0);
+
+  const roundedWeights = Object.fromEntries(
+    Object.entries(result.aggregatedWeights).map(([key, value]) => [key, round(value)])
+  );
+
+  return RunMetricsSchema.parse({
+    scenarioKind: result.scenario.kind,
+    scenarioVersion: result.scenario.version,
+    seed: result.scenario.seed,
+    codeVersion: readCodeVersion(),
+    population: {
+      subscriberCount: result.population.subscribers.length,
+      postCount: result.population.posts.length,
+      voteCount: result.population.votes.length,
+    },
+    aggregation: {
+      epochId: result.epochBeforeId,
+      weights: roundedWeights,
+      weightSum: round(weightSum),
+    },
+    transition: {
+      fromEpochId: result.epochBeforeId,
+      toEpochId: result.epochAfterId,
+    },
+    scoring: {
+      epochId: result.epochAfterId,
+      scoredPostCount: result.scoredPostCount,
+      topPosts: result.topPosts.map((post) => ({ ...post, totalScore: round(post.totalScore) })),
+    },
+  });
+}
+
+/** Build the full artifact envelope (metrics + raw event trace) for a run. */
+export function toArtifacts(
+  runId: string,
+  generatedAt: string,
+  metrics: RunMetrics,
+  events: SimulationEvent[]
+): RunArtifacts {
+  return RunArtifactsSchema.parse({ runId, generatedAt, metrics, events });
+}
+
+export interface WrittenArtifactPaths {
+  jsonPath: string;
+  csvPath: string;
+}
+
+const CSV_HEADER = [
+  'scenarioKind',
+  'seed',
+  'codeVersion',
+  'subscriberCount',
+  'postCount',
+  'voteCount',
+  'fromEpochId',
+  'toEpochId',
+  'scoredPostCount',
+  'weightSum',
+] as const;
+
+function toCsvSummary(metrics: RunMetrics): string {
+  const row = [
+    metrics.scenarioKind,
+    metrics.seed,
+    metrics.codeVersion,
+    metrics.population.subscriberCount,
+    metrics.population.postCount,
+    metrics.population.voteCount,
+    metrics.transition.fromEpochId,
+    metrics.transition.toEpochId,
+    metrics.scoring.scoredPostCount,
+    metrics.aggregation.weightSum,
+  ];
+  return `${CSV_HEADER.join(',')}\n${row.join(',')}\n`;
+}
+
+/**
+ * Persist a run's artifacts to `<baseDir>/<scenarioKind>/<seed>/<codeVersion>/`:
+ * `metrics.json` (schema-validated JSON, full artifact envelope) and
+ * `summary.csv` (one-row tabular summary, easy to diff in PR review).
+ */
+export async function writeArtifacts(baseDir: string, artifacts: RunArtifacts): Promise<WrittenArtifactPaths> {
+  const dir = path.join(
+    baseDir,
+    artifacts.metrics.scenarioKind,
+    String(artifacts.metrics.seed),
+    artifacts.metrics.codeVersion
+  );
+  await mkdir(dir, { recursive: true });
+
+  const jsonPath = path.join(dir, 'metrics.json');
+  const csvPath = path.join(dir, 'summary.csv');
+
+  await writeFile(jsonPath, `${JSON.stringify(artifacts, null, 2)}\n`, 'utf8');
+  await writeFile(csvPath, toCsvSummary(artifacts.metrics), 'utf8');
+
+  return { jsonPath, csvPath };
+}

--- a/src/harness/population.ts
+++ b/src/harness/population.ts
@@ -133,12 +133,16 @@ function generateVotes(
 
   return participantOrder.map((subscriberIndex) => {
     const subscriber = subscribers[subscriberIndex];
+    const castsWeightVote = rng.chance(config.castsWeightVoteRate);
     const castsContentVote = rng.chance(config.contentVoteRate);
 
-    // Normalize through the REAL production helper so every generated vote
-    // satisfies the same sum-to-1 invariant the API layer enforces, rather
-    // than duplicating that math here.
-    const weights = normalizeWeights(generateRawWeightVector(rng));
+    // Keyword-only voters (VoteSeed.weights: null) never compute/normalize a
+    // weight vector at all — this is the only place `weights: null` is ever
+    // produced, mirroring the real API's "cast keywords without a weight
+    // opinion" shape. Normalize through the REAL production helper for the
+    // rest so every weighted vote satisfies the same sum-to-1 invariant the
+    // API layer enforces, rather than duplicating that math here.
+    const weights = castsWeightVote ? normalizeWeights(generateRawWeightVector(rng)) : null;
 
     const includeKeywords = castsContentVote && rng.chance(0.5) ? [rng.pick(SAMPLE_KEYWORDS)] : [];
     const excludeKeywords = castsContentVote ? [rng.pick(SAMPLE_EXCLUDE_KEYWORDS)] : [];

--- a/src/harness/population.ts
+++ b/src/harness/population.ts
@@ -134,7 +134,13 @@ function generateVotes(
   return participantOrder.map((subscriberIndex) => {
     const subscriber = subscribers[subscriberIndex];
     const castsWeightVote = rng.chance(config.castsWeightVoteRate);
-    const castsContentVote = rng.chance(config.contentVoteRate);
+    // Always draw so the deterministic RNG sequence (and the weighted/null-vote
+    // pattern) stays stable regardless of this rule. A voter with no weight
+    // opinion (weights: null) must still carry at least one keyword — otherwise
+    // it is a no-op vote (no weight opinion AND no content opinion), which the
+    // real API would never accept. So keyword-only voters always cast content.
+    const drawsContentVote = rng.chance(config.contentVoteRate);
+    const castsContentVote = castsWeightVote ? drawsContentVote : true;
 
     // Keyword-only voters (VoteSeed.weights: null) never compute/normalize a
     // weight vector at all — this is the only place `weights: null` is ever

--- a/src/harness/population.ts
+++ b/src/harness/population.ts
@@ -1,0 +1,166 @@
+/**
+ * Population Generation
+ *
+ * Pure, deterministic generation of a synthetic community: subscribers
+ * (governance voters), posts (with engagement counts), and votes. Takes an
+ * injected `Rng`/`Clock` and a validated `PopulationConfig` — never reads
+ * `Math.random()`/`Date.now()` itself, so the same `(seed, config)` always
+ * produces byte-identical output.
+ *
+ * This module does no I/O. Seeding the generated population into
+ * Postgres/Redis is `Simulation`'s job (src/harness/simulation.ts) — keeping
+ * "generate" and "drive" separate lets population shapes be unit-tested with
+ * zero database dependency.
+ */
+
+import type { Rng, Clock } from './rng.js';
+import type { PopulationConfig } from './scenario.js';
+import { normalizeWeights } from '../governance/governance.types.js';
+import type { GovernanceWeights } from '../shared/api-types.js';
+
+const SCORING_WINDOW_MS = 72 * 60 * 60 * 1000;
+const SAMPLE_KEYWORDS = ['news', 'sports', 'tech', 'art', 'music', 'science'] as const;
+const SAMPLE_EXCLUDE_KEYWORDS = ['spam', 'nsfw'] as const;
+const TOPIC_SLUGS = ['software-development', 'sports', 'music', 'science', 'politics'] as const;
+
+export interface SubscriberSeed {
+  did: string;
+}
+
+export interface PostSeed {
+  uri: string;
+  cid: string;
+  authorDid: string;
+  text: string;
+  createdAt: Date;
+  hasMedia: boolean;
+  likeCount: number;
+  repostCount: number;
+  replyCount: number;
+  embedUrl: string | null;
+  topicVector: Record<string, number>;
+}
+
+export interface VoteSeed {
+  voterDid: string;
+  /** null = a keyword-only vote (no weight opinion cast). */
+  weights: GovernanceWeights | null;
+  includeKeywords: string[];
+  excludeKeywords: string[];
+}
+
+export interface Population {
+  subscribers: SubscriberSeed[];
+  posts: PostSeed[];
+  votes: VoteSeed[];
+}
+
+function padIndex(index: number): string {
+  return String(index).padStart(6, '0');
+}
+
+function generateSubscribers(count: number): SubscriberSeed[] {
+  return Array.from({ length: count }, (_, index) => ({
+    did: `did:plc:corgisimsub${padIndex(index)}`,
+  }));
+}
+
+/** Deterministic Fisher-Yates shuffle of indices [0, count), driven by `rng`. */
+function shuffledIndices(rng: Rng, count: number): number[] {
+  const indices = Array.from({ length: count }, (_, i) => i);
+  for (let i = indices.length - 1; i > 0; i--) {
+    const j = rng.int(i + 1);
+    [indices[i], indices[j]] = [indices[j], indices[i]];
+  }
+  return indices;
+}
+
+function generatePosts(
+  rng: Rng,
+  clock: Clock,
+  count: number,
+  authorDids: readonly string[]
+): PostSeed[] {
+  const nowMs = clock.now().getTime();
+
+  return Array.from({ length: count }, (_, index) => {
+    const author = authorDids[index % authorDids.length];
+    const ageMs = rng.int(SCORING_WINDOW_MS);
+    // Subtract `index` ms too so no two posts share an exact timestamp —
+    // avoids ORDER BY created_at DESC tie-breaking ambiguity downstream.
+    const createdAt = new Date(nowMs - ageMs - index);
+
+    const topicVector: Record<string, number> = {};
+    const topicCount = rng.int(3); // 0, 1, or 2 topics
+    for (let t = 0; t < topicCount; t++) {
+      const slug = rng.pick(TOPIC_SLUGS);
+      topicVector[slug] = Math.round(rng.next() * 1000) / 1000;
+    }
+
+    return {
+      uri: `at://${author}/app.bsky.feed.post/corgisimpost${padIndex(index)}`,
+      cid: `bafycorgisim${padIndex(index)}`,
+      authorDid: author,
+      text: `Simulated post #${index} about ${rng.pick(SAMPLE_KEYWORDS)}`,
+      createdAt,
+      hasMedia: rng.chance(0.1),
+      likeCount: rng.int(50),
+      repostCount: rng.int(20),
+      replyCount: rng.int(10),
+      embedUrl: rng.chance(0.15) ? `https://example.test/article/${rng.int(20)}` : null,
+      topicVector,
+    };
+  });
+}
+
+function generateRawWeightVector(rng: Rng): GovernanceWeights {
+  return {
+    recency: rng.next(),
+    engagement: rng.next(),
+    bridging: rng.next(),
+    sourceDiversity: rng.next(),
+    relevance: rng.next(),
+  };
+}
+
+function generateVotes(
+  rng: Rng,
+  subscribers: readonly SubscriberSeed[],
+  config: PopulationConfig
+): VoteSeed[] {
+  const voterCount = Math.round(subscribers.length * config.voteParticipationRate);
+  const participantOrder = shuffledIndices(rng, subscribers.length).slice(0, voterCount);
+
+  return participantOrder.map((subscriberIndex) => {
+    const subscriber = subscribers[subscriberIndex];
+    const castsContentVote = rng.chance(config.contentVoteRate);
+
+    // Normalize through the REAL production helper so every generated vote
+    // satisfies the same sum-to-1 invariant the API layer enforces, rather
+    // than duplicating that math here.
+    const weights = normalizeWeights(generateRawWeightVector(rng));
+
+    const includeKeywords = castsContentVote && rng.chance(0.5) ? [rng.pick(SAMPLE_KEYWORDS)] : [];
+    const excludeKeywords = castsContentVote ? [rng.pick(SAMPLE_EXCLUDE_KEYWORDS)] : [];
+
+    return {
+      voterDid: subscriber.did,
+      weights,
+      includeKeywords,
+      excludeKeywords,
+    };
+  });
+}
+
+/**
+ * Generate a full synthetic population for a scenario run. Pure function of
+ * `(rng, clock, config)` — same inputs always produce the same output.
+ */
+export function generatePopulation(rng: Rng, clock: Clock, config: PopulationConfig): Population {
+  const subscribers = generateSubscribers(config.subscriberCount);
+  const authorDids = subscribers.length > 0 ? subscribers.map((s) => s.did) : ['did:plc:corgisimfallbackauthor'];
+  const posts = generatePosts(rng, clock, config.postCount, authorDids);
+  const votes = generateVotes(rng, subscribers, config);
+
+  return { subscribers, posts, votes };
+}

--- a/src/harness/prod-guard.ts
+++ b/src/harness/prod-guard.ts
@@ -38,19 +38,33 @@ export interface GuardOptions {
   allowFlag?: boolean;
 }
 
+// Mirrors docker-compose.prod.yml's `postgres` service exactly (`POSTGRES_USER`,
+// `POSTGRES_DB`, and the host-side port of the `ports:` mapping). This is
+// deliberately hardcoded rather than read from the compose file at runtime —
+// see this file's header (no dependency on anything that does I/O or env
+// parsing) — but that means these three values can silently drift from the
+// compose file if it's ever edited without a matching update here. This
+// exact pairing is asserted in tests/harness/prod-guard.test.ts (a test
+// reads docker-compose.prod.yml and confirms these constants still match),
+// so a drift shows up as a CI failure instead of a silently weakened guard.
 const KNOWN_PROD_POSTGRES = {
   port: 5433,
   database: 'bluesky_feed',
   user: 'feed',
 } as const;
 
+// Mirrors docker-compose.prod.yml's `redis` service host-side port. Same
+// drift risk/test coverage as KNOWN_PROD_POSTGRES above.
 const KNOWN_PROD_REDIS = {
   port: 6380,
 } as const;
 
 function isLoopbackHost(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
-  return normalized === '127.0.0.1' || normalized === 'localhost' || normalized === '::1' || normalized === '[::1]';
+  // Note: `new URL(...).hostname` always keeps the brackets for IPv6
+  // literals (e.g. `[::1]`), never the bare `::1` form, so only the
+  // bracketed form is checked here.
+  return normalized === '127.0.0.1' || normalized === 'localhost' || normalized === '[::1]';
 }
 
 function parseUrlOrThrow(url: string, kind: 'Postgres' | 'Redis'): URL {

--- a/src/harness/prod-guard.ts
+++ b/src/harness/prod-guard.ts
@@ -1,0 +1,147 @@
+/**
+ * Simulation Prod-Guard
+ *
+ * A1 (headless simulation core) is designed to run destructive, high-volume
+ * synthetic governance/scoring cycles (seed votes, force epoch transitions,
+ * rescore everything) against Postgres/Redis. Running that against the real
+ * production database/cache would be catastrophic. This module is the single
+ * chokepoint every entrypoint (`runScenario`, `Simulation`) must call before
+ * touching either connection.
+ *
+ * Deliberately has NO dependency on `src/config.ts` (which eagerly parses
+ * `process.env` and throws on missing required vars): this file must be
+ * importable and unit-testable in total isolation, with arbitrary URL
+ * strings, from a bare `vitest run` with no env setup at all.
+ *
+ * Policy:
+ * 1. The known production signature (from `docker-compose.prod.yml`: Postgres
+ *    port 5433 / db `bluesky_feed` / user `feed`; Redis port 6380) is refused
+ *    unconditionally. No flag can override this — it is a hard stop.
+ * 2. Otherwise, a loopback host (`127.0.0.1` / `localhost` / `::1`) is always
+ *    allowed — this is what Testcontainers and the local `docker-compose.yml`
+ *    dev stack both bind to.
+ * 3. A non-loopback host is refused unless `CORGI_SIM_ALLOW` (or an explicit
+ *    `allowFlag: true`) is set, for the rare case of an intentionally
+ *    ephemeral remote target (e.g. a CI-provisioned Docker host). Even then,
+ *    rule 1 still applies.
+ */
+
+export class ProdGuardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProdGuardError';
+  }
+}
+
+export interface GuardOptions {
+  /** Explicit override for a non-loopback host. Never overrides the hard prod refusal. */
+  allowFlag?: boolean;
+}
+
+const KNOWN_PROD_POSTGRES = {
+  port: 5433,
+  database: 'bluesky_feed',
+  user: 'feed',
+} as const;
+
+const KNOWN_PROD_REDIS = {
+  port: 6380,
+} as const;
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === '127.0.0.1' || normalized === 'localhost' || normalized === '::1' || normalized === '[::1]';
+}
+
+function parseUrlOrThrow(url: string, kind: 'Postgres' | 'Redis'): URL {
+  try {
+    return new URL(url);
+  } catch {
+    throw new ProdGuardError(`Refusing to run simulation: could not parse ${kind} URL "${url}".`);
+  }
+}
+
+function resolveAllowFlag(options?: GuardOptions): boolean {
+  if (options?.allowFlag !== undefined) {
+    return options.allowFlag;
+  }
+  const raw = process.env.CORGI_SIM_ALLOW;
+  return raw === '1' || raw?.toLowerCase() === 'true';
+}
+
+/**
+ * Abort unless `databaseUrl` clearly targets an ephemeral/local Postgres
+ * instance. Throws `ProdGuardError` otherwise.
+ */
+export function assertEphemeralPostgresUrl(databaseUrl: string, options?: GuardOptions): void {
+  const parsed = parseUrlOrThrow(databaseUrl, 'Postgres');
+  const port = parsed.port ? Number(parsed.port) : 5432;
+  const database = parsed.pathname.replace(/^\//, '');
+  const user = decodeURIComponent(parsed.username ?? '');
+
+  const matchesProdPort = port === KNOWN_PROD_POSTGRES.port;
+  const matchesProdDatabase = database === KNOWN_PROD_POSTGRES.database;
+  const matchesProdUser = user === KNOWN_PROD_POSTGRES.user;
+
+  // Hard refusal: known production signature. Never overridable by any flag.
+  if ((matchesProdPort && matchesProdDatabase) || (matchesProdUser && matchesProdDatabase)) {
+    throw new ProdGuardError(
+      `Refusing to run simulation: Postgres target matches the known production ` +
+        `signature (port ${KNOWN_PROD_POSTGRES.port}, db "${KNOWN_PROD_POSTGRES.database}", ` +
+        `user "${KNOWN_PROD_POSTGRES.user}"). This guard cannot be bypassed for the ` +
+        `production database under any circumstances.`
+    );
+  }
+
+  if (isLoopbackHost(parsed.hostname)) {
+    return;
+  }
+
+  if (!resolveAllowFlag(options)) {
+    throw new ProdGuardError(
+      `Refusing to run simulation against non-local Postgres host "${parsed.hostname}". ` +
+        `Set CORGI_SIM_ALLOW=1 (or pass { allowFlag: true }) only for an explicitly ` +
+        `ephemeral, non-production remote target.`
+    );
+  }
+}
+
+/**
+ * Abort unless `redisUrl` clearly targets an ephemeral/local Redis instance.
+ * Throws `ProdGuardError` otherwise.
+ */
+export function assertEphemeralRedisUrl(redisUrl: string, options?: GuardOptions): void {
+  const parsed = parseUrlOrThrow(redisUrl, 'Redis');
+  const port = parsed.port ? Number(parsed.port) : 6379;
+
+  // Hard refusal: known production signature. Never overridable by any flag.
+  if (port === KNOWN_PROD_REDIS.port) {
+    throw new ProdGuardError(
+      `Refusing to run simulation: Redis target matches the known production ` +
+        `signature (port ${KNOWN_PROD_REDIS.port}). This guard cannot be bypassed for ` +
+        `the production cache under any circumstances.`
+    );
+  }
+
+  if (isLoopbackHost(parsed.hostname)) {
+    return;
+  }
+
+  if (!resolveAllowFlag(options)) {
+    throw new ProdGuardError(
+      `Refusing to run simulation against non-local Redis host "${parsed.hostname}". ` +
+        `Set CORGI_SIM_ALLOW=1 (or pass { allowFlag: true }) only for an explicitly ` +
+        `ephemeral, non-production remote target.`
+    );
+  }
+}
+
+/** Convenience wrapper asserting both targets at once. */
+export function assertEphemeralTarget(
+  databaseUrl: string,
+  redisUrl: string,
+  options?: GuardOptions
+): void {
+  assertEphemeralPostgresUrl(databaseUrl, options);
+  assertEphemeralRedisUrl(redisUrl, options);
+}

--- a/src/harness/rng.ts
+++ b/src/harness/rng.ts
@@ -1,0 +1,105 @@
+/**
+ * Deterministic RNG + Clock
+ *
+ * Deterministic Simulation Testing (DST) requires every source of
+ * non-determinism inside the simulated system to be injected rather than
+ * read from ambient globals. This module provides the two primitives the
+ * rest of the harness (population generation, `Simulation`) is required to
+ * use instead of `Math.random()` / `Date.now()` / `new Date()`:
+ *
+ * - `Rng`: a seeded pseudo-random number generator (mulberry32). Pure,
+ *   dependency-free, fully specified by a 32-bit integer seed.
+ * - `Clock`: an injectable source of "now" so simulated timestamps are a
+ *   pure function of the seed/config rather than wall-clock time.
+ *
+ * Neither of these touches `Math.random` or `Date.now` internally except
+ * `SeededClock`'s starting point, which is itself derived from the caller's
+ * seed, not sampled at construction time.
+ */
+
+/** A seeded, deterministic source of randomness. */
+export interface Rng {
+  /** Next pseudo-random float in [0, 1). */
+  next(): number;
+  /** Next pseudo-random integer in [0, maxExclusive). */
+  int(maxExclusive: number): number;
+  /** Pick a uniformly random element from a non-empty array. */
+  pick<T>(items: readonly T[]): T;
+  /** Return true with the given probability (0..1). */
+  chance(probability: number): boolean;
+}
+
+/**
+ * mulberry32 seeded PRNG.
+ *
+ * Small, fast, fully specified by a single 32-bit seed. Not cryptographically
+ * secure — that's not a requirement here, only reproducibility.
+ *
+ * Reference: https://www.4rknova.com/blog/2026/03/01/mulberry32-rng
+ */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function generate(): number {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Create a deterministic `Rng` from an integer seed. The same seed always
+ * produces the same sequence of `next()`/`int()`/`pick()`/`chance()` calls.
+ */
+export function createRng(seed: number): Rng {
+  const generate = mulberry32(seed);
+
+  const next = (): number => generate();
+
+  const int = (maxExclusive: number): number => {
+    if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) {
+      throw new Error(`Rng.int requires maxExclusive > 0, got ${maxExclusive}`);
+    }
+    return Math.floor(next() * maxExclusive);
+  };
+
+  const pick = <T>(items: readonly T[]): T => {
+    if (items.length === 0) {
+      throw new Error('Rng.pick requires a non-empty array');
+    }
+    return items[int(items.length)];
+  };
+
+  const chance = (probability: number): boolean => next() < probability;
+
+  return { next, int, pick, chance };
+}
+
+/** An injectable source of "now", so simulated code never reads the wall clock directly. */
+export interface Clock {
+  now(): Date;
+}
+
+/**
+ * A deterministic clock that starts at a fixed instant and only advances
+ * when explicitly told to. Used by the harness so post/vote timestamps are
+ * a pure function of `(seed, config)`, not of when the test happened to run.
+ */
+export class SeededClock implements Clock {
+  private currentMs: number;
+
+  constructor(startMs: number) {
+    this.currentMs = startMs;
+  }
+
+  now(): Date {
+    return new Date(this.currentMs);
+  }
+
+  /** Advance the clock by `ms` milliseconds and return the new instant. */
+  advance(ms: number): Date {
+    this.currentMs += ms;
+    return this.now();
+  }
+}

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -1,0 +1,52 @@
+/**
+ * Run Orchestration
+ *
+ * `runScenario` is the harness's top-level entrypoint: validate config →
+ * drive the simulation → measure → (optionally) write artifacts. This is the
+ * "config → run → artifacts" pipeline the DST-style architecture calls for.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { parseScenario } from './scenario.js';
+import { Simulation, type SimulationDeps } from './simulation.js';
+import { measure, toArtifacts, writeArtifacts, type RunMetrics, type RunArtifacts } from './metrics.js';
+
+export interface RunScenarioOptions {
+  deps: SimulationDeps;
+  /** When set, writes metrics.json + summary.csv under this directory. */
+  artifactsDir?: string;
+}
+
+export interface RunScenarioResult {
+  metrics: RunMetrics;
+  artifacts: RunArtifacts;
+  artifactPaths?: { jsonPath: string; csvPath: string };
+}
+
+/**
+ * Validate `input` as a Scenario, run it, and return schema-validated
+ * metrics + artifacts. Throws on invalid scenario input or simulation
+ * failure — callers that need a non-throwing boundary should call
+ * `parseScenario` themselves first.
+ */
+export async function runScenario(input: unknown, options: RunScenarioOptions): Promise<RunScenarioResult> {
+  const parsed = parseScenario(input);
+  if (!parsed.success) {
+    throw new Error(`Invalid scenario: ${parsed.error.message}`);
+  }
+  const scenario = parsed.data;
+
+  const simulation = new Simulation(scenario, options.deps);
+  const result = await simulation.run();
+
+  const metrics = measure(result);
+  const runId = randomUUID();
+  const generatedAt = options.deps.clock.now().toISOString();
+  const artifacts = toArtifacts(runId, generatedAt, metrics, result.events);
+
+  const artifactPaths = options.artifactsDir
+    ? await writeArtifacts(options.artifactsDir, artifacts)
+    : undefined;
+
+  return { metrics, artifacts, artifactPaths };
+}

--- a/src/harness/scenario.ts
+++ b/src/harness/scenario.ts
@@ -9,17 +9,32 @@
 
 import { z } from 'zod';
 
-/** Config for the synthetic population a scenario seeds before running. */
-export const PopulationConfigSchema = z.object({
-  /** How many synthetic subscribers (governance voters) to seed. */
-  subscriberCount: z.number().int().min(1).max(2000).default(30),
-  /** How many synthetic posts to seed into the scoring window. */
-  postCount: z.number().int().min(0).max(5000).default(50),
-  /** Fraction of subscribers who cast a weight vote (0..1). */
-  voteParticipationRate: z.number().min(0).max(1).default(0.8),
-  /** Fraction of voters who additionally cast a content (keyword) vote. */
-  contentVoteRate: z.number().min(0).max(1).default(0.2),
-});
+/**
+ * Config for the synthetic population a scenario seeds before running.
+ *
+ * `.strict()` (not the Zod-object default `.strip()`): a typo like
+ * `subscriberCont` must surface as a validation error at the boundary, not
+ * be silently dropped in favor of the default — that would defeat the whole
+ * point of validating untrusted config before it reaches `Simulation`.
+ */
+export const PopulationConfigSchema = z
+  .object({
+    /** How many synthetic subscribers (governance voters) to seed. */
+    subscriberCount: z.number().int().min(1).max(2000).default(30),
+    /** How many synthetic posts to seed into the scoring window. */
+    postCount: z.number().int().min(0).max(5000).default(50),
+    /** Fraction of subscribers who cast a weight vote (0..1). */
+    voteParticipationRate: z.number().min(0).max(1).default(0.8),
+    /** Fraction of voters who additionally cast a content (keyword) vote. */
+    contentVoteRate: z.number().min(0).max(1).default(0.2),
+    /**
+     * Fraction of participating voters who cast an actual weight opinion
+     * (0..1). The remainder cast a keyword-only vote (`VoteSeed.weights:
+     * null` — see population.ts).
+     */
+    castsWeightVoteRate: z.number().min(0).max(1).default(0.9),
+  })
+  .strict();
 export type PopulationConfig = z.infer<typeof PopulationConfigSchema>;
 
 const baseFields = {
@@ -32,26 +47,30 @@ const baseFields = {
  * new scenario shapes can be added later without breaking existing callers.
  */
 export const ScenarioV1Schema = z.discriminatedUnion('kind', [
-  z.object({
-    kind: z.literal('epoch-vote-cycle'),
-    version: z.literal(1),
-    ...baseFields,
-  }),
-  z.object({
-    kind: z.literal('multi-epoch-cycle'),
-    version: z.literal(1),
-    /**
-     * How many aggregate→transition→score cycles to run back to back.
-     *
-     * Reserved shape: `parseScenario()` accepts this today, but
-     * `Simulation.run()` (simulation.ts) does not yet implement a
-     * multi-round driver and throws rather than silently running just one
-     * round. Implement the loop in `Simulation.run()` before removing that
-     * guard.
-     */
-    rounds: z.number().int().min(1).max(20),
-    ...baseFields,
-  }),
+  z
+    .object({
+      kind: z.literal('epoch-vote-cycle'),
+      version: z.literal(1),
+      ...baseFields,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('multi-epoch-cycle'),
+      version: z.literal(1),
+      /**
+       * How many aggregate→transition→score cycles to run back to back.
+       *
+       * Reserved shape: `parseScenario()` accepts this today, but
+       * `Simulation.run()` (simulation.ts) does not yet implement a
+       * multi-round driver and throws rather than silently running just one
+       * round. Implement the loop in `Simulation.run()` before removing that
+       * guard.
+       */
+      rounds: z.number().int().min(1).max(20),
+      ...baseFields,
+    })
+    .strict(),
 ]);
 
 export type ScenarioV1 = z.infer<typeof ScenarioV1Schema>;

--- a/src/harness/scenario.ts
+++ b/src/harness/scenario.ts
@@ -1,0 +1,76 @@
+/**
+ * Scenario Schemas
+ *
+ * A `Scenario` is the harness's typed, versioned configuration surface.
+ * Every entrypoint validates untrusted input with `.safeParse()` at the
+ * boundary — invalid config never reaches `Simulation`. Breaking shape
+ * changes get a new version (`ScenarioV2`, ...) rather than mutating V1.
+ */
+
+import { z } from 'zod';
+
+/** Config for the synthetic population a scenario seeds before running. */
+export const PopulationConfigSchema = z.object({
+  /** How many synthetic subscribers (governance voters) to seed. */
+  subscriberCount: z.number().int().min(1).max(2000).default(30),
+  /** How many synthetic posts to seed into the scoring window. */
+  postCount: z.number().int().min(0).max(5000).default(50),
+  /** Fraction of subscribers who cast a weight vote (0..1). */
+  voteParticipationRate: z.number().min(0).max(1).default(0.8),
+  /** Fraction of voters who additionally cast a content (keyword) vote. */
+  contentVoteRate: z.number().min(0).max(1).default(0.2),
+});
+export type PopulationConfig = z.infer<typeof PopulationConfigSchema>;
+
+const baseFields = {
+  seed: z.number().int().nonnegative(),
+  population: PopulationConfigSchema.default({}),
+};
+
+/**
+ * ScenarioV1: the only version today. A discriminated union on `kind` so
+ * new scenario shapes can be added later without breaking existing callers.
+ */
+export const ScenarioV1Schema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('epoch-vote-cycle'),
+    version: z.literal(1),
+    ...baseFields,
+  }),
+  z.object({
+    kind: z.literal('multi-epoch-cycle'),
+    version: z.literal(1),
+    /**
+     * How many aggregate→transition→score cycles to run back to back.
+     *
+     * Reserved shape: `parseScenario()` accepts this today, but
+     * `Simulation.run()` (simulation.ts) does not yet implement a
+     * multi-round driver and throws rather than silently running just one
+     * round. Implement the loop in `Simulation.run()` before removing that
+     * guard.
+     */
+    rounds: z.number().int().min(1).max(20),
+    ...baseFields,
+  }),
+]);
+
+export type ScenarioV1 = z.infer<typeof ScenarioV1Schema>;
+
+/** Current scenario type alias. Update when a `ScenarioV2` is introduced. */
+export type Scenario = ScenarioV1;
+
+export type ParseScenarioResult =
+  | { success: true; data: Scenario }
+  | { success: false; error: z.ZodError };
+
+/**
+ * Validate untrusted scenario input. Never throws — callers pattern-match on
+ * `{ success, data } | { success: false, error }`.
+ */
+export function parseScenario(input: unknown): ParseScenarioResult {
+  const result = ScenarioV1Schema.safeParse(input);
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+  return { success: false, error: result.error };
+}

--- a/src/harness/simulation.ts
+++ b/src/harness/simulation.ts
@@ -45,6 +45,43 @@ export interface SimulationDeps {
   /** Connection string backing the production Redis singleton — checked by the prod-guard. */
   redisUrl: string;
   guard?: GuardOptions;
+  /**
+   * Bounded timeout (ms) applied to each of the three real-pipeline steps
+   * (aggregateVotes / forceEpochTransition / runScoringPipeline). Defaults to
+   * `DEFAULT_PIPELINE_STEP_TIMEOUT_MS`. A hung call against a misbehaving
+   * Testcontainers instance fails fast with a diagnosable error instead of
+   * blocking the whole run (and any CI job driving it) indefinitely.
+   */
+  pipelineStepTimeoutMs?: number;
+}
+
+/** Default bound for `SimulationDeps.pipelineStepTimeoutMs` — see its doc. */
+export const DEFAULT_PIPELINE_STEP_TIMEOUT_MS = 30_000;
+
+/**
+ * Race `promise` against a timer. Rejects with a diagnosable error naming
+ * `label` if `promise` hasn't settled within `timeoutMs` — never silently
+ * swallows the underlying error, and never leaves a dangling timer.
+ */
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new Error(
+          `Simulation.run(): "${label}" did not complete within ${timeoutMs}ms — it may be hung ` +
+            'against a misbehaving Postgres/Redis/Testcontainers instance. Failing fast instead of ' +
+            'blocking indefinitely.'
+        )
+      );
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export interface SimulationEvent {
@@ -106,6 +143,53 @@ async function ensureActiveEpoch(db: QueryableDb): Promise<number> {
   return inserted.rows[0].id;
 }
 
+/** Max rows per batched `INSERT ... VALUES (...),(...)` — keeps a single
+ *  query's parameter count (`rows * columnsPerRow`) well under Postgres's
+ *  65535 bound and query text to a sane size, even at this harness's max
+ *  population sizes (2000 subscribers / 5000 posts). */
+const INSERT_BATCH_SIZE = 500;
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/** Build a `($1, $2), ($3, $4), ...` VALUES clause for `rowCount` rows of
+ *  `colCount` columns each, numbered starting at `offset + 1`. */
+function valuesClause(rowCount: number, colCount: number, offset: number): string {
+  const rows: string[] = [];
+  for (let r = 0; r < rowCount; r++) {
+    const base = offset + r * colCount;
+    const placeholders = Array.from({ length: colCount }, (_, c) => `$${base + c + 1}`);
+    rows.push(`(${placeholders.join(', ')})`);
+  }
+  return rows.join(', ');
+}
+
+/**
+ * Insert `items` in chunks of `INSERT_BATCH_SIZE`, each chunk as one
+ * multi-row `INSERT ... VALUES (...),(...)` round trip instead of one
+ * round trip per row. `buildQuery` receives the chunk and its param offset
+ * (always 0 here — kept as a parameter so `valuesClause` stays reusable if
+ * a caller ever needs to combine a batch with other leading params).
+ */
+async function insertBatched<T>(
+  db: QueryableDb,
+  items: readonly T[],
+  buildQuery: (batch: T[], offset: number) => { text: string; params: unknown[] }
+): Promise<void> {
+  for (const batch of chunk(items, INSERT_BATCH_SIZE)) {
+    if (batch.length === 0) {
+      continue;
+    }
+    const { text, params } = buildQuery(batch, 0);
+    await db.query(text, params);
+  }
+}
+
 export class Simulation {
   constructor(
     private readonly scenario: Scenario,
@@ -162,9 +246,15 @@ export class Simulation {
     });
     record('population_seeded', { epochId: epochBeforeId });
 
+    const timeoutMs = this.deps.pipelineStepTimeoutMs ?? DEFAULT_PIPELINE_STEP_TIMEOUT_MS;
+
     // 1. Drive the REAL vote aggregation so the harness observes exactly
     //    what the production governance engine computes from the seeded votes.
-    const aggregatedWeights = await aggregateVotes(epochBeforeId);
+    const aggregatedWeights = await withTimeout(
+      aggregateVotes(epochBeforeId),
+      timeoutMs,
+      'aggregateVotes'
+    );
     if (!aggregatedWeights) {
       throw new Error(
         `aggregateVotes(${epochBeforeId}) returned null — no eligible weight votes were seeded. ` +
@@ -178,14 +268,14 @@ export class Simulation {
     //    synthetic populations still transition deterministically; it
     //    internally re-runs aggregateVotes/aggregateContentVotes and, on a
     //    best-effort basis, one scoring pass for its transition-impact audit.
-    const epochAfterId = await forceEpochTransition();
+    const epochAfterId = await withTimeout(forceEpochTransition(), timeoutMs, 'forceEpochTransition');
     record('epoch_transitioned', { fromEpochId: epochBeforeId, toEpochId: epochAfterId });
 
     // 3. Drive the REAL scoring pipeline as its own explicit, awaited step —
     //    decoupled from step 2's best-effort internal invocation, so a
     //    scoring failure here surfaces as a simulation failure rather than
     //    a swallowed warning.
-    await runScoringPipeline();
+    await withTimeout(runScoringPipeline(), timeoutMs, 'runScoringPipeline');
     record('scoring_pipeline_run', { epochId: epochAfterId });
 
     const topPosts = await this.fetchTopScoredPosts(epochAfterId, 50);
@@ -213,39 +303,60 @@ export class Simulation {
   ): Promise<void> {
     const { db } = this.deps;
 
-    for (const subscriber of population.subscribers) {
-      await db.query(`INSERT INTO subscribers (did) VALUES ($1) ON CONFLICT (did) DO NOTHING`, [
-        subscriber.did,
-      ]);
-    }
+    // Subscribers and posts/engagement are batched (multi-row `INSERT ...
+    // VALUES (...),(...)`) rather than one awaited round trip per row — see
+    // `insertBatched` below. Votes stay per-row: each insert's `RETURNING id`
+    // feeds a per-row dual-write (see the TODO in that loop for why batching
+    // it isn't a clean, semantics-preserving change today.
+    await insertBatched(
+      db,
+      population.subscribers,
+      (batch, offset) => ({
+        text: `INSERT INTO subscribers (did) VALUES ${valuesClause(batch.length, 1, offset)} ON CONFLICT (did) DO NOTHING`,
+        params: batch.map((subscriber) => subscriber.did),
+      })
+    );
 
-    for (const post of population.posts) {
-      await db.query(
-        `INSERT INTO posts (uri, cid, author_did, text, created_at, has_media, embed_url, topic_vector)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-         ON CONFLICT (uri) DO NOTHING`,
-        [
-          post.uri,
-          post.cid,
-          post.authorDid,
-          post.text,
-          post.createdAt.toISOString(),
-          post.hasMedia,
-          post.embedUrl,
-          JSON.stringify(post.topicVector),
-        ]
-      );
-      await db.query(
-        `INSERT INTO post_engagement (post_uri, like_count, repost_count, reply_count)
-         VALUES ($1, $2, $3, $4)
-         ON CONFLICT (post_uri) DO UPDATE SET
-           like_count = EXCLUDED.like_count,
-           repost_count = EXCLUDED.repost_count,
-           reply_count = EXCLUDED.reply_count`,
-        [post.uri, post.likeCount, post.repostCount, post.replyCount]
-      );
-    }
+    await insertBatched(db, population.posts, (batch, offset) => ({
+      text: `INSERT INTO posts (uri, cid, author_did, text, created_at, has_media, embed_url, topic_vector)
+             VALUES ${valuesClause(batch.length, 8, offset)}
+             ON CONFLICT (uri) DO NOTHING`,
+      params: batch.flatMap((post) => [
+        post.uri,
+        post.cid,
+        post.authorDid,
+        post.text,
+        post.createdAt.toISOString(),
+        post.hasMedia,
+        post.embedUrl,
+        JSON.stringify(post.topicVector),
+      ]),
+    }));
 
+    await insertBatched(db, population.posts, (batch, offset) => ({
+      text: `INSERT INTO post_engagement (post_uri, like_count, repost_count, reply_count)
+             VALUES ${valuesClause(batch.length, 4, offset)}
+             ON CONFLICT (post_uri) DO UPDATE SET
+               like_count = EXCLUDED.like_count,
+               repost_count = EXCLUDED.repost_count,
+               reply_count = EXCLUDED.reply_count`,
+      params: batch.flatMap((post) => [post.uri, post.likeCount, post.repostCount, post.replyCount]),
+    }));
+
+    // NOT batched (unlike subscribers/posts/post_engagement above): each
+    // insert's `RETURNING id` drives a per-row dual-write into the
+    // governance_vote_weights long table below, and this insert has an
+    // `ON CONFLICT (voter_did, epoch_id) DO NOTHING`. A batched multi-row
+    // `INSERT ... RETURNING` does not reliably let you correlate returned
+    // rows back to specific input rows once some of those rows are skipped
+    // by the conflict clause — silently mis-attributing (or dropping) a
+    // dual-write would be a correctness regression, not just a perf one.
+    // TODO(A2/A3): revisit once population-scale vote volumes make this a
+    // real bottleneck — likely needs either an `unnest($1::text[], ...)`
+    // form that returns `(input_index, id)` pairs, or dropping the
+    // `ON CONFLICT DO NOTHING` guard (votes are already unique per
+    // `generateVotes()` participant, so it's only a defense-in-depth no-op
+    // in a single harness run).
     for (const vote of population.votes) {
       if (!vote.weights) {
         continue;

--- a/src/harness/simulation.ts
+++ b/src/harness/simulation.ts
@@ -1,0 +1,299 @@
+/**
+ * Simulation
+ *
+ * Drives the REAL Corgi governance/scoring engine (aggregateVotes, an epoch
+ * transition, runScoringPipeline) against injected Postgres/Redis. This is
+ * the "drive" half of the harness — `metrics.ts` is the "measure" half.
+ * Keeping them separate mirrors the DST system/simulator/observer split:
+ * `Simulation` never computes metrics itself, it only produces a raw event
+ * log that `measure()` turns into a `RunMetrics` snapshot.
+ *
+ * The governance/scoring modules (`src/governance/*`, `src/scoring/pipeline.js`)
+ * are imported dynamically inside `run()`, AFTER the prod-guard check, rather
+ * than statically at module top. Two reasons:
+ *   1. Those modules transitively import `src/config.ts` (parses `process.env`
+ *      at import time) and `src/db/redis.ts` (opens a TCP connection as an
+ *      import side effect — see docs/agent build-bible §6). Deferring the
+ *      import means constructing a `Simulation` never has that side effect;
+ *      only calling `.run()` does, and only after the guard has already
+ *      passed.
+ *   2. It keeps `src/harness/index.ts` — not this file — as the sole
+ *      externally-imported surface: nothing outside the harness needs to
+ *      know these modules exist.
+ */
+
+import type { Rng, Clock } from './rng.js';
+import type { Scenario } from './scenario.js';
+import { generatePopulation, type Population } from './population.js';
+import { assertEphemeralPostgresUrl, assertEphemeralRedisUrl, type GuardOptions } from './prod-guard.js';
+import { createDefaultGovernanceWeightRecord } from '../config/votable-params.js';
+import { weightsToVotePayload } from '../governance/governance.types.js';
+import type { GovernanceWeights } from '../shared/api-types.js';
+
+/** Minimal query surface `Simulation` needs to seed its own synthetic data. */
+export interface QueryableDb {
+  query<T = Record<string, unknown>>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+export interface SimulationDeps {
+  rng: Rng;
+  clock: Clock;
+  /** Used only for the harness's own population-seeding queries. */
+  db: QueryableDb;
+  /** Connection string backing `db` — checked by the prod-guard. */
+  databaseUrl: string;
+  /** Connection string backing the production Redis singleton — checked by the prod-guard. */
+  redisUrl: string;
+  guard?: GuardOptions;
+}
+
+export interface SimulationEvent {
+  /** Simulated-time ISO timestamp (from the injected Clock, not wall clock). */
+  at: string;
+  type: string;
+  data?: Record<string, unknown>;
+}
+
+export interface TopScoredPost {
+  uri: string;
+  rank: number;
+  totalScore: number;
+}
+
+export interface SimulationResult {
+  scenario: Scenario;
+  population: Population;
+  epochBeforeId: number;
+  epochAfterId: number;
+  aggregatedWeights: GovernanceWeights;
+  scoredPostCount: number;
+  topPosts: TopScoredPost[];
+  events: SimulationEvent[];
+}
+
+/**
+ * Seed the first governance epoch with equal default weights (mirrors
+ * `scripts/seed-governance.ts`'s bootstrap, but driven from the
+ * registry-derived default record so a 6th registered component doesn't
+ * silently drift). No-ops if an active/voting epoch already exists.
+ */
+async function ensureActiveEpoch(db: QueryableDb): Promise<number> {
+  const existing = await db.query<{ id: number }>(
+    `SELECT id FROM governance_epochs WHERE status IN ('active', 'voting') ORDER BY id DESC LIMIT 1`
+  );
+  if (existing.rows[0]) {
+    return existing.rows[0].id;
+  }
+
+  const defaults = createDefaultGovernanceWeightRecord() as GovernanceWeights;
+  const payload = weightsToVotePayload(defaults);
+
+  const inserted = await db.query<{ id: number }>(
+    `INSERT INTO governance_epochs (
+      status, recency_weight, engagement_weight, bridging_weight,
+      source_diversity_weight, relevance_weight, vote_count, description
+    ) VALUES ('active', $1, $2, $3, $4, $5, 0, 'A1 simulation harness bootstrap epoch')
+    RETURNING id`,
+    [
+      payload.recency_weight,
+      payload.engagement_weight,
+      payload.bridging_weight,
+      payload.source_diversity_weight,
+      payload.relevance_weight,
+    ]
+  );
+
+  return inserted.rows[0].id;
+}
+
+export class Simulation {
+  constructor(
+    private readonly scenario: Scenario,
+    private readonly deps: SimulationDeps
+  ) {}
+
+  async run(): Promise<SimulationResult> {
+    assertEphemeralPostgresUrl(this.deps.databaseUrl, this.deps.guard);
+    assertEphemeralRedisUrl(this.deps.redisUrl, this.deps.guard);
+
+    // `ScenarioV1Schema` (scenario.ts) accepts `kind: 'multi-epoch-cycle'`
+    // (with a `rounds` field) as a documented future shape, but this class
+    // only ever drives a single aggregate -> transition -> score cycle today.
+    // Without this check, a `multi-epoch-cycle` scenario would silently run
+    // exactly one round — `rounds` quietly ignored — and still report
+    // `scenarioKind: 'multi-epoch-cycle'` in its metrics, which would be a
+    // convincing but wrong signal. Fail fast and loud instead until a real
+    // multi-round driver is implemented.
+    if (this.scenario.kind !== 'epoch-vote-cycle') {
+      throw new Error(
+        `Simulation.run(): scenario kind "${this.scenario.kind}" is not yet implemented. ` +
+          `Only "epoch-vote-cycle" drives a real cycle today; "multi-epoch-cycle" is a ` +
+          `reserved future shape (see src/harness/scenario.ts).`
+      );
+    }
+
+    // Deferred import — see file header for why this must not be static.
+    const { aggregateVotes } = await import('../governance/aggregation.js');
+    const { forceEpochTransition } = await import('../governance/epoch-manager.js');
+    const { runScoringPipeline, __resetPipelineState } = await import('../scoring/pipeline.js');
+    const { writeVoteWeights } = await import('../governance/weight-longtable.js');
+    const { config } = await import('../config.js');
+
+    __resetPipelineState();
+
+    const events: SimulationEvent[] = [];
+    const record = (type: string, data?: Record<string, unknown>): void => {
+      events.push({ at: this.deps.clock.now().toISOString(), type, data });
+    };
+
+    const epochBeforeId = await ensureActiveEpoch(this.deps.db);
+    record('epoch_ensured', { epochId: epochBeforeId });
+
+    const population = generatePopulation(this.deps.rng, this.deps.clock, this.scenario.population);
+    record('population_generated', {
+      subscriberCount: population.subscribers.length,
+      postCount: population.posts.length,
+      voteCount: population.votes.length,
+    });
+
+    await this.seedPopulation(population, epochBeforeId, {
+      writeVoteWeights,
+      dualWriteEnabled: config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED,
+    });
+    record('population_seeded', { epochId: epochBeforeId });
+
+    // 1. Drive the REAL vote aggregation so the harness observes exactly
+    //    what the production governance engine computes from the seeded votes.
+    const aggregatedWeights = await aggregateVotes(epochBeforeId);
+    if (!aggregatedWeights) {
+      throw new Error(
+        `aggregateVotes(${epochBeforeId}) returned null — no eligible weight votes were seeded. ` +
+          'Increase population.subscriberCount / voteParticipationRate.'
+      );
+    }
+    record('votes_aggregated', { epochId: epochBeforeId, weights: aggregatedWeights });
+
+    // 2. Drive the REAL epoch-transition op. `forceEpochTransition` (rather
+    //    than the vote-count-gated `triggerEpochTransition`) is used so small
+    //    synthetic populations still transition deterministically; it
+    //    internally re-runs aggregateVotes/aggregateContentVotes and, on a
+    //    best-effort basis, one scoring pass for its transition-impact audit.
+    const epochAfterId = await forceEpochTransition();
+    record('epoch_transitioned', { fromEpochId: epochBeforeId, toEpochId: epochAfterId });
+
+    // 3. Drive the REAL scoring pipeline as its own explicit, awaited step —
+    //    decoupled from step 2's best-effort internal invocation, so a
+    //    scoring failure here surfaces as a simulation failure rather than
+    //    a swallowed warning.
+    await runScoringPipeline();
+    record('scoring_pipeline_run', { epochId: epochAfterId });
+
+    const topPosts = await this.fetchTopScoredPosts(epochAfterId, 50);
+    record('top_posts_fetched', { epochId: epochAfterId, count: topPosts.length });
+
+    return {
+      scenario: this.scenario,
+      population,
+      epochBeforeId,
+      epochAfterId,
+      aggregatedWeights,
+      scoredPostCount: topPosts.length,
+      topPosts,
+      events,
+    };
+  }
+
+  private async seedPopulation(
+    population: Population,
+    epochId: number,
+    voteWeightDualWrite: {
+      writeVoteWeights: (voteId: string, weights: GovernanceWeights) => Promise<void>;
+      dualWriteEnabled: boolean;
+    }
+  ): Promise<void> {
+    const { db } = this.deps;
+
+    for (const subscriber of population.subscribers) {
+      await db.query(`INSERT INTO subscribers (did) VALUES ($1) ON CONFLICT (did) DO NOTHING`, [
+        subscriber.did,
+      ]);
+    }
+
+    for (const post of population.posts) {
+      await db.query(
+        `INSERT INTO posts (uri, cid, author_did, text, created_at, has_media, embed_url, topic_vector)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT (uri) DO NOTHING`,
+        [
+          post.uri,
+          post.cid,
+          post.authorDid,
+          post.text,
+          post.createdAt.toISOString(),
+          post.hasMedia,
+          post.embedUrl,
+          JSON.stringify(post.topicVector),
+        ]
+      );
+      await db.query(
+        `INSERT INTO post_engagement (post_uri, like_count, repost_count, reply_count)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (post_uri) DO UPDATE SET
+           like_count = EXCLUDED.like_count,
+           repost_count = EXCLUDED.repost_count,
+           reply_count = EXCLUDED.reply_count`,
+        [post.uri, post.likeCount, post.repostCount, post.replyCount]
+      );
+    }
+
+    for (const vote of population.votes) {
+      if (!vote.weights) {
+        continue;
+      }
+      const inserted = await db.query<{ id: string }>(
+        `INSERT INTO governance_votes (
+          voter_did, epoch_id,
+          recency_weight, engagement_weight, bridging_weight,
+          source_diversity_weight, relevance_weight,
+          include_keywords, exclude_keywords
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        ON CONFLICT (voter_did, epoch_id) DO NOTHING
+        RETURNING id`,
+        [
+          vote.voterDid,
+          epochId,
+          vote.weights.recency,
+          vote.weights.engagement,
+          vote.weights.bridging,
+          vote.weights.sourceDiversity,
+          vote.weights.relevance,
+          vote.includeKeywords,
+          vote.excludeKeywords,
+        ]
+      );
+
+      // Mirror src/governance/routes/vote.ts's dual-write exactly: aggregateVotes
+      // reads from the governance_vote_weights long table (not the wide columns
+      // just inserted above) whenever GOVERNANCE_LONGTABLE_READ_ENABLED is on
+      // (the production default) — without this, seeded votes would be
+      // invisible to the real aggregateVotes the harness is driving.
+      const voteId = inserted.rows[0]?.id;
+      if (voteId && voteWeightDualWrite.dualWriteEnabled) {
+        await voteWeightDualWrite.writeVoteWeights(voteId, vote.weights);
+      }
+    }
+  }
+
+  private async fetchTopScoredPosts(epochId: number, limit: number): Promise<TopScoredPost[]> {
+    const result = await this.deps.db.query<{ post_uri: string; total_score: number | string }>(
+      `SELECT post_uri, total_score FROM post_scores WHERE epoch_id = $1 ORDER BY total_score DESC, post_uri ASC LIMIT $2`,
+      [epochId, limit]
+    );
+
+    return result.rows.map((row, index) => ({
+      uri: row.post_uri,
+      rank: index + 1,
+      totalScore: Number(row.total_score),
+    }));
+  }
+}

--- a/tests/harness/__golden__/epoch-vote-cycle-seed-42.metrics.json
+++ b/tests/harness/__golden__/epoch-vote-cycle-seed-42.metrics.json
@@ -1,0 +1,82 @@
+{
+  "scenarioKind": "epoch-vote-cycle",
+  "scenarioVersion": 1,
+  "seed": 42,
+  "codeVersion": "1.0.0",
+  "population": {
+    "subscriberCount": 8,
+    "postCount": 10,
+    "voteCount": 8
+  },
+  "aggregation": {
+    "epochId": 1,
+    "weights": {
+      "recency": 0.185,
+      "engagement": 0.258,
+      "bridging": 0.166,
+      "sourceDiversity": 0.132,
+      "relevance": 0.259
+    },
+    "weightSum": 1
+  },
+  "transition": {
+    "fromEpochId": 1,
+    "toEpochId": 2
+  },
+  "scoring": {
+    "epochId": 2,
+    "scoredPostCount": 10,
+    "topPosts": [
+      {
+        "uri": "at://did:plc:corgisimsub000002/app.bsky.feed.post/corgisimpost000002",
+        "rank": 1,
+        "totalScore": 0.556009
+      },
+      {
+        "uri": "at://did:plc:corgisimsub000007/app.bsky.feed.post/corgisimpost000007",
+        "rank": 2,
+        "totalScore": 0.481346
+      },
+      {
+        "uri": "at://did:plc:corgisimsub000005/app.bsky.feed.post/corgisimpost000005",
+        "rank": 3,
+        "totalScore": 0.474891
+      },
+      {
+        "uri": "at://did:plc:corgisimsub000001/app.bsky.feed.post/corgisimpost000001",
+        "rank": 4,
+        "totalScore": 0.466578
+      },
+      {
+        "uri": "at://did:plc:corgisimsub000006/app.bsky.feed.post/corgisimpost000006",
+        "rank": 5,
+        "totalScore": 0.447153
+      },
+      {
+        "uri": "at://did:plc:corgisimsub000000/app.bsky.feed.post/corgisimpost000008",
+        "rank": 6,
+        "totalScore": 0.429241
+      },
+      {
+        "uri": "at://did:plc:corgisimsub000004/app.bsky.feed.post/corgisimpost000004",
+        "rank": 7,
+        "totalScore": 0.422598
+      },
+      {
+        "uri": "at://did:plc:corgisimsub000003/app.bsky.feed.post/corgisimpost000003",
+        "rank": 8,
+        "totalScore": 0.389242
+      },
+      {
+        "uri": "at://did:plc:corgisimsub000000/app.bsky.feed.post/corgisimpost000000",
+        "rank": 9,
+        "totalScore": 0.383067
+      },
+      {
+        "uri": "at://did:plc:corgisimsub000001/app.bsky.feed.post/corgisimpost000009",
+        "rank": 10,
+        "totalScore": 0.3699
+      }
+    ]
+  }
+}

--- a/tests/harness/__golden__/epoch-vote-cycle-seed-42.metrics.json
+++ b/tests/harness/__golden__/epoch-vote-cycle-seed-42.metrics.json
@@ -11,11 +11,11 @@
   "aggregation": {
     "epochId": 1,
     "weights": {
-      "recency": 0.185,
-      "engagement": 0.258,
-      "bridging": 0.166,
-      "sourceDiversity": 0.132,
-      "relevance": 0.259
+      "recency": 0.234,
+      "engagement": 0.196,
+      "bridging": 0.24,
+      "sourceDiversity": 0.181,
+      "relevance": 0.149
     },
     "weightSum": 1
   },
@@ -30,52 +30,52 @@
       {
         "uri": "at://did:plc:corgisimsub000002/app.bsky.feed.post/corgisimpost000002",
         "rank": 1,
-        "totalScore": 0.556009
+        "totalScore": 0.613363
       },
       {
         "uri": "at://did:plc:corgisimsub000007/app.bsky.feed.post/corgisimpost000007",
         "rank": 2,
-        "totalScore": 0.481346
+        "totalScore": 0.514218
       },
       {
         "uri": "at://did:plc:corgisimsub000005/app.bsky.feed.post/corgisimpost000005",
         "rank": 3,
-        "totalScore": 0.474891
+        "totalScore": 0.507584
       },
       {
         "uri": "at://did:plc:corgisimsub000001/app.bsky.feed.post/corgisimpost000001",
         "rank": 4,
-        "totalScore": 0.466578
+        "totalScore": 0.506529
       },
       {
         "uri": "at://did:plc:corgisimsub000006/app.bsky.feed.post/corgisimpost000006",
         "rank": 5,
-        "totalScore": 0.447153
+        "totalScore": 0.473313
       },
       {
         "uri": "at://did:plc:corgisimsub000000/app.bsky.feed.post/corgisimpost000008",
         "rank": 6,
-        "totalScore": 0.429241
+        "totalScore": 0.449319
       },
       {
         "uri": "at://did:plc:corgisimsub000004/app.bsky.feed.post/corgisimpost000004",
         "rank": 7,
-        "totalScore": 0.422598
+        "totalScore": 0.44198
       },
       {
         "uri": "at://did:plc:corgisimsub000003/app.bsky.feed.post/corgisimpost000003",
         "rank": 8,
-        "totalScore": 0.389242
+        "totalScore": 0.410074
       },
       {
         "uri": "at://did:plc:corgisimsub000000/app.bsky.feed.post/corgisimpost000000",
         "rank": 9,
-        "totalScore": 0.383067
+        "totalScore": 0.389785
       },
       {
         "uri": "at://did:plc:corgisimsub000001/app.bsky.feed.post/corgisimpost000009",
         "rank": 10,
-        "totalScore": 0.3699
+        "totalScore": 0.370049
       }
     ]
   }

--- a/tests/harness/global-setup.ts
+++ b/tests/harness/global-setup.ts
@@ -78,7 +78,10 @@ export default async function setup(project: TestProject): Promise<() => Promise
     project.provide('corgiSimPgUrl', databaseUrl);
     project.provide('corgiSimRedisUrl', redisUrl);
   } catch (error) {
-    await stopAll(pg, redis);
+    // Best-effort cleanup — never let a container-stop failure replace the real
+    // setup/migration error that CI needs to diagnose. The original error always
+    // propagates; any stop failure is swallowed here (Ryuk remains the backstop).
+    await stopAll(pg, redis).catch(() => {});
     throw error;
   }
 

--- a/tests/harness/global-setup.ts
+++ b/tests/harness/global-setup.ts
@@ -20,26 +20,72 @@ import { runMigrations } from '../../scripts/migrate.js';
 // Ambient `ProvidedContext` augmentation lives in ./vitest-provided-context.d.ts
 // (a type-only declaration file — nothing to import at runtime).
 
+/** Stop whichever of the two containers actually started, tolerating either
+ *  (or both) already being stopped/never-started/failed-to-stop — used both
+ *  on the setup-failure path and in the normal teardown below, so a leaked
+ *  container is never left behind just because its sibling errored. */
+async function stopAll(
+  pg: StartedPostgreSqlContainer | undefined,
+  redis: StartedRedisContainer | undefined
+): Promise<void> {
+  const results = await Promise.allSettled([pg?.stop(), redis?.stop()]);
+  const rejected = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  );
+  if (rejected) {
+    throw rejected.reason;
+  }
+}
+
 export default async function setup(project: TestProject): Promise<() => Promise<void>> {
-  const [pg, redis]: [StartedPostgreSqlContainer, StartedRedisContainer] = await Promise.all([
-    new PostgreSqlContainer('postgres:16')
-      .withDatabase('corgi_sim_test')
-      .withUsername('corgi_sim')
-      .withPassword('corgi_sim')
-      .start(),
-    new RedisContainer('redis:7-alpine').start(),
-  ]);
+  let pg: StartedPostgreSqlContainer | undefined;
+  let redis: StartedRedisContainer | undefined;
 
-  const databaseUrl = pg.getConnectionUri();
-  const redisUrl = redis.getConnectionUrl();
+  try {
+    // Started via allSettled (not Promise.all) so that if one container
+    // fails to start, we still know whether the OTHER one came up — and can
+    // stop it in the catch block below instead of leaking it. Testcontainers'
+    // Ryuk reaper is a backstop, not something routine setup failures during
+    // CI/local iteration should have to rely on.
+    const [pgResult, redisResult] = await Promise.allSettled([
+      new PostgreSqlContainer('postgres:16')
+        .withDatabase('corgi_sim_test')
+        .withUsername('corgi_sim')
+        .withPassword('corgi_sim')
+        .start(),
+      new RedisContainer('redis:7-alpine').start(),
+    ]);
 
-  // Real migrations, real engine — not a schema-recreate hack.
-  await runMigrations(databaseUrl);
+    if (pgResult.status === 'fulfilled') {
+      pg = pgResult.value;
+    }
+    if (redisResult.status === 'fulfilled') {
+      redis = redisResult.value;
+    }
+    if (pgResult.status === 'rejected') {
+      throw pgResult.reason;
+    }
+    if (redisResult.status === 'rejected') {
+      throw redisResult.reason;
+    }
 
-  project.provide('corgiSimPgUrl', databaseUrl);
-  project.provide('corgiSimRedisUrl', redisUrl);
+    const databaseUrl = pg.getConnectionUri();
+    const redisUrl = redis.getConnectionUrl();
+
+    // Real migrations, real engine — not a schema-recreate hack.
+    await runMigrations(databaseUrl);
+
+    project.provide('corgiSimPgUrl', databaseUrl);
+    project.provide('corgiSimRedisUrl', redisUrl);
+  } catch (error) {
+    await stopAll(pg, redis);
+    throw error;
+  }
 
   return async function teardown(): Promise<void> {
-    await Promise.all([pg.stop(), redis.stop()]);
+    // Promise.allSettled (not Promise.all): if `pg.stop()` rejects,
+    // `redis.stop()` must still be attempted — otherwise one failing
+    // teardown leaks the other container between test runs.
+    await stopAll(pg, redis);
   };
 }

--- a/tests/harness/global-setup.ts
+++ b/tests/harness/global-setup.ts
@@ -1,0 +1,45 @@
+/**
+ * Vitest globalSetup for the A1 simulation-harness integration suite.
+ *
+ * Starts real `postgres:16` + `redis` Testcontainers, runs the REAL
+ * migration runner (`scripts/migrate.ts`'s `runMigrations`) against the
+ * container so the suite exercises the same DDL path as production (never
+ * a schema-recreate hack, never pg-mem), then hands the connection URLs to
+ * every test file via `project.provide` / `inject`.
+ *
+ * Only wired up for `tests/harness/**` via `vitest.harness.config.ts` — the
+ * repo's default `npm test` (`vitest tests`, no config) never loads this
+ * file, so the existing fast/fully-mocked unit suite is unaffected.
+ */
+
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { RedisContainer, type StartedRedisContainer } from '@testcontainers/redis';
+import type { TestProject } from 'vitest/node';
+import { runMigrations } from '../../scripts/migrate.js';
+
+// Ambient `ProvidedContext` augmentation lives in ./vitest-provided-context.d.ts
+// (a type-only declaration file — nothing to import at runtime).
+
+export default async function setup(project: TestProject): Promise<() => Promise<void>> {
+  const [pg, redis]: [StartedPostgreSqlContainer, StartedRedisContainer] = await Promise.all([
+    new PostgreSqlContainer('postgres:16')
+      .withDatabase('corgi_sim_test')
+      .withUsername('corgi_sim')
+      .withPassword('corgi_sim')
+      .start(),
+    new RedisContainer('redis:7-alpine').start(),
+  ]);
+
+  const databaseUrl = pg.getConnectionUri();
+  const redisUrl = redis.getConnectionUrl();
+
+  // Real migrations, real engine — not a schema-recreate hack.
+  await runMigrations(databaseUrl);
+
+  project.provide('corgiSimPgUrl', databaseUrl);
+  project.provide('corgiSimRedisUrl', redisUrl);
+
+  return async function teardown(): Promise<void> {
+    await Promise.all([pg.stop(), redis.stop()]);
+  };
+}

--- a/tests/harness/golden-snapshot.sim.ts
+++ b/tests/harness/golden-snapshot.sim.ts
@@ -1,0 +1,57 @@
+/**
+ * Fixed-seed golden-snapshot smoke test.
+ *
+ * Runs the whole config -> run -> artifacts pipeline once, with a fixed seed
+ * and a frozen `Date` (so the real-wall-clock `recency` scoring component
+ * reads the same instant every run), and asserts the resulting `RunMetrics`
+ * exactly match a checked-in fixture. A snapshot diff here is a genuine
+ * whole-pipeline regression/drift signal — CI fails loudly on it, it is not
+ * a warning.
+ *
+ * Only `metrics` is snapshotted, not the full `RunArtifacts` envelope:
+ * `runId` (a fresh UUID) and `generatedAt` (wall-clock write time) are
+ * intentionally excluded from the deterministic surface — see metrics.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runScenario } from '../../src/harness/index.js';
+import { buildSimulationDeps, resetHarnessData, HARNESS_FIXED_CLOCK_MS } from './helpers.js';
+
+describe('golden snapshot: epoch-vote-cycle, seed=42', () => {
+  beforeEach(() => {
+    // Freeze real wall-clock Date so production's recency component (which
+    // reads Date.now() directly and is out of scope to edit) computes the
+    // same post age every run. Only `Date` is faked — setTimeout/setInterval
+    // stay real so Postgres/Redis I/O behaves normally.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(HARNESS_FIXED_CLOCK_MS));
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await resetHarnessData();
+  });
+
+  it('matches the checked-in golden metrics fixture', async () => {
+    const deps = buildSimulationDeps(42, HARNESS_FIXED_CLOCK_MS);
+
+    const { metrics } = await runScenario(
+      {
+        kind: 'epoch-vote-cycle',
+        version: 1,
+        seed: 42,
+        population: {
+          subscriberCount: 8,
+          postCount: 10,
+          voteParticipationRate: 1,
+          contentVoteRate: 0,
+        },
+      },
+      { deps }
+    );
+
+    await expect(JSON.stringify(metrics, null, 2)).toMatchFileSnapshot(
+      './__golden__/epoch-vote-cycle-seed-42.metrics.json'
+    );
+  });
+});

--- a/tests/harness/helpers.ts
+++ b/tests/harness/helpers.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared test-only helpers for the A1 simulation-harness integration suite.
+ *
+ * NOT imported by src/harness — this is test infrastructure, analogous to
+ * tests/stress/_helpers.ts (which also imports the real db/redis singletons
+ * directly rather than mocking, for the same reason: these are the one
+ * corner of the test suite meant to exercise real infrastructure).
+ *
+ * Must only be imported from a test file AFTER `setup-env.ts` (a vitest
+ * `setupFiles` entry) has already set `process.env.DATABASE_URL` /
+ * `REDIS_URL` — see that file's header comment for why ordering matters.
+ */
+
+import { db } from '../../src/db/client.js';
+import { redis } from '../../src/db/redis.js';
+import { createRng, SeededClock } from '../../src/harness/rng.js';
+import type { SimulationDeps } from '../../src/harness/simulation.js';
+
+/**
+ * Fixed simulated "now" used only by the golden-snapshot smoke test, paired
+ * there with `vi.useFakeTimers({ toFake: ['Date'] })` so recency scoring
+ * (real wall-clock `Date.now()`, not Clock-injected) reads this exact
+ * instant too, giving byte-for-byte reproducible scores independent of the
+ * real calendar date the suite runs on.
+ */
+export const HARNESS_FIXED_CLOCK_MS = Date.UTC(2026, 0, 1, 12, 0, 0);
+
+/**
+ * Default clock anchor: a real `Date.now()` read taken once, here in test
+ * setup — never inside `Simulation`/`population.ts`, which only ever see an
+ * already-constructed `Clock` and must stay pure functions of it. This is
+ * what production's `recency` scoring component (`src/scoring/components/
+ * recency.ts`) implicitly requires: it computes post age against the REAL
+ * wall clock (it isn't, and per the task, must not be, edited to take an
+ * injected Clock), so seeded posts need `created_at` timestamps close to
+ * real "now" to land inside `SCORING_WINDOW_HOURS` regardless of which
+ * calendar day the suite happens to run on.
+ *
+ * Tests that need byte-for-byte reproducibility independent of the actual
+ * wall-clock date (the golden-snapshot smoke test) instead pass a fixed
+ * `startMs` here AND freeze `Date` itself with `vi.useFakeTimers({ toFake:
+ * ['Date'] })` so recency scoring reads that same fixed instant too — see
+ * golden-snapshot.sim.ts.
+ */
+export function buildSimulationDeps(seed: number, startMs: number = Date.now()): SimulationDeps {
+  const databaseUrl = process.env.DATABASE_URL;
+  const redisUrl = process.env.REDIS_URL;
+  if (!databaseUrl || !redisUrl) {
+    throw new Error(
+      'DATABASE_URL/REDIS_URL are not set — was this test file loaded without ' +
+        'tests/harness/setup-env.ts as a vitest setupFiles entry?'
+    );
+  }
+
+  return {
+    rng: createRng(seed),
+    clock: new SeededClock(startMs),
+    db,
+    databaseUrl,
+    redisUrl,
+  };
+}
+
+/**
+ * Tables the harness itself writes to (population seeding + the real
+ * governance/scoring writes it drives). Truncated between tests so each
+ * test starts from a clean, epoch-free database.
+ */
+const HARNESS_TABLES = [
+  'post_score_components',
+  'post_scores',
+  'post_engagement',
+  'likes',
+  'reposts',
+  'follows',
+  'posts',
+  'governance_vote_weights',
+  'governance_epoch_weights',
+  'governance_votes',
+  'governance_audit_log',
+  'governance_epochs',
+  'subscribers',
+  'system_status',
+] as const;
+
+export async function resetHarnessData(): Promise<void> {
+  await db.query(`TRUNCATE TABLE ${HARNESS_TABLES.join(', ')} RESTART IDENTITY CASCADE`);
+
+  const feedKeys = await redis.keys('feed:*');
+  if (feedKeys.length > 0) {
+    await redis.del(...feedKeys);
+  }
+  const contentRuleKeys = await redis.keys('content_rules:*');
+  if (contentRuleKeys.length > 0) {
+    await redis.del(...contentRuleKeys);
+  }
+}
+
+/**
+ * Insert `count` bare subscriber rows (no posts/votes) — used by property
+ * tests that only need real subscriber DIDs to satisfy `governance_votes`'
+ * `voter_is_subscriber` foreign key, independent of full population
+ * generation.
+ */
+export async function seedSubscribers(count: number, prefix = 'did:plc:corgipropsub'): Promise<string[]> {
+  const dids = Array.from({ length: count }, (_, i) => `${prefix}${String(i).padStart(6, '0')}`);
+  for (const did of dids) {
+    await db.query(`INSERT INTO subscribers (did) VALUES ($1) ON CONFLICT (did) DO NOTHING`, [did]);
+  }
+  return dids;
+}
+
+/** Insert a fresh 'active' governance epoch with equal default weights. Returns its id. */
+export async function insertActiveEpoch(description = 'harness test epoch'): Promise<number> {
+  const result = await db.query<{ id: number }>(
+    `INSERT INTO governance_epochs (
+      status, recency_weight, engagement_weight, bridging_weight,
+      source_diversity_weight, relevance_weight, vote_count, description
+    ) VALUES ('active', 0.2, 0.2, 0.2, 0.2, 0.2, 0, $1)
+    RETURNING id`,
+    [description]
+  );
+  return result.rows[0].id;
+}

--- a/tests/harness/invariants.sim.ts
+++ b/tests/harness/invariants.sim.ts
@@ -1,0 +1,190 @@
+/**
+ * fast-check invariants for the governance vote-aggregation math.
+ *
+ * - `normalizeWeights` (pure, exported): weights always sum to 1 within 1e-9.
+ * - trimmed mean (general math property, see comment below): stays within
+ *   [min, max] of its input.
+ * - `aggregateVotes` (real production code, real Postgres via Testcontainers):
+ *   calling it twice on the same epoch is idempotent.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import { normalizeWeights } from '../../src/governance/governance.types.js';
+import { aggregateVotes } from '../../src/governance/aggregation.js';
+import { writeVoteWeights } from '../../src/governance/weight-longtable.js';
+import { config } from '../../src/config.js';
+import { db } from '../../src/db/client.js';
+import { resetHarnessData, seedSubscribers, insertActiveEpoch } from './helpers.js';
+
+const FC_SEED = 20260630;
+const MAX_VOTERS = 15;
+
+describe('normalizeWeights (real, exported production code): sum invariant', () => {
+  it('normalized weights always sum to exactly 1 within 1e-9, regardless of input scale', () => {
+    fc.assert(
+      fc.property(
+        fc
+          .tuple(
+            fc.float({ min: 0, max: 1000, noNaN: true }),
+            fc.float({ min: 0, max: 1000, noNaN: true }),
+            fc.float({ min: 0, max: 1000, noNaN: true }),
+            fc.float({ min: 0, max: 1000, noNaN: true }),
+            fc.float({ min: 0, max: 1000, noNaN: true })
+          )
+          .filter(([a, b, c, d, e]) => a + b + c + d + e > 0),
+        ([recency, engagement, bridging, sourceDiversity, relevance]) => {
+          const normalized = normalizeWeights({
+            recency,
+            engagement,
+            bridging,
+            sourceDiversity,
+            relevance,
+          });
+          const sum = Object.values(normalized).reduce((total, value) => total + value, 0);
+          return Math.abs(sum - 1) < 1e-9;
+        }
+      ),
+      { seed: FC_SEED, numRuns: 200 }
+    );
+  });
+
+  it('every normalized component stays within [0, 1]', () => {
+    fc.assert(
+      fc.property(
+        fc
+          .tuple(
+            fc.float({ min: -1000, max: 1000, noNaN: true }),
+            fc.float({ min: -1000, max: 1000, noNaN: true }),
+            fc.float({ min: -1000, max: 1000, noNaN: true }),
+            fc.float({ min: -1000, max: 1000, noNaN: true }),
+            fc.float({ min: -1000, max: 1000, noNaN: true })
+          )
+          .filter(([a, b, c, d, e]) => a + b + c + d + e > 0),
+        ([recency, engagement, bridging, sourceDiversity, relevance]) => {
+          const normalized = normalizeWeights({
+            recency,
+            engagement,
+            bridging,
+            sourceDiversity,
+            relevance,
+          });
+          return Object.values(normalized).every((value) => value >= 0 && value <= 1);
+        }
+      ),
+      { seed: FC_SEED, numRuns: 200 }
+    );
+  });
+});
+
+/**
+ * Pure re-implementation of the trim-then-mean step inside
+ * `aggregateVotes` (src/governance/aggregation.ts): 10% trim from each end
+ * when n >= 10, else no trim, then arithmetic mean of the remainder.
+ *
+ * DEVIATION FROM THE BLUEPRINT (documented, see builder report): the
+ * production code doesn't export this step standalone — it always follows
+ * it with a cross-component `normalizeWeights` call that rescales every
+ * component so the 5-vector sums to 1, which would make "the aggregated
+ * weight stays within [min, max] of that one component's raw votes" true or
+ * false almost by accident of how the OTHER four components happened to
+ * trim, not a meaningful test of the trim/mean step itself. So this test
+ * targets the general trimmed-mean algorithm in isolation — a property that
+ * must hold for ANY correct trimmed-mean implementation, independent of
+ * which of aggregateVotes's five components it's later plugged into. The
+ * idempotency test below covers `aggregateVotes` end-to-end against real
+ * Postgres, exactly as instructed as the fallback when the pure math isn't
+ * separately exported.
+ */
+function trimmedMean(values: readonly number[]): number {
+  const n = values.length;
+  const sorted = [...values].sort((a, b) => a - b);
+  const trimCount = n >= 10 ? Math.floor(n * 0.1) : 0;
+  const trimmed = trimCount > 0 ? sorted.slice(trimCount, n - trimCount) : sorted;
+  return trimmed.reduce((sum, value) => sum + value, 0) / trimmed.length;
+}
+
+describe('trimmed mean: general bounds invariant', () => {
+  it('stays within [min, max] of the input population', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.float({ min: 0, max: 1, noNaN: true }), { minLength: 1, maxLength: 200 }),
+        (values) => {
+          const result = trimmedMean(values);
+          const lo = Math.min(...values);
+          const hi = Math.max(...values);
+          return result >= lo - 1e-9 && result <= hi + 1e-9;
+        }
+      ),
+      { seed: FC_SEED, numRuns: 200 }
+    );
+  });
+});
+
+describe('aggregateVotes (real production code, real Postgres): idempotency', () => {
+  let subscriberDids: string[] = [];
+
+  beforeAll(async () => {
+    subscriberDids = await seedSubscribers(MAX_VOTERS);
+  });
+
+  afterAll(async () => {
+    await resetHarnessData();
+  });
+
+  it('calling aggregateVotes twice on the same epoch returns identical output', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(
+          fc.record({
+            recency: fc.float({ min: 0, max: 1, noNaN: true }),
+            engagement: fc.float({ min: 0, max: 1, noNaN: true }),
+            bridging: fc.float({ min: 0, max: 1, noNaN: true }),
+            sourceDiversity: fc.float({ min: 0, max: 1, noNaN: true }),
+            relevance: fc.float({ min: 0, max: 1, noNaN: true }),
+          }),
+          { minLength: 1, maxLength: MAX_VOTERS }
+        ),
+        async (rawVotes) => {
+          const epochId = await insertActiveEpoch('idempotency-property-epoch');
+
+          for (const [index, raw] of rawVotes.entries()) {
+            const weights = normalizeWeights(raw);
+            const inserted = await db.query<{ id: string }>(
+              `INSERT INTO governance_votes (
+                voter_did, epoch_id, recency_weight, engagement_weight,
+                bridging_weight, source_diversity_weight, relevance_weight
+              ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+              RETURNING id`,
+              [
+                subscriberDids[index],
+                epochId,
+                weights.recency,
+                weights.engagement,
+                weights.bridging,
+                weights.sourceDiversity,
+                weights.relevance,
+              ]
+            );
+
+            // aggregateVotes reads governance_vote_weights (the long table),
+            // not the wide columns just inserted above, whenever
+            // GOVERNANCE_LONGTABLE_READ_ENABLED is on (the production
+            // default) — mirror src/governance/routes/vote.ts's dual-write
+            // or the seeded votes would be invisible to it.
+            if (config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED) {
+              await writeVoteWeights(inserted.rows[0].id, weights);
+            }
+          }
+
+          const once = await aggregateVotes(epochId);
+          const twice = await aggregateVotes(epochId);
+
+          expect(once).not.toBeNull();
+          expect(twice).toEqual(once);
+        }
+      ),
+      { seed: FC_SEED, numRuns: 10 }
+    );
+  }, 60_000);
+});

--- a/tests/harness/invariants.sim.ts
+++ b/tests/harness/invariants.sim.ts
@@ -13,6 +13,7 @@ import fc from 'fast-check';
 import { normalizeWeights } from '../../src/governance/governance.types.js';
 import { aggregateVotes } from '../../src/governance/aggregation.js';
 import { writeVoteWeights } from '../../src/governance/weight-longtable.js';
+import { createDefaultGovernanceWeightRecord } from '../../src/config/votable-params.js';
 import { config } from '../../src/config.js';
 import { db } from '../../src/db/client.js';
 import { resetHarnessData, seedSubscribers, insertActiveEpoch } from './helpers.js';
@@ -74,6 +75,23 @@ describe('normalizeWeights (real, exported production code): sum invariant', () 
       ),
       { seed: FC_SEED, numRuns: 200 }
     );
+  });
+
+  // Both property tests above filter with `a + b + c + d + e > 0`, so the
+  // `total === 0` default-equal-weights branch (governance.types.ts) is
+  // excluded from fuzzing entirely — exercise it directly here instead.
+  it('falls back to the default equal-weight record when every input is zero', () => {
+    const normalized = normalizeWeights({
+      recency: 0,
+      engagement: 0,
+      bridging: 0,
+      sourceDiversity: 0,
+      relevance: 0,
+    });
+
+    expect(normalized).toEqual(createDefaultGovernanceWeightRecord());
+    const sum = Object.values(normalized).reduce((total, value) => total + value, 0);
+    expect(sum).toBeCloseTo(1, 9);
   });
 });
 

--- a/tests/harness/population.test.ts
+++ b/tests/harness/population.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Population Generation Unit Tests
+ *
+ * Pure — no Postgres/Redis/Testcontainers dependency, same pattern as
+ * prod-guard.test.ts / simulation.test.ts. `generatePopulation` is a pure
+ * function of `(rng, clock, config)`, so it's fully exercisable here.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generatePopulation } from '../../src/harness/population.js';
+import { createRng, SeededClock } from '../../src/harness/rng.js';
+import type { PopulationConfig } from '../../src/harness/scenario.js';
+
+function buildConfig(overrides: Partial<PopulationConfig> = {}): PopulationConfig {
+  return {
+    subscriberCount: 30,
+    postCount: 0,
+    voteParticipationRate: 1,
+    contentVoteRate: 0,
+    castsWeightVoteRate: 0.5,
+    ...overrides,
+  };
+}
+
+describe('generateVotes / castsWeightVoteRate', () => {
+  it('produces a mix of weighted and keyword-only (weights: null) votes for a mid-range rate', () => {
+    const rng = createRng(7);
+    const clock = new SeededClock(0);
+
+    const population = generatePopulation(rng, clock, buildConfig({ castsWeightVoteRate: 0.5 }));
+
+    const weighted = population.votes.filter((vote) => vote.weights !== null);
+    const keywordOnly = population.votes.filter((vote) => vote.weights === null);
+
+    // Not a hardcoded golden count — just proves both branches are reachable
+    // (the point of this fix) for a deterministic seed/config.
+    expect(weighted.length).toBeGreaterThan(0);
+    expect(keywordOnly.length).toBeGreaterThan(0);
+    expect(weighted.length + keywordOnly.length).toBe(population.votes.length);
+  });
+
+  it('never produces a null-weight vote when castsWeightVoteRate is 1', () => {
+    const rng = createRng(11);
+    const clock = new SeededClock(0);
+
+    const population = generatePopulation(rng, clock, buildConfig({ castsWeightVoteRate: 1 }));
+
+    expect(population.votes.every((vote) => vote.weights !== null)).toBe(true);
+  });
+
+  it('always produces null-weight votes when castsWeightVoteRate is 0', () => {
+    const rng = createRng(13);
+    const clock = new SeededClock(0);
+
+    const population = generatePopulation(rng, clock, buildConfig({ castsWeightVoteRate: 0 }));
+
+    expect(population.votes.length).toBeGreaterThan(0);
+    expect(population.votes.every((vote) => vote.weights === null)).toBe(true);
+  });
+
+  it('is deterministic: the same (seed, config) always produces the same weights: null pattern', () => {
+    const config = buildConfig({ castsWeightVoteRate: 0.5 });
+
+    const first = generatePopulation(createRng(99), new SeededClock(0), config);
+    const second = generatePopulation(createRng(99), new SeededClock(0), config);
+
+    expect(first.votes.map((vote) => vote.weights === null)).toEqual(
+      second.votes.map((vote) => vote.weights === null)
+    );
+  });
+});

--- a/tests/harness/population.test.ts
+++ b/tests/harness/population.test.ts
@@ -68,4 +68,36 @@ describe('generateVotes / castsWeightVoteRate', () => {
       second.votes.map((vote) => vote.weights === null)
     );
   });
+
+  it('keyword-only (null-weight) votes always carry at least one keyword', () => {
+    // Worst case: no weight opinions and contentVoteRate 0. Every vote is
+    // keyword-only, and none would draw content by rate — they must still carry
+    // keywords, otherwise the population is full of no-op votes the real API
+    // would reject.
+    const population = generatePopulation(
+      createRng(23),
+      new SeededClock(0),
+      buildConfig({ castsWeightVoteRate: 0, contentVoteRate: 0 })
+    );
+
+    expect(population.votes.length).toBeGreaterThan(0);
+    for (const vote of population.votes) {
+      expect(vote.weights).toBeNull();
+      expect(vote.includeKeywords.length + vote.excludeKeywords.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('produces no votes when there are no participants', () => {
+    const rng = createRng(17);
+    const clock = new SeededClock(0);
+
+    // Zero subscribers => no voters (and no author-fallback misfire on votes).
+    const noSubscribers = generatePopulation(rng, clock, buildConfig({ subscriberCount: 0 }));
+    expect(noSubscribers.subscribers).toHaveLength(0);
+    expect(noSubscribers.votes).toHaveLength(0);
+
+    // Subscribers exist but nobody participates.
+    const noParticipation = generatePopulation(rng, clock, buildConfig({ voteParticipationRate: 0 }));
+    expect(noParticipation.votes).toHaveLength(0);
+  });
 });

--- a/tests/harness/prod-guard.test.ts
+++ b/tests/harness/prod-guard.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Prod-Guard Unit Tests
+ *
+ * Pure — no Postgres/Redis/Testcontainers dependency at all. Verifies the
+ * simulation harness refuses to run against anything that looks like
+ * production, and that the refusal of the *known* production signature
+ * (docker-compose.prod.yml: Postgres port 5433 / db "bluesky_feed" / user
+ * "feed"; Redis port 6380) cannot be bypassed by any flag.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  assertEphemeralPostgresUrl,
+  assertEphemeralRedisUrl,
+  assertEphemeralTarget,
+  ProdGuardError,
+} from '../../src/harness/prod-guard.js';
+
+const PROD_POSTGRES_URL = 'postgresql://feed:supersecret@127.0.0.1:5433/bluesky_feed';
+const PROD_REDIS_URL = 'redis://127.0.0.1:6380';
+
+describe('assertEphemeralPostgresUrl', () => {
+  afterEach(() => {
+    delete process.env.CORGI_SIM_ALLOW;
+  });
+
+  it('aborts on the known production Postgres signature (port + db name)', () => {
+    expect(() => assertEphemeralPostgresUrl(PROD_POSTGRES_URL)).toThrow(ProdGuardError);
+  });
+
+  it('aborts on the known production signature even when CORGI_SIM_ALLOW=1', () => {
+    process.env.CORGI_SIM_ALLOW = '1';
+    expect(() => assertEphemeralPostgresUrl(PROD_POSTGRES_URL)).toThrow(ProdGuardError);
+  });
+
+  it('aborts on the known production signature even with an explicit allowFlag: true', () => {
+    expect(() => assertEphemeralPostgresUrl(PROD_POSTGRES_URL, { allowFlag: true })).toThrow(
+      ProdGuardError
+    );
+  });
+
+  it('aborts when db name matches production even on a different loopback port', () => {
+    expect(() =>
+      assertEphemeralPostgresUrl('postgresql://feed:pw@127.0.0.1:5432/bluesky_feed')
+    ).toThrow(ProdGuardError);
+  });
+
+  it('allows a Testcontainers-style loopback URL with a random port and test db name', () => {
+    expect(() =>
+      assertEphemeralPostgresUrl('postgresql://corgi_sim:corgi_sim@127.0.0.1:55432/corgi_sim_test')
+    ).not.toThrow();
+  });
+
+  it('allows "localhost" as a loopback hostname', () => {
+    expect(() =>
+      assertEphemeralPostgresUrl('postgresql://postgres:postgres@localhost:5432/community_feed')
+    ).not.toThrow();
+  });
+
+  it('aborts on a non-local host with no allow flag set', () => {
+    expect(() =>
+      assertEphemeralPostgresUrl('postgresql://user:pw@db.example.com:5432/some_db')
+    ).toThrow(ProdGuardError);
+  });
+
+  it('allows a non-local, non-prod-signature host when CORGI_SIM_ALLOW=1', () => {
+    process.env.CORGI_SIM_ALLOW = '1';
+    expect(() =>
+      assertEphemeralPostgresUrl('postgresql://user:pw@ci-docker-host.example.com:5432/some_db')
+    ).not.toThrow();
+  });
+
+  it('allows a non-local, non-prod-signature host with an explicit allowFlag: true', () => {
+    expect(() =>
+      assertEphemeralPostgresUrl('postgresql://user:pw@ci-docker-host.example.com:5432/some_db', {
+        allowFlag: true,
+      })
+    ).not.toThrow();
+  });
+
+  it('throws a descriptive ProdGuardError on unparseable URLs', () => {
+    expect(() => assertEphemeralPostgresUrl('not-a-url')).toThrow(ProdGuardError);
+  });
+});
+
+describe('assertEphemeralRedisUrl', () => {
+  afterEach(() => {
+    delete process.env.CORGI_SIM_ALLOW;
+  });
+
+  it('aborts on the known production Redis signature (port 6380)', () => {
+    expect(() => assertEphemeralRedisUrl(PROD_REDIS_URL)).toThrow(ProdGuardError);
+  });
+
+  it('aborts on the known production Redis signature even with allowFlag: true', () => {
+    expect(() => assertEphemeralRedisUrl(PROD_REDIS_URL, { allowFlag: true })).toThrow(
+      ProdGuardError
+    );
+  });
+
+  it('allows a Testcontainers-style loopback Redis URL on a random port', () => {
+    expect(() => assertEphemeralRedisUrl('redis://127.0.0.1:54932')).not.toThrow();
+  });
+
+  it('aborts on a non-local Redis host with no allow flag set', () => {
+    expect(() => assertEphemeralRedisUrl('redis://cache.example.com:6379')).toThrow(ProdGuardError);
+  });
+
+  it('allows a non-local, non-prod-signature Redis host with allowFlag: true', () => {
+    expect(() =>
+      assertEphemeralRedisUrl('redis://ci-docker-host.example.com:6379', { allowFlag: true })
+    ).not.toThrow();
+  });
+});
+
+describe('assertEphemeralTarget', () => {
+  it('checks both Postgres and Redis, throwing if either matches production', () => {
+    const okPostgres = 'postgresql://corgi_sim:corgi_sim@127.0.0.1:55432/corgi_sim_test';
+    expect(() => assertEphemeralTarget(okPostgres, PROD_REDIS_URL)).toThrow(ProdGuardError);
+    expect(() => assertEphemeralTarget(PROD_POSTGRES_URL, 'redis://127.0.0.1:54932')).toThrow(
+      ProdGuardError
+    );
+  });
+
+  it('passes when both targets are clearly ephemeral/local', () => {
+    expect(() =>
+      assertEphemeralTarget(
+        'postgresql://corgi_sim:corgi_sim@127.0.0.1:55432/corgi_sim_test',
+        'redis://127.0.0.1:54932'
+      )
+    ).not.toThrow();
+  });
+});

--- a/tests/harness/prod-guard.test.ts
+++ b/tests/harness/prod-guard.test.ts
@@ -8,6 +8,9 @@
  * "feed"; Redis port 6380) cannot be bypassed by any flag.
  */
 
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   assertEphemeralPostgresUrl,
@@ -18,6 +21,9 @@ import {
 
 const PROD_POSTGRES_URL = 'postgresql://feed:supersecret@127.0.0.1:5433/bluesky_feed';
 const PROD_REDIS_URL = 'redis://127.0.0.1:6380';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const COMPOSE_PROD_PATH = path.join(REPO_ROOT, 'docker-compose.prod.yml');
 
 describe('assertEphemeralPostgresUrl', () => {
   afterEach(() => {
@@ -102,6 +108,10 @@ describe('assertEphemeralRedisUrl', () => {
     expect(() => assertEphemeralRedisUrl('redis://127.0.0.1:54932')).not.toThrow();
   });
 
+  it('allows "localhost" as a loopback hostname', () => {
+    expect(() => assertEphemeralRedisUrl('redis://localhost:6379')).not.toThrow();
+  });
+
   it('aborts on a non-local Redis host with no allow flag set', () => {
     expect(() => assertEphemeralRedisUrl('redis://cache.example.com:6379')).toThrow(ProdGuardError);
   });
@@ -110,6 +120,45 @@ describe('assertEphemeralRedisUrl', () => {
     expect(() =>
       assertEphemeralRedisUrl('redis://ci-docker-host.example.com:6379', { allowFlag: true })
     ).not.toThrow();
+  });
+
+  it('throws a descriptive ProdGuardError on unparseable Redis URLs', () => {
+    expect(() => assertEphemeralRedisUrl('not-a-url')).toThrow(ProdGuardError);
+  });
+});
+
+describe('KNOWN_PROD_POSTGRES / KNOWN_PROD_REDIS: docker-compose.prod.yml parity', () => {
+  /**
+   * Drift guard for prod-guard.ts's hardcoded production signature (see its
+   * header comment). Reads the actual compose file and re-derives the
+   * Postgres/Redis URL docker-compose.prod.yml's own values would produce,
+   * then asserts the guard still hard-refuses it. If someone edits the
+   * compose file's user/db/ports without updating prod-guard.ts's constants,
+   * this test fails instead of the guard silently getting weaker.
+   */
+  it('still refuses a Postgres URL built from docker-compose.prod.yml\'s own values', async () => {
+    const compose = await readFile(COMPOSE_PROD_PATH, 'utf8');
+
+    const user = /POSTGRES_USER:\s*(\S+)/.exec(compose)?.[1];
+    const database = /POSTGRES_DB:\s*(\S+)/.exec(compose)?.[1];
+    const port = /"127\.0\.0\.1:(\d+):5432"/.exec(compose)?.[1];
+
+    expect(user, 'POSTGRES_USER not found in docker-compose.prod.yml').toBeTruthy();
+    expect(database, 'POSTGRES_DB not found in docker-compose.prod.yml').toBeTruthy();
+    expect(port, 'postgres host port not found in docker-compose.prod.yml').toBeTruthy();
+
+    const composeUrl = `postgresql://${user}:whatever@127.0.0.1:${port}/${database}`;
+    expect(() => assertEphemeralPostgresUrl(composeUrl)).toThrow(ProdGuardError);
+  });
+
+  it('still refuses a Redis URL built from docker-compose.prod.yml\'s own port', async () => {
+    const compose = await readFile(COMPOSE_PROD_PATH, 'utf8');
+
+    const port = /"127\.0\.0\.1:(\d+):6379"/.exec(compose)?.[1];
+    expect(port, 'redis host port not found in docker-compose.prod.yml').toBeTruthy();
+
+    const composeUrl = `redis://127.0.0.1:${port}`;
+    expect(() => assertEphemeralRedisUrl(composeUrl)).toThrow(ProdGuardError);
   });
 });
 

--- a/tests/harness/setup-env.ts
+++ b/tests/harness/setup-env.ts
@@ -1,0 +1,47 @@
+/**
+ * Per-test-file environment setup for the A1 simulation-harness suite.
+ *
+ * `src/config.ts` runs `ConfigSchema.parse(process.env)` synchronously at
+ * *import time* (see docs/agent build-bible §6), so every required env var
+ * must exist in `process.env` BEFORE any test file statically imports
+ * anything under `src/**` (directly, or transitively via
+ * `src/harness/index.ts`). Vitest's `setupFiles` run to completion before
+ * the test file's own module graph is evaluated, so this file — not a
+ * `beforeAll` inside a test — is the only place this can be done safely for
+ * a plain top-level `import`.
+ *
+ * `inject()` reads the Testcontainers connection URLs the globalSetup
+ * (`global-setup.ts`) handed off via `project.provide`.
+ */
+
+import { inject } from 'vitest';
+
+// @testcontainers/postgresql's `getConnectionUri()` returns the short
+// `postgres://` scheme; `src/config.ts` requires the literal `postgresql://`
+// prefix (`z.string().startsWith('postgresql://')`). Both are the same
+// connection string as far as `pg` is concerned — normalize the scheme so
+// `ConfigSchema.parse` accepts it.
+const databaseUrl = inject('corgiSimPgUrl').replace(/^postgres:\/\//, 'postgresql://');
+const redisUrl = inject('corgiSimRedisUrl');
+
+process.env.DATABASE_URL = databaseUrl;
+process.env.REDIS_URL = redisUrl;
+
+// The harness never talks to Jetstream/Bluesky/a real bot account — these
+// are placeholder values that only need to satisfy `ConfigSchema`'s shape
+// (`did:` prefix, valid URL, non-empty string) so `src/config.ts` parses.
+process.env.FEEDGEN_SERVICE_DID ??= 'did:plc:corgisimharness00000000000';
+process.env.FEEDGEN_PUBLISHER_DID ??= 'did:plc:corgisimharnesspublisher0';
+process.env.FEEDGEN_HOSTNAME ??= 'sim-harness.local.test';
+process.env.JETSTREAM_URL ??= 'wss://sim-harness.local.test/subscribe';
+process.env.JETSTREAM_FALLBACK_URL ??= 'wss://sim-harness.local.test/subscribe-fallback';
+process.env.JETSTREAM_COLLECTIONS ??= 'app.bsky.feed.post';
+process.env.BSKY_IDENTIFIER ??= 'sim-harness.test';
+process.env.BSKY_APP_PASSWORD ??= 'sim-harness-not-a-real-password';
+
+// Explicit, defense-in-depth: never let a simulation run post to Bluesky or
+// enable the semantic embedding classifier (irrelevant to A1, and slower).
+process.env.NODE_ENV ??= 'test';
+process.env.LOG_LEVEL ??= 'warn';
+process.env.BOT_ENABLED ??= 'false';
+process.env.TOPIC_EMBEDDING_ENABLED ??= 'false';

--- a/tests/harness/simulation.integration.sim.ts
+++ b/tests/harness/simulation.integration.sim.ts
@@ -1,0 +1,145 @@
+/**
+ * Integration test: one full aggregate -> transition -> score cycle driven
+ * against the real Testcontainers-backed Postgres + Redis stack.
+ *
+ * This is also what `npm run sim:core` runs.
+ */
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { runScenario } from '../../src/harness/index.js';
+import { assertEphemeralPostgresUrl, assertEphemeralRedisUrl } from '../../src/harness/prod-guard.js';
+import { db } from '../../src/db/client.js';
+import { redis } from '../../src/db/redis.js';
+import { buildSimulationDeps, resetHarnessData } from './helpers.js';
+
+describe('Simulation: epoch-vote-cycle integration', () => {
+  let artifactsDir: string;
+
+  beforeAll(async () => {
+    artifactsDir = await mkdtemp(path.join(tmpdir(), 'corgi-sim-artifacts-'));
+  });
+
+  afterEach(async () => {
+    await resetHarnessData();
+  });
+
+  afterAll(async () => {
+    await rm(artifactsDir, { recursive: true, force: true });
+  });
+
+  it('seeds epoch 1 + a synthetic population, then completes one real aggregate -> transition -> score cycle with zero prod contact', async () => {
+    const deps = buildSimulationDeps(1234);
+
+    // Zero prod contact: the exact same guard `Simulation.run()` calls
+    // internally must pass on the URLs this test is about to drive against,
+    // and those URLs must not resemble the known production signature.
+    expect(() => assertEphemeralPostgresUrl(deps.databaseUrl)).not.toThrow();
+    expect(() => assertEphemeralRedisUrl(deps.redisUrl)).not.toThrow();
+    const pgUrl = new URL(deps.databaseUrl);
+    const redisUrl = new URL(deps.redisUrl);
+    expect(['127.0.0.1', 'localhost']).toContain(pgUrl.hostname);
+    expect(pgUrl.port).not.toBe('5433');
+    expect(['127.0.0.1', 'localhost']).toContain(redisUrl.hostname);
+    expect(redisUrl.port).not.toBe('6380');
+
+    const { metrics, artifacts, artifactPaths } = await runScenario(
+      {
+        kind: 'epoch-vote-cycle',
+        version: 1,
+        seed: 1234,
+        population: {
+          subscriberCount: 12,
+          postCount: 20,
+          voteParticipationRate: 0.9,
+          // 0: no content (keyword) votes cast, so aggregateContentVotes takes
+          // its "no content votes" safety-net branch (exclude-only defaults,
+          // no include-keyword restriction) rather than a real but randomly
+          // generated include-keyword filter that would make the resulting
+          // scoredPostCount config-dependent instead of a reliable assertion.
+          contentVoteRate: 0,
+        },
+      },
+      { deps, artifactsDir }
+    );
+
+    // Seeded epoch 1 -> transitioned to epoch 2 (RESTART IDENTITY in
+    // resetHarnessData guarantees this is a fresh sequence starting at 1).
+    expect(metrics.transition.fromEpochId).toBe(1);
+    expect(metrics.transition.toEpochId).toBe(2);
+    expect(metrics.aggregation.epochId).toBe(1);
+
+    // Real aggregateVotes output: normalized weights sum to 1.
+    expect(metrics.aggregation.weightSum).toBeCloseTo(1, 6);
+    const weightValues = Object.values(metrics.aggregation.weights);
+    expect(weightValues).toHaveLength(5);
+    for (const value of weightValues) {
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(1);
+    }
+
+    // Real runScoringPipeline output: every seeded post got scored into the
+    // new epoch (first run against this epoch => full rescore, not incremental).
+    expect(metrics.scoring.epochId).toBe(2);
+    expect(metrics.scoring.scoredPostCount).toBe(20);
+    expect(metrics.scoring.topPosts.length).toBe(20);
+    expect(metrics.population.subscriberCount).toBe(12);
+    expect(metrics.population.postCount).toBe(20);
+    expect(metrics.population.voteCount).toBe(Math.round(12 * 0.9));
+
+    // Ranks are contiguous starting at 1, descending by score.
+    const ranks = metrics.scoring.topPosts.map((post) => post.rank);
+    expect(ranks).toEqual(Array.from({ length: ranks.length }, (_, i) => i + 1));
+    for (let i = 1; i < metrics.scoring.topPosts.length; i++) {
+      expect(metrics.scoring.topPosts[i - 1].totalScore).toBeGreaterThanOrEqual(
+        metrics.scoring.topPosts[i].totalScore
+      );
+    }
+
+    // The event log recorded all three "drive" steps in order.
+    const eventTypes = artifacts.events.map((event) => event.type);
+    expect(eventTypes).toEqual([
+      'epoch_ensured',
+      'population_generated',
+      'population_seeded',
+      'votes_aggregated',
+      'epoch_transitioned',
+      'scoring_pipeline_run',
+      'top_posts_fetched',
+    ]);
+
+    // Real audit trail: the epoch transition was actually persisted, not just computed in memory.
+    const auditRows = await db.query<{ action: string }>(
+      `SELECT action FROM governance_audit_log WHERE epoch_id = $1 ORDER BY id ASC`,
+      [metrics.transition.toEpochId]
+    );
+    expect(auditRows.rows.map((r) => r.action)).toContain('epoch_created');
+
+    // Real Redis write: the scored feed was published to the sorted set.
+    const feedCount = await redis.get('feed:count');
+    expect(Number(feedCount)).toBe(20);
+    const feedEpoch = await redis.get('feed:epoch');
+    expect(Number(feedEpoch)).toBe(2);
+
+    // Artifacts were actually written to disk and are valid JSON matching the returned object.
+    expect(artifactPaths).toBeDefined();
+    const writtenJson = JSON.parse(await readFile(artifactPaths!.jsonPath, 'utf8'));
+    expect(writtenJson.metrics).toEqual(metrics);
+    const writtenCsv = await readFile(artifactPaths!.csvPath, 'utf8');
+    expect(writtenCsv).toContain('epoch-vote-cycle');
+  });
+
+  it('rejects invalid scenario input via .safeParse before touching the database', async () => {
+    const deps = buildSimulationDeps(1);
+
+    await expect(
+      runScenario({ kind: 'not-a-real-kind', version: 1, seed: 1 }, { deps })
+    ).rejects.toThrow(/Invalid scenario/);
+
+    // No epoch should have been created — the guard/parse rejected before any I/O.
+    const epochs = await db.query(`SELECT id FROM governance_epochs`);
+    expect(epochs.rows).toHaveLength(0);
+  });
+});

--- a/tests/harness/simulation.test.ts
+++ b/tests/harness/simulation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Simulation Unit Tests
+ *
+ * Pure — no Postgres/Redis/Testcontainers dependency. `Simulation`'s
+ * constructor and the `multi-epoch-cycle` fail-fast guard (checked before
+ * any dynamic import of the governance/scoring modules) can be exercised
+ * with a fake `QueryableDb` and ephemeral-looking connection strings, same
+ * pattern as `prod-guard.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Simulation, type QueryableDb, type SimulationDeps } from '../../src/harness/simulation.js';
+import { createRng, SeededClock } from '../../src/harness/rng.js';
+import type { Scenario } from '../../src/harness/scenario.js';
+
+/** Never expected to be called by the guards this suite exercises. */
+const unreachableDb: QueryableDb = {
+  query: async () => {
+    throw new Error('unreachable: Simulation.run() must not touch the db for an unimplemented scenario kind');
+  },
+};
+
+function buildDeps(): SimulationDeps {
+  return {
+    rng: createRng(1),
+    clock: new SeededClock(0),
+    db: unreachableDb,
+    databaseUrl: 'postgresql://corgi_sim:corgi_sim@127.0.0.1:55432/corgi_sim_test',
+    redisUrl: 'redis://127.0.0.1:54932',
+  };
+}
+
+describe('Simulation.run(): multi-epoch-cycle (reserved, unimplemented)', () => {
+  it('throws a clear error instead of silently running a single round', async () => {
+    const scenario: Scenario = {
+      kind: 'multi-epoch-cycle',
+      version: 1,
+      seed: 1,
+      rounds: 3,
+      population: {
+        subscriberCount: 10,
+        postCount: 10,
+        voteParticipationRate: 0.8,
+        contentVoteRate: 0.2,
+      },
+    };
+
+    const simulation = new Simulation(scenario, buildDeps());
+
+    await expect(simulation.run()).rejects.toThrow(/multi-epoch-cycle.*not yet implemented/i);
+  });
+
+  it('still enforces the prod-guard before the scenario-kind check', async () => {
+    const scenario: Scenario = {
+      kind: 'multi-epoch-cycle',
+      version: 1,
+      seed: 1,
+      rounds: 1,
+      population: {
+        subscriberCount: 1,
+        postCount: 0,
+        voteParticipationRate: 0,
+        contentVoteRate: 0,
+      },
+    };
+
+    const deps: SimulationDeps = {
+      ...buildDeps(),
+      databaseUrl: 'postgresql://feed:supersecret@127.0.0.1:5433/bluesky_feed',
+    };
+
+    const simulation = new Simulation(scenario, deps);
+
+    await expect(simulation.run()).rejects.toThrow(/Refusing to run simulation/);
+  });
+});

--- a/tests/harness/simulation.test.ts
+++ b/tests/harness/simulation.test.ts
@@ -42,6 +42,7 @@ describe('Simulation.run(): multi-epoch-cycle (reserved, unimplemented)', () => 
         postCount: 10,
         voteParticipationRate: 0.8,
         contentVoteRate: 0.2,
+        castsWeightVoteRate: 0.9,
       },
     };
 
@@ -61,12 +62,38 @@ describe('Simulation.run(): multi-epoch-cycle (reserved, unimplemented)', () => 
         postCount: 0,
         voteParticipationRate: 0,
         contentVoteRate: 0,
+        castsWeightVoteRate: 0.9,
       },
     };
 
     const deps: SimulationDeps = {
       ...buildDeps(),
       databaseUrl: 'postgresql://feed:supersecret@127.0.0.1:5433/bluesky_feed',
+    };
+
+    const simulation = new Simulation(scenario, deps);
+
+    await expect(simulation.run()).rejects.toThrow(/Refusing to run simulation/);
+  });
+
+  it('still enforces the Redis prod-guard even with an otherwise-ephemeral Postgres URL', async () => {
+    const scenario: Scenario = {
+      kind: 'multi-epoch-cycle',
+      version: 1,
+      seed: 1,
+      rounds: 1,
+      population: {
+        subscriberCount: 1,
+        postCount: 0,
+        voteParticipationRate: 0,
+        contentVoteRate: 0,
+        castsWeightVoteRate: 0.9,
+      },
+    };
+
+    const deps: SimulationDeps = {
+      ...buildDeps(),
+      redisUrl: 'redis://127.0.0.1:6380',
     };
 
     const simulation = new Simulation(scenario, deps);

--- a/tests/harness/vitest-provided-context.d.ts
+++ b/tests/harness/vitest-provided-context.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Ambient typing for the globalSetup -> inject() handoff shared across every
+ * file in the A1 simulation-harness integration suite. See global-setup.ts.
+ */
+declare module 'vitest' {
+  export interface ProvidedContext {
+    corgiSimPgUrl: string;
+    corgiSimRedisUrl: string;
+  }
+}

--- a/vitest.harness.config.ts
+++ b/vitest.harness.config.ts
@@ -1,0 +1,47 @@
+/**
+ * Vitest config for the A1 simulation-harness suite (tests/harness/**).
+ *
+ * Deliberately NOT named `vitest.config.ts`/`.mts`: this repo has no root
+ * Vitest config today (`npm test` = `vitest tests` on pure defaults, fully
+ * mocked, no real DB/Redis — see docs/agent build-bible §1/§4). Adding a
+ * root `vitest.config.ts` with a Testcontainers `globalSetup` would be
+ * auto-loaded by that plain `vitest tests` invocation too, silently adding
+ * container startup + a real Postgres/Redis dependency to every existing
+ * unit test run. Naming this file something Vitest doesn't auto-resolve
+ * keeps the two tiers (fast, fully-mocked unit suite vs. this
+ * Testcontainers-backed integration suite) genuinely separate, matching the
+ * two-tier CI split the harness blueprint calls for.
+ *
+ * A second, complementary reason `include` below covers `*.sim.ts` in
+ * addition to `*.test.ts`: files that need the real Testcontainers stack
+ * (invariants, the integration cycle, the golden snapshot) are named
+ * `*.sim.ts` — NOT `*.test.ts` — so they fall outside Vitest's default
+ * include glob (`**\/*.{test,spec}.?(c|m)[jt]s?(x)`) too. Without that,
+ * merely having these files exist under `tests/harness/**` would make the
+ * plain default `npm test` (`vitest tests`, no config) sweep them up and
+ * fail (missing env vars / no container). This mirrors the exact convention
+ * this repo already uses for `tests/stress/*.stress.ts` — see build bible
+ * §1: "stress scenario files ... are structurally excluded from `npm test`
+ * by naming, not by explicit exclude config." `prod-guard.test.ts` is the
+ * one harness file that's pure/fast/needs-no-container, so it keeps the
+ * `.test.ts` suffix and is safe to run under the plain default suite too.
+ *
+ * Invoked explicitly via `npm run sim:core` or
+ * `vitest run --config vitest.harness.config.ts tests/harness`.
+ */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/harness/**/*.test.ts', 'tests/harness/**/*.sim.ts'],
+    globalSetup: ['tests/harness/global-setup.ts'],
+    setupFiles: ['tests/harness/setup-env.ts'],
+    testTimeout: 60_000,
+    hookTimeout: 120_000,
+    // All integration tests share one Testcontainers-backed Postgres/Redis
+    // instance for the whole run — keep test files from racing each other's
+    // TRUNCATE/epoch-transition writes by never running two files at once.
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
Implements **PROJ-1482 (A1)** — the headless simulation core that all governance-robustness experiments (A2–A8) build on.

## What
A deterministic, strong-typed driver under `src/harness/` that runs the **real** Corgi governance + scoring code (`aggregateVotes` → epoch transition → `runScoringPipeline`) against an **ephemeral, isolated** Postgres+Redis via Testcontainers — behind a zod-validated `Scenario` API with an injected seeded RNG + Clock (Deterministic Simulation Testing pattern). Includes a hard prod-guard, fast-check invariants, and a fixed-seed golden snapshot.

Scope is new code only under `src/harness/**` + `tests/harness/**`; the only change to existing files is a `sim:core` script + 3 dev-deps in `package.json`. No production runtime code touched.

## Evidence (all acceptance criteria PASS — expectations-first QA)
- **AC1** e2e cycle: `npm run sim:core` boots Testcontainers, runs 22 real migrations, and completes a real `aggregate→transition→score` cycle (epoch 1→2, 20 posts scored), asserting the DB/Redis are localhost/ephemeral — zero prod contact. `1 file / 2 tests`.
- **AC2** prod-guard aborts on the real prod URL (port 5433 / db `bluesky_feed`) even with an allow-flag — container-free. `17 tests`.
- **AC3** fast-check invariants: `normalizeWeights` sums to 1 (±1e-9) & ∈[0,1]; trimmed-mean bounds; `aggregateVotes` byte-identically idempotent vs real Postgres. `4 tests`.
- **AC4** fixed-seed golden snapshot: reproducible across re-runs, checked in, not gitignored.
- **AC5** `npm run build` + `tsc --noEmit` clean; **full suite 79 files / 582 tests, zero regressions** (baseline independently re-derived at 77/563 via `git stash`; harness adds exactly +2 test files).
- **AC6** only `src/harness/**`, `tests/harness/**`, `package.json`/`lock`, `vitest.harness.config.ts` changed.

## Notable engineering decisions
- Container-backed tests use a `.sim.ts` suffix + a dedicated `vitest.harness.config.ts` (not `vitest.config.ts`) so the default `npm test` stays fast/mock-only — mirrors the repo's existing `tests/stress/*.stress.ts` convention.
- Verified importing the real governance/scoring modules has **no side effects** (no server/scheduler start; only `src/index.ts` calls `main()`, and it's never imported).
- Population seeding mirrors the real `governance_vote_weights` long-table dual-write, so seeded votes are visible to the real aggregator.