### PR TITLE
[PROJ-1499] Make the frontend axios CI guard self-maintaining

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,17 +88,25 @@ jobs:
       - name: Install frontend dependencies
         run: cd web && npm ci
 
-      # This expected version must move in lockstep with web/package.json
-      # dependencies.axios on every reviewed bump (currently 1.18.1).
+      # Supply-chain guard for axios: require an EXACT pin (no ^/~/range) that
+      # matches the resolved package-lock version. Self-maintaining — Dependabot
+      # bumps package.json + the lockfile together, so reviewed bumps pass with no
+      # manual edit here. Replaces the hard-coded version literal that drifted red
+      # on every bump (PROJ-1289 1.16->1.17, PROJ-1499 ->1.18.x).
       - name: Validate frontend Axios pin
         run: |
           node --input-type=module -e '
             import fs from "node:fs";
 
-            const packageJson = JSON.parse(fs.readFileSync("web/package.json", "utf8"));
-            const axiosVersion = packageJson.dependencies?.axios;
-            if (axiosVersion !== "1.18.1") {
-              throw new Error(`web/package.json must pin axios to exact 1.18.1; found ${axiosVersion ?? "missing"}`);
+            const pkg = JSON.parse(fs.readFileSync("web/package.json", "utf8"));
+            const lock = JSON.parse(fs.readFileSync("web/package-lock.json", "utf8"));
+            const declared = pkg.dependencies?.axios;
+            const resolved = lock.packages?.["node_modules/axios"]?.version;
+            if (!declared || !/^\d+\.\d+\.\d+$/.test(declared)) {
+              throw new Error(`web/package.json must pin axios to an exact version (no ^/~/range); found ${declared ?? "missing"}`);
+            }
+            if (declared !== resolved) {
+              throw new Error(`web/package.json axios (${declared}) must match package-lock.json resolved axios (${resolved ?? "missing"})`);
             }
           '
 


### PR DESCRIPTION
## Problem
The "Validate frontend Axios pin" step hard-codes a version literal, so `frontend-verify` goes red on `main` after every Dependabot axios bump until someone hand-advances the literal in a separate PR. This has recurred twice (1.16→1.17 in PROJ-1289/#270; →1.18.x fixed inline by #280). #280 made main green again — this PR stops the *next* recurrence.

## Fix (durable; supersedes the closed #276 band-aid)
Replace the literal equality with a **self-maintaining consistency check**:
- axios must be **exact-pinned** (no `^`/`~`/range), and
- `web/package.json` must **match the resolved version in `web/package-lock.json`**.

Dependabot bumps both files together, so reviewed bumps stay green with **zero manual edits** — while preserving the exact-pin / no-drift supply-chain intent of the original guard.

## Verification
- Guard snippet run locally from repo root: **passes** for current exact-pinned `1.18.1` (== lockfile).
- Correctly **fails** for a `^1.18.1` range and for a package.json↔lockfile drift (both tested).
- `cd web && npm audit --audit-level=moderate` → 0 vulnerabilities. Valid YAML.
- Diff vs main: the guard step only (+14/−6), rebased on current main.

Closes PROJ-1499.