### PR TITLE
[PROJ-1523] Wire vote and dashboard to live backend data with session auth

### DIFF
--- a/web-next/app/dashboard/page.tsx
+++ b/web-next/app/dashboard/page.tsx
@@ -270,7 +270,7 @@ export default function DashboardPage() {
               <SectionHeader label="What changed" />
               <EmptyState heading="Round comparison unavailable" body="We need at least two governance rounds to show what changed between them." showCorgi={false} />
             </>
-          ) : diff.weight_changes.length === 0 && diff.keywords_added.include.length === 0 && diff.keywords_removed.exclude.length === 0 ? (
+          ) : diff.weight_changes.length === 0 && diff.keywords_added.include.length === 0 && diff.keywords_added.exclude.length === 0 && diff.keywords_removed.include.length === 0 && diff.keywords_removed.exclude.length === 0 ? (
             <>
               <SectionHeader
                 label={`What changed — round ${diff.previous_round} → ${diff.current_round}`}
@@ -306,12 +306,14 @@ export default function DashboardPage() {
                     </div>
                   </div>
                 )}
-                {(diff.keywords_added.include.length > 0 || diff.keywords_removed.exclude.length > 0) && (
+                {(diff.keywords_added.include.length > 0 || diff.keywords_added.exclude.length > 0 || diff.keywords_removed.include.length > 0 || diff.keywords_removed.exclude.length > 0) && (
                   <div className="p-5 flex flex-col gap-3">
                     <p className="text-xs font-semibold text-foreground/50 uppercase tracking-wide">Content rule changes</p>
                     <div className="flex flex-wrap gap-2">
-                      {diff.keywords_added.include.map((w) => <KeywordChip key={w} word={w} variant="add" />)}
-                      {diff.keywords_removed.exclude.map((w) => <KeywordChip key={w} word={w} variant="remove" />)}
+                      {diff.keywords_added.include.map((w) => <KeywordChip key={`ai-${w}`} word={w} variant="add" />)}
+                      {diff.keywords_added.exclude.map((w) => <KeywordChip key={`ae-${w}`} word={w} variant="add" />)}
+                      {diff.keywords_removed.include.map((w) => <KeywordChip key={`ri-${w}`} word={w} variant="remove" />)}
+                      {diff.keywords_removed.exclude.map((w) => <KeywordChip key={`re-${w}`} word={w} variant="remove" />)}
                     </div>
                   </div>
                 )}

--- a/web-next/app/dashboard/page.tsx
+++ b/web-next/app/dashboard/page.tsx
@@ -3,61 +3,13 @@
 import { useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+import { useQuery } from "@tanstack/react-query"
 import { AppShell } from "@/components/app-shell"
 import { WeightBar } from "@/components/ui/weight-bar"
 import { StatusChip } from "@/components/ui/status-chip"
-import { StatClusterSkeleton, WeightsSkeleton, EmptyState, ErrorCard } from "@/components/ui/state-kit"
+import { StatClusterSkeleton, WeightsSkeleton, EmptyState, ErrorCard, Skeleton } from "@/components/ui/state-kit"
 import { Button } from "@/components/ui/button"
-
-/* ─── Mock data (exact field names from the brief seam) ─── */
-const MOCK_STATS = {
-  epoch: { id: 47, phase: "voting" },
-  feed_stats: {
-    total_posts_scored: 1240,
-    unique_authors: 318,
-    avg_bridging: 0.41,
-    median_bridging: 0.39,
-    avg_engagement_score: 0.52,
-    median_engagement: 0.48,
-    avg_total: 0.57,
-    median_total: 0.55,
-  },
-  governance: { votes_this_epoch: 312 },
-  metrics: {
-    author_gini: 0.34,
-    vs_chronological_overlap: 0.61,
-    vs_engagement_overlap: 0.44,
-  },
-}
-
-const MOCK_WEIGHTS = {
-  recency: 0.35,
-  engagement: 0.25,
-  bridging: 0.20,
-  source_diversity: 0.15,
-  relevance: 0.05,
-}
-
-const MOCK_ROUND_DIFF = {
-  current_round: 47,
-  previous_round: 46,
-  voter_count: 312,
-  applied_at: "2026-06-25T00:00:00Z",
-  weight_changes: [
-    { key: "recency",          before: 0.30, after: 0.35, delta: 0.05 },
-    { key: "engagement",       before: 0.30, after: 0.25, delta: -0.05 },
-    { key: "source_diversity", before: 0.10, after: 0.15, delta: 0.05 },
-  ],
-  keywords_added:   { include: ["ai"],  exclude: [] },
-  keywords_removed: { include: [],      exclude: ["nft"] },
-}
-
-const MOCK_LEDGER = [
-  { id: 991, action: "weights_applied", epoch_id: 47, created_at: "2026-06-25T00:00:00Z" },
-  { id: 990, action: "vote_submitted",  epoch_id: 47, created_at: "2026-06-24T18:32:00Z" },
-  { id: 989, action: "epoch_opened",    epoch_id: 47, created_at: "2026-06-24T00:00:00Z" },
-  { id: 988, action: "weights_applied", epoch_id: 46, created_at: "2026-06-18T00:00:00Z" },
-]
+import { transparencyApi, weightsApi, type EpochResponse } from "@/lib/api/client"
 
 const WEIGHT_LABELS: Record<string, string> = {
   recency: "Recency",
@@ -67,7 +19,53 @@ const WEIGHT_LABELS: Record<string, string> = {
   relevance: "Relevance",
 }
 
-type PageState = "loading" | "loaded" | "error"
+/* ─── Round-diff derivation ────────────────────────────────
+ * The API has no dedicated round-diff endpoint, so we derive it from the two
+ * most recent epochs. Needs ≥2 epochs; otherwise the section renders empty. */
+
+interface RoundDiff {
+  current_round: number
+  previous_round: number
+  voter_count: number
+  weight_changes: { key: string; before: number; after: number; delta: number }[]
+  keywords_added: { include: string[]; exclude: string[] }
+  keywords_removed: { include: string[]; exclude: string[] }
+}
+
+function deriveRoundDiff(epochs?: EpochResponse[]): RoundDiff | null {
+  if (!epochs || epochs.length < 2) return null
+  const sorted = [...epochs].sort((a, b) => b.id - a.id)
+  const curr = sorted[0]
+  const prev = sorted[1]
+  const keys = ["recency", "engagement", "bridging", "source_diversity", "relevance"] as const
+  const weight_changes = keys
+    .map((key) => {
+      const before = prev.weights[key]
+      const after = curr.weights[key]
+      return { key, before, after, delta: after - before }
+    })
+    .filter((wc) => Math.abs(wc.delta) > 0.001)
+
+  const currInc = curr.content_rules?.include_keywords ?? []
+  const prevInc = prev.content_rules?.include_keywords ?? []
+  const currExc = curr.content_rules?.exclude_keywords ?? []
+  const prevExc = prev.content_rules?.exclude_keywords ?? []
+
+  return {
+    current_round: curr.id,
+    previous_round: prev.id,
+    voter_count: curr.vote_count,
+    weight_changes,
+    keywords_added: {
+      include: currInc.filter((w) => !prevInc.includes(w)),
+      exclude: currExc.filter((w) => !prevExc.includes(w)),
+    },
+    keywords_removed: {
+      include: prevInc.filter((w) => !currInc.includes(w)),
+      exclude: prevExc.filter((w) => !currExc.includes(w)),
+    },
+  }
+}
 
 /* ─── Sub-components ───────────────────────────────────── */
 
@@ -131,17 +129,42 @@ const CheckIcon = () => (
 
 export default function DashboardPage() {
   const router = useRouter()
-  const [pageState, setPageState] = useState<PageState>("loaded")
   const [explainUri, setExplainUri] = useState("")
   const [lastUpdated] = useState(() => new Date())
 
-  const stats = MOCK_STATS
-  const weights = MOCK_WEIGHTS
-  const diff = MOCK_ROUND_DIFF
-  const ledger = MOCK_LEDGER
+  const statsQuery = useQuery({
+    queryKey: ["transparency", "stats"],
+    queryFn: transparencyApi.getStats,
+    retry: false,
+  })
+  const auditQuery = useQuery({
+    queryKey: ["transparency", "audit", 8],
+    queryFn: () => transparencyApi.getAuditLog({ limit: 8 }),
+    retry: false,
+  })
+  const epochQuery = useQuery({
+    queryKey: ["epoch", "current"],
+    queryFn: weightsApi.getCurrentEpoch,
+    retry: false,
+  })
+  const epochsQuery = useQuery({
+    queryKey: ["epochs", 2],
+    queryFn: () => transparencyApi.getEpochHistory(2),
+    retry: false,
+  })
+
+  const stats = statsQuery.data
+  const currentEpoch = epochQuery.data
+  const diff = deriveRoundDiff(epochsQuery.data?.epochs)
+  const entries = auditQuery.data?.entries ?? []
+
+  // Header identity — prefer the stats epoch, fall back to the current epoch.
+  const roundId = stats?.epoch.id ?? currentEpoch?.id
+  const roundPhase = stats?.epoch.status ?? currentEpoch?.phase ?? currentEpoch?.status
+  const voteCount = stats?.governance.votes_this_epoch ?? currentEpoch?.vote_count
 
   return (
-    <AppShell user={null}>
+    <AppShell>
       <div className="max-w-5xl mx-auto px-5 py-10 flex flex-col gap-10">
 
         {/* ── Page header ──────────────────────────────────── */}
@@ -151,25 +174,16 @@ export default function DashboardPage() {
               <h1 className="font-display text-2xl font-bold text-foreground tracking-tight">
                 Transparency overview
               </h1>
-              <StatusChip phase={stats.epoch.phase} />
+              {roundPhase && <StatusChip phase={roundPhase} />}
             </div>
             <p className="text-sm text-foreground/55">
-              Round #{stats.epoch.id} · {stats.governance.votes_this_epoch} votes ·{" "}
+              {roundId != null ? `Round #${roundId}` : "Round —"} · {voteCount ?? 0} votes ·{" "}
               <span className="font-mono text-xs">
                 Updated {lastUpdated.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
               </span>
             </p>
           </div>
           <div className="flex items-center gap-2 flex-wrap">
-            {/* Dev-only state switcher */}
-            <div className="hidden" aria-hidden="true">
-              {(["loading", "loaded", "error"] as PageState[]).map((s) => (
-                <button key={s} onClick={() => setPageState(s)}
-                  className={`text-xs px-2 py-1 rounded border ${pageState === s ? "bg-primary text-primary-foreground border-primary" : "border-border text-foreground/50"}`}>
-                  {s}
-                </button>
-              ))}
-            </div>
             <Button asChild variant="outline" size="sm"
               className="border-border text-foreground/70 hover:text-foreground hover:bg-biscuit text-xs rounded-full">
               <Link href="/vote">Vote now</Link>
@@ -183,38 +197,38 @@ export default function DashboardPage() {
 
         {/* ── Stat cluster ────────────────────────────────── */}
         <section aria-label="Feed statistics">
-          {pageState === "loading" ? (
+          {statsQuery.isLoading ? (
             <StatClusterSkeleton />
-          ) : pageState === "error" ? (
-            <ErrorCard heading="Overview unavailable" body="We couldn't load feed statistics." onRetry={() => setPageState("loaded")} />
+          ) : statsQuery.isError || !stats ? (
+            <ErrorCard heading="Overview unavailable" body="We couldn't load feed statistics." onRetry={() => statsQuery.refetch()} />
           ) : (
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               <StatCard label="Posts scored" value={stats.feed_stats.total_posts_scored.toLocaleString()} sub={`Round #${stats.epoch.id}`} />
               <StatCard label="Unique authors" value={stats.feed_stats.unique_authors.toLocaleString()} />
               <StatCard label="Community votes" value={stats.governance.votes_this_epoch.toLocaleString()} sub="this round" />
-              <StatCard label="Avg total score" value={stats.feed_stats.avg_total.toFixed(2)} sub={`median ${stats.feed_stats.median_total.toFixed(2)}`} />
+              <StatCard label="Median total score" value={stats.feed_stats.median_total_score.toFixed(2)} sub={`avg bridging ${stats.feed_stats.avg_bridging_score.toFixed(2)}`} />
             </div>
           )}
         </section>
 
         {/* ── Feed health strip ────────────────────────────── */}
-        {pageState === "loaded" && (
+        {stats?.metrics && (
           <section aria-label="Feed health metrics">
             <SectionHeader label="Feed health" />
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div className="rounded-xl border border-border bg-card p-5 flex flex-col gap-1">
                 <span className="text-xs text-foreground/50 uppercase tracking-wide font-medium">Author concentration</span>
-                <span className="text-xl font-mono font-bold text-foreground">{stats.metrics.author_gini.toFixed(2)}</span>
+                <span className="text-xl font-mono font-bold text-foreground">{stats.metrics.author_gini != null ? stats.metrics.author_gini.toFixed(2) : "—"}</span>
                 <span className="text-xs text-foreground/45">Gini coefficient · lower = more diverse</span>
               </div>
               <div className="rounded-xl border border-border bg-card p-5 flex flex-col gap-1">
                 <span className="text-xs text-foreground/50 uppercase tracking-wide font-medium">vs. Chronological</span>
-                <span className="text-xl font-mono font-bold text-foreground">{(stats.metrics.vs_chronological_overlap * 100).toFixed(0)}%</span>
+                <span className="text-xl font-mono font-bold text-foreground">{stats.metrics.vs_chronological_overlap != null ? `${(stats.metrics.vs_chronological_overlap * 100).toFixed(0)}%` : "—"}</span>
                 <span className="text-xs text-foreground/45">Overlap with time-only feed</span>
               </div>
               <div className="rounded-xl border border-border bg-card p-5 flex flex-col gap-1">
                 <span className="text-xs text-foreground/50 uppercase tracking-wide font-medium">vs. Engagement</span>
-                <span className="text-xl font-mono font-bold text-foreground">{(stats.metrics.vs_engagement_overlap * 100).toFixed(0)}%</span>
+                <span className="text-xl font-mono font-bold text-foreground">{stats.metrics.vs_engagement_overlap != null ? `${(stats.metrics.vs_engagement_overlap * 100).toFixed(0)}%` : "—"}</span>
                 <span className="text-xs text-foreground/45">Overlap with engagement-only feed</span>
               </div>
             </div>
@@ -225,17 +239,17 @@ export default function DashboardPage() {
         <section aria-label="Active community weights">
           <SectionHeader label="Active weight mix" />
           <div className="rounded-xl border border-border bg-card p-6">
-            {pageState === "loading" ? (
+            {epochQuery.isLoading ? (
               <WeightsSkeleton />
-            ) : pageState === "error" ? (
+            ) : epochQuery.isError || !currentEpoch ? (
               <EmptyState heading="Weights unavailable" body="Could not load the current weight mix." showCorgi={false} />
             ) : (
               <div className="flex flex-col gap-5">
-                {Object.entries(weights).map(([key, val]) => (
+                {Object.entries(currentEpoch.weights).map(([key, val]) => (
                   <WeightBar key={key} label={WEIGHT_LABELS[key] ?? key} value={val} />
                 ))}
                 <p className="text-xs text-foreground/40 italic pt-1 border-t border-border/60">
-                  Set by {stats.governance.votes_this_epoch} community votes · Round #{stats.epoch.id}
+                  Set by {currentEpoch.vote_count} community votes · Round #{currentEpoch.id}
                 </p>
               </div>
             )}
@@ -244,45 +258,65 @@ export default function DashboardPage() {
 
         {/* ── What changed this round ──────────────────────── */}
         <section aria-label="Round diff">
-          <SectionHeader
-            label={`What changed — round ${diff.previous_round} → ${diff.current_round}`}
-            action={<span className="text-xs font-mono text-foreground/40">{diff.voter_count} voters</span>}
-          />
-          {diff.weight_changes.length === 0 && diff.keywords_added.include.length === 0 && diff.keywords_removed.exclude.length === 0 ? (
-            <EmptyState heading="No changes this round" body="Weights and content rules stayed the same from the previous round." showCorgi={false} />
+          {epochsQuery.isLoading ? (
+            <>
+              <SectionHeader label="What changed" />
+              <div className="rounded-xl border border-border bg-card p-6">
+                <WeightsSkeleton />
+              </div>
+            </>
+          ) : !diff ? (
+            <>
+              <SectionHeader label="What changed" />
+              <EmptyState heading="Round comparison unavailable" body="We need at least two governance rounds to show what changed between them." showCorgi={false} />
+            </>
+          ) : diff.weight_changes.length === 0 && diff.keywords_added.include.length === 0 && diff.keywords_removed.exclude.length === 0 ? (
+            <>
+              <SectionHeader
+                label={`What changed — round ${diff.previous_round} → ${diff.current_round}`}
+                action={<span className="text-xs font-mono text-foreground/40">{diff.voter_count} voters</span>}
+              />
+              <EmptyState heading="No changes this round" body="Weights and content rules stayed the same from the previous round." showCorgi={false} />
+            </>
           ) : (
-            <div className="rounded-xl border border-border bg-card divide-y divide-border/60">
-              {diff.weight_changes.length > 0 && (
-                <div className="p-5 flex flex-col gap-3">
-                  <p className="text-xs font-semibold text-foreground/50 uppercase tracking-wide">Weight changes</p>
-                  <div className="flex flex-col gap-3">
-                    {diff.weight_changes.map((wc) => (
-                      <div key={wc.key} className="flex items-center justify-between gap-2 sm:gap-4">
-                        <span className="text-sm font-medium text-foreground w-24 sm:w-36 flex-shrink-0">{WEIGHT_LABELS[wc.key] ?? wc.key}</span>
-                        <div className="flex items-center gap-2 flex-1">
-                          <span className="text-xs font-mono text-foreground/45 w-8 text-right">{(wc.before * 100).toFixed(0)}%</span>
-                          <div className="flex-1 h-1.5 rounded-full bg-biscuit overflow-hidden relative">
-                            <div className="absolute inset-y-0 left-0 rounded-full bg-foreground/20" style={{ width: `${wc.before * 100}%` }} />
-                            <div className="absolute inset-y-0 left-0 rounded-full bg-primary transition-all" style={{ width: `${wc.after * 100}%` }} />
+            <>
+              <SectionHeader
+                label={`What changed — round ${diff.previous_round} → ${diff.current_round}`}
+                action={<span className="text-xs font-mono text-foreground/40">{diff.voter_count} voters</span>}
+              />
+              <div className="rounded-xl border border-border bg-card divide-y divide-border/60">
+                {diff.weight_changes.length > 0 && (
+                  <div className="p-5 flex flex-col gap-3">
+                    <p className="text-xs font-semibold text-foreground/50 uppercase tracking-wide">Weight changes</p>
+                    <div className="flex flex-col gap-3">
+                      {diff.weight_changes.map((wc) => (
+                        <div key={wc.key} className="flex items-center justify-between gap-2 sm:gap-4">
+                          <span className="text-sm font-medium text-foreground w-24 sm:w-36 flex-shrink-0">{WEIGHT_LABELS[wc.key] ?? wc.key}</span>
+                          <div className="flex items-center gap-2 flex-1">
+                            <span className="text-xs font-mono text-foreground/45 w-8 text-right">{(wc.before * 100).toFixed(0)}%</span>
+                            <div className="flex-1 h-1.5 rounded-full bg-biscuit overflow-hidden relative">
+                              <div className="absolute inset-y-0 left-0 rounded-full bg-foreground/20" style={{ width: `${wc.before * 100}%` }} />
+                              <div className="absolute inset-y-0 left-0 rounded-full bg-primary transition-all" style={{ width: `${wc.after * 100}%` }} />
+                            </div>
+                            <span className="text-xs font-mono text-foreground w-8">{(wc.after * 100).toFixed(0)}%</span>
                           </div>
-                          <span className="text-xs font-mono text-foreground w-8">{(wc.after * 100).toFixed(0)}%</span>
+                          <DeltaChip delta={wc.delta} />
                         </div>
-                        <DeltaChip delta={wc.delta} />
-                      </div>
-                    ))}
+                      ))}
+                    </div>
                   </div>
-                </div>
-              )}
-              {(diff.keywords_added.include.length > 0 || diff.keywords_removed.exclude.length > 0) && (
-                <div className="p-5 flex flex-col gap-3">
-                  <p className="text-xs font-semibold text-foreground/50 uppercase tracking-wide">Content rule changes</p>
-                  <div className="flex flex-wrap gap-2">
-                    {diff.keywords_added.include.map((w) => <KeywordChip key={w} word={w} variant="add" />)}
-                    {diff.keywords_removed.exclude.map((w) => <KeywordChip key={w} word={w} variant="remove" />)}
+                )}
+                {(diff.keywords_added.include.length > 0 || diff.keywords_removed.exclude.length > 0) && (
+                  <div className="p-5 flex flex-col gap-3">
+                    <p className="text-xs font-semibold text-foreground/50 uppercase tracking-wide">Content rule changes</p>
+                    <div className="flex flex-wrap gap-2">
+                      {diff.keywords_added.include.map((w) => <KeywordChip key={w} word={w} variant="add" />)}
+                      {diff.keywords_removed.exclude.map((w) => <KeywordChip key={w} word={w} variant="remove" />)}
+                    </div>
                   </div>
-                </div>
-              )}
-            </div>
+                )}
+              </div>
+            </>
           )}
         </section>
 
@@ -326,11 +360,22 @@ export default function DashboardPage() {
               </Link>
             }
           />
-          {ledger.length === 0 ? (
+          {auditQuery.isLoading ? (
+            <div className="rounded-xl border border-border bg-card divide-y divide-border/60 overflow-hidden" aria-busy="true">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="flex items-center justify-between gap-4 px-5 py-3">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+              ))}
+            </div>
+          ) : auditQuery.isError ? (
+            <ErrorCard heading="Ledger unavailable" body="We couldn't load recent audit activity." onRetry={() => auditQuery.refetch()} />
+          ) : entries.length === 0 ? (
             <EmptyState heading="No ledger entries yet" body="Audit events will appear here once governance activity begins." showCorgi={false} />
           ) : (
             <div className="rounded-xl border border-border bg-card divide-y divide-border/60 overflow-hidden">
-              {ledger.map((entry) => {
+              {entries.map((entry) => {
                 const date = new Date(entry.created_at)
                 return (
                   <div key={entry.id} className="flex items-center justify-between gap-4 px-5 py-3 hover:bg-biscuit/30 transition-colors">

--- a/web-next/app/vote/page.tsx
+++ b/web-next/app/vote/page.tsx
@@ -267,6 +267,8 @@ function VoteWorkbench({ epoch, myVote, topics, contentRules, isAuthenticated, o
   const invalidateVote = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["vote", "mine"] })
     queryClient.invalidateQueries({ queryKey: ["epoch", "current"] })
+    queryClient.invalidateQueries({ queryKey: ["content-rules"] })
+    queryClient.invalidateQueries({ queryKey: ["topics"] })
   }, [queryClient])
 
   const weightsMutation = useMutation({
@@ -627,6 +629,29 @@ export default function VotePage() {
           heading="Ballot unavailable"
           body="We couldn't load the current voting round. Try again in a moment."
           onRetry={() => epochQuery.refetch()}
+        />
+      </div>
+    )
+  } else if (topicsQuery.isError || contentRulesQuery.isError) {
+    content = (
+      <div className="max-w-xl mx-auto px-5 py-20">
+        <ErrorCard
+          heading="Ballot data incomplete"
+          body="Part of the ballot (topics or content rules) failed to load, so the ballot can't be shown accurately."
+          onRetry={() => {
+            if (topicsQuery.isError) void topicsQuery.refetch()
+            if (contentRulesQuery.isError) void contentRulesQuery.refetch()
+          }}
+        />
+      </div>
+    )
+  } else if (isAuthenticated && myVoteQuery.isError) {
+    content = (
+      <div className="max-w-xl mx-auto px-5 py-20">
+        <ErrorCard
+          heading="Your ballot couldn't be loaded"
+          body="We couldn't retrieve your previous vote, so the ballot won't be shown pre-filled. Retry to load it."
+          onRetry={() => void myVoteQuery.refetch()}
         />
       </div>
     )

--- a/web-next/app/vote/page.tsx
+++ b/web-next/app/vote/page.tsx
@@ -1,8 +1,11 @@
 "use client"
 
-import { useState, useRef, useCallback } from "react"
+import { useCallback, useRef, useState } from "react"
 import Link from "next/link"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { AppShell } from "@/components/app-shell"
+import { SignInDialog } from "@/components/sign-in-dialog"
+import { useAuth } from "@/components/auth-provider"
 import { StatusChip } from "@/components/ui/status-chip"
 import { WeightBar } from "@/components/ui/weight-bar"
 import { LinkedSlider, type SliderSignal } from "@/components/ui/linked-slider"
@@ -10,49 +13,14 @@ import { KeywordInput } from "@/components/ui/keyword-input"
 import { TopicGroup } from "@/components/ui/topic-slider"
 import { WeightsSkeleton, ErrorCard, EmptyState } from "@/components/ui/state-kit"
 import { Button } from "@/components/ui/button"
-
-/* ─── Mock data — exact seam field names from brief ──────── */
-
-const MOCK_EPOCH = {
-  id: 47,
-  status: "voting",
-  phase: "voting",
-  vote_count: 312,
-  subscriber_count: 480,
-  voting_ends_at: "2026-07-01T17:00:00Z",
-  weights: {
-    recency: 0.35,
-    engagement: 0.25,
-    bridging: 0.20,
-    source_diversity: 0.15,
-    relevance: 0.05,
-  },
-}
-
-const MOCK_MY_VOTE = {
-  vote: { recency: 0.3, engagement: 0.3, bridging: 0.2, sourceDiversity: 0.1, relevance: 0.1 },
-  contentVote: { includeKeywords: ["ai"], excludeKeywords: ["spam"] },
-  topicWeights: { "machine-learning": 0.8 },
-  voted_at: "2026-06-26T14:10:00Z",
-  epoch_id: 47,
-}
-
-const MOCK_TOPICS = [
-  { slug: "machine-learning", name: "Machine learning", description: null, parentSlug: "technology", currentWeight: 0.62 },
-  { slug: "open-source",      name: "Open source",      description: null, parentSlug: "technology", currentWeight: 0.55 },
-  { slug: "climate",          name: "Climate",          description: null, parentSlug: "science",    currentWeight: 0.44 },
-  { slug: "research",         name: "Research",         description: null, parentSlug: "science",    currentWeight: 0.50 },
-  { slug: "local-news",       name: "Local news",       description: null, parentSlug: "news",       currentWeight: 0.38 },
-]
-
-const MOCK_CONTENT_RULES = {
-  include_keywords: ["ai"],
-  exclude_keywords: ["spam"],
-  include_keyword_votes: { ai: 12 },
-  exclude_keyword_votes: { spam: 7 },
-  total_voters: 312,
-  threshold: 0.3,
-}
+import {
+  voteApi,
+  weightsApi,
+  type EpochResponse,
+  type GetVoteResponse,
+  type TopicCatalogEntry,
+  type ContentRulesResponse,
+} from "@/lib/api/client"
 
 /* ─── Slider signal definitions ────────────────────────────── */
 
@@ -65,8 +33,15 @@ const SIGNAL_META: Record<string, { label: string; description: string }> = {
 }
 
 type Section = "weights" | "content" | "topics"
-type PageState = "loading" | "loaded" | "error"
 type SubmitState = "idle" | "submitting" | "success" | "error"
+
+/** Map a react-query mutation's flags to the SubmitRow visual state. */
+function submitStateOf(m: { isPending: boolean; isSuccess: boolean; isError: boolean }): SubmitState {
+  if (m.isPending) return "submitting"
+  if (m.isSuccess) return "success"
+  if (m.isError) return "error"
+  return "idle"
+}
 
 function phaseLabel(phase: string) {
   if (phase === "voting")  return { label: "Voting open",   locked: false }
@@ -114,9 +89,11 @@ function SectionTab({ id, active, label, done, onClick }: {
   )
 }
 
-function RoundCard({ epoch }: { epoch: typeof MOCK_EPOCH }) {
-  const { locked } = phaseLabel(epoch.phase)
-  const pct = Math.round((epoch.vote_count / epoch.subscriber_count) * 100)
+function RoundCard({ epoch }: { epoch: EpochResponse }) {
+  const phase = epoch.phase ?? epoch.status
+  const { locked } = phaseLabel(phase)
+  const denom = epoch.subscriber_count ?? 0
+  const pct = denom > 0 ? Math.round((epoch.vote_count / denom) * 100) : 0
   return (
     <div className="rounded-xl border border-border bg-card p-5 flex flex-col gap-5">
       {/* Page identity lives here, not floating above the grid */}
@@ -136,12 +113,12 @@ function RoundCard({ epoch }: { epoch: typeof MOCK_EPOCH }) {
           <span className="text-[10px] text-foreground/40 font-mono uppercase tracking-widest">Round</span>
           <span className="text-2xl font-mono font-bold text-foreground leading-none">#{epoch.id}</span>
         </div>
-        <StatusChip phase={epoch.phase} />
+        <StatusChip phase={phase} />
       </div>
 
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between text-xs">
-          <span className="text-foreground/50">{epoch.vote_count.toLocaleString()} of {epoch.subscriber_count.toLocaleString()} voted</span>
+          <span className="text-foreground/50">{epoch.vote_count.toLocaleString()} of {denom.toLocaleString()} voted</span>
           <span className="font-mono text-foreground/60">{pct}%</span>
         </div>
         <div className="h-1.5 rounded-full bg-biscuit overflow-hidden">
@@ -153,12 +130,12 @@ function RoundCard({ epoch }: { epoch: typeof MOCK_EPOCH }) {
         <div className="rounded-lg bg-biscuit px-3 py-2.5 text-xs text-foreground/55 leading-relaxed">
           Voting is closed for this round. Results are being tallied.
         </div>
-      ) : (
+      ) : epoch.voting_ends_at ? (
         <div className="flex items-center justify-between">
           <span className="text-[10px] text-foreground/40 font-mono uppercase tracking-widest">Closes</span>
           <span className="text-xs font-mono text-primary font-semibold">{timeUntil(epoch.voting_ends_at)}</span>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -214,44 +191,107 @@ function SubmitRow({
   )
 }
 
-/* ─── Page ───────────────────────────────────────────────── */
+/* ─── Loaded ballot workbench ─────────────────────────────── */
 
-export default function VotePage() {
-  const [pageState] = useState<PageState>("loaded")
+interface VoteWorkbenchProps {
+  epoch: EpochResponse
+  /** The signed-in user's existing vote, if any (undefined when unauthenticated). */
+  myVote?: GetVoteResponse
+  topics: TopicCatalogEntry[]
+  /** Community content rules; undefined when unavailable (e.g. no active epoch). */
+  contentRules?: ContentRulesResponse
+  isAuthenticated: boolean
+  onRequireAuth: () => void
+}
+
+function VoteWorkbench({ epoch, myVote, topics, contentRules, isAuthenticated, onRequireAuth }: VoteWorkbenchProps) {
+  const queryClient = useQueryClient()
+  const phase = epoch.phase ?? epoch.status
+  const { locked } = phaseLabel(phase)
+
   const [activeSection, setActiveSection] = useState<Section>("weights")
 
-  // Weight signals state
-  const epoch = MOCK_EPOCH
-  const { locked } = phaseLabel(epoch.phase)
+  // Seed the weight sliders from the user's existing vote, falling back to the
+  // current community weights. (Both shapes sum to 1.)
+  const seedVote = myVote?.vote
+  const initialSignalValues: Record<string, number> = seedVote
+    ? {
+        recency: seedVote.recency,
+        engagement: seedVote.engagement,
+        bridging: seedVote.bridging,
+        source_diversity: seedVote.sourceDiversity,
+        relevance: seedVote.relevance,
+      }
+    : {
+        recency: epoch.weights.recency,
+        engagement: epoch.weights.engagement,
+        bridging: epoch.weights.bridging,
+        source_diversity: epoch.weights.source_diversity,
+        relevance: epoch.weights.relevance,
+      }
 
-  const [signals, setSignals] = useState<SliderSignal[]>([
-    { key: "recency",          value: MOCK_MY_VOTE.vote.recency,         ...SIGNAL_META["recency"] },
-    { key: "engagement",       value: MOCK_MY_VOTE.vote.engagement,      ...SIGNAL_META["engagement"] },
-    { key: "bridging",         value: MOCK_MY_VOTE.vote.bridging,        ...SIGNAL_META["bridging"] },
-    { key: "source_diversity", value: MOCK_MY_VOTE.vote.sourceDiversity, ...SIGNAL_META["source_diversity"] },
-    { key: "relevance",        value: MOCK_MY_VOTE.vote.relevance,       ...SIGNAL_META["relevance"] },
-  ])
+  const [signals, setSignals] = useState<SliderSignal[]>(
+    ["recency", "engagement", "bridging", "source_diversity", "relevance"].map((key) => ({
+      key,
+      value: initialSignalValues[key] ?? 0,
+      ...SIGNAL_META[key],
+    }))
+  )
   const [lastMoved, setLastMoved] = useState<string | null>(null)
   const prevSignalValues = useRef<Record<string, number>>(
     Object.fromEntries(signals.map((s) => [s.key, s.value]))
   )
-  const [weightSubmit, setWeightSubmit] = useState<SubmitState>("idle")
 
-  // Content vote state
-  const [includeKeywords, setIncludeKeywords] = useState<string[]>(MOCK_MY_VOTE.contentVote.includeKeywords)
-  const [excludeKeywords, setExcludeKeywords] = useState<string[]>(MOCK_MY_VOTE.contentVote.excludeKeywords)
-  const [contentSubmit, setContentSubmit] = useState<SubmitState>("idle")
+  // Content vote state (seeded from the user's existing content vote).
+  const [includeKeywords, setIncludeKeywords] = useState<string[]>(myVote?.contentVote?.includeKeywords ?? [])
+  const [excludeKeywords, setExcludeKeywords] = useState<string[]>(myVote?.contentVote?.excludeKeywords ?? [])
 
-  // Topic state
+  // Topic state (seeded from the user's per-topic weights, else neutral 0.5).
   const [topicValues, setTopicValues] = useState<Record<string, number>>(() => {
     const init: Record<string, number> = {}
-    MOCK_TOPICS.forEach((t) => { init[t.slug] = MOCK_MY_VOTE.topicWeights[t.slug as keyof typeof MOCK_MY_VOTE.topicWeights] ?? 0.5 })
+    topics.forEach((t) => { init[t.slug] = myVote?.topicWeights?.[t.slug] ?? 0.5 })
     return init
   })
-  const [topicSubmit, setTopicSubmit] = useState<SubmitState>("idle")
 
-  // Running weights for the right rail (community weights from epoch)
   const communityWeights = epoch.weights
+  const rules = contentRules ?? {
+    epoch_id: epoch.id,
+    include_keywords: [],
+    exclude_keywords: [],
+    include_keyword_votes: {},
+    exclude_keyword_votes: {},
+    total_voters: 0,
+    threshold: 0,
+  }
+
+  const invalidateVote = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["vote", "mine"] })
+    queryClient.invalidateQueries({ queryKey: ["epoch", "current"] })
+  }, [queryClient])
+
+  const weightsMutation = useMutation({
+    mutationFn: () => {
+      const vals = Object.fromEntries(signals.map((s) => [s.key, s.value]))
+      return voteApi.submitVote({
+        recency: vals.recency,
+        engagement: vals.engagement,
+        bridging: vals.bridging,
+        sourceDiversity: vals.source_diversity,
+        relevance: vals.relevance,
+      })
+    },
+    onSuccess: invalidateVote,
+  })
+
+  const contentMutation = useMutation({
+    mutationFn: () => voteApi.submitVote(null, { includeKeywords, excludeKeywords }),
+    onSuccess: invalidateVote,
+  })
+
+  const topicsMutation = useMutation({
+    mutationFn: () => voteApi.submitVote(null, undefined, topicValues),
+    onSuccess: invalidateVote,
+  })
 
   const handleSignalChange = useCallback((updated: SliderSignal[]) => {
     const moved = updated.find((u, i) => Math.abs(u.value - signals[i].value) > 0.001)
@@ -260,16 +300,24 @@ export default function VotePage() {
       setLastMoved(moved.key)
     }
     setSignals(updated)
-    setWeightSubmit("idle")
-  }, [signals])
+    weightsMutation.reset()
+  }, [signals, weightsMutation])
 
-  const mockSubmit = (setter: (s: SubmitState) => void) => {
-    setter("submitting")
-    setTimeout(() => setter("success"), 1200)
+  const submitWeights = () => {
+    if (!isAuthenticated) { onRequireAuth(); return }
+    weightsMutation.mutate()
+  }
+  const submitContent = () => {
+    if (!isAuthenticated) { onRequireAuth(); return }
+    contentMutation.mutate()
+  }
+  const submitTopics = () => {
+    if (!isAuthenticated) { onRequireAuth(); return }
+    topicsMutation.mutate()
   }
 
   // Group topics by parentSlug
-  const topicGroups = MOCK_TOPICS.reduce<Record<string, typeof MOCK_TOPICS>>((acc, t) => {
+  const topicGroups = topics.reduce<Record<string, TopicCatalogEntry[]>>((acc, t) => {
     const key = t.parentSlug ?? "other"
     ;(acc[key] = acc[key] ?? []).push(t)
     return acc
@@ -279,268 +327,326 @@ export default function VotePage() {
     ([, v]) => Math.abs(v - 0.5) > 0.01
   ).length
 
-  if (pageState === "loading") {
-    return (
-      <AppShell user={null}>
-        <div className="max-w-6xl mx-auto px-5 py-10">
-          <WeightsSkeleton />
-        </div>
-      </AppShell>
-    )
-  }
+  const participationPct = (epoch.subscriber_count ?? 0) > 0
+    ? Math.round((epoch.vote_count / (epoch.subscriber_count ?? 1)) * 100)
+    : 0
 
-  if (pageState === "error") {
-    return (
-      <AppShell user={null}>
-        <div className="max-w-xl mx-auto px-5 py-20">
-          <ErrorCard heading="Ballot unavailable" body="We couldn't load the current voting round. Try again in a moment." />
-        </div>
-      </AppShell>
+  return (
+    <div className="max-w-6xl mx-auto px-5 py-8 flex flex-col gap-6">
+
+      {/* ── 3-column workbench ───────────────────────────── */}
+      <div className="grid grid-cols-1 lg:grid-cols-[220px_1fr_240px] gap-6 items-start">
+
+        {/* ── LEFT RAIL ─────────────────────────────────── */}
+        <aside className="flex flex-col gap-4 lg:sticky lg:top-20">
+          <RoundCard epoch={epoch} />
+
+          {/* Section nav — flat list, no card chrome */}
+          <nav className="flex flex-col gap-0.5 px-1" aria-label="Ballot sections">
+            <SectionTab id="weights" active={activeSection === "weights"} label="Ranking weights"   done={weightsMutation.isSuccess} onClick={() => setActiveSection("weights")} />
+            <SectionTab id="content" active={activeSection === "content"} label="Content rules"      done={contentMutation.isSuccess} onClick={() => setActiveSection("content")} />
+            <SectionTab id="topics"  active={activeSection === "topics"}  label="Topic preferences"  done={topicsMutation.isSuccess}  onClick={() => setActiveSection("topics")} />
+          </nav>
+
+          {/* Back to overview */}
+          <Link href="/dashboard" className="text-xs text-foreground/40 hover:text-foreground/70 transition-colors text-center">
+            ← Back to overview
+          </Link>
+        </aside>
+
+        {/* ── CENTER ─────────────────────────────────────── */}
+        <main className="flex flex-col gap-6 min-w-0">
+
+          {/* ── Section 01: Ranking weights ─────────────── */}
+          {activeSection === "weights" && (
+            <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-6">
+              <div className="flex flex-col gap-1.5">
+                <span className="text-[10px] font-mono text-foreground/35 uppercase tracking-widest">01 — Ranking weights</span>
+                <h2 className="text-lg font-semibold text-foreground leading-snug">Signal weights</h2>
+                <p className="text-sm text-foreground/50 leading-relaxed">
+                  Drag to allocate importance across the five signals. Adjusting one redistributes the rest — they always sum to 100%.
+                </p>
+              </div>
+
+              {locked ? (
+                <div className="flex flex-col gap-4">
+                  {signals.map((sig) => (
+                    <WeightBar key={sig.key} label={sig.label} value={sig.value} />
+                  ))}
+                  <p className="text-xs text-foreground/40 italic">Ballot locked — your vote from this round is shown above.</p>
+                </div>
+              ) : (
+                <LinkedSlider
+                  signals={signals}
+                  onChange={handleSignalChange}
+                  lastMoved={lastMoved}
+                  prevValues={prevSignalValues.current}
+                  disabled={locked}
+                />
+              )}
+
+              <SubmitRow
+                label="Submit weight vote"
+                state={submitStateOf(weightsMutation)}
+                votedAt={myVote?.voted_at}
+                onSubmit={submitWeights}
+                disabled={locked}
+              />
+            </div>
+          )}
+
+          {/* ── Section 02: Content rules ────────────────── */}
+          {activeSection === "content" && (
+            <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-6">
+              <div className="flex flex-col gap-1.5">
+                <span className="text-[10px] font-mono text-foreground/35 uppercase tracking-widest">02 — Content rules</span>
+                <h2 className="text-lg font-semibold text-foreground leading-snug">Keywords</h2>
+                <p className="text-sm text-foreground/50 leading-relaxed">
+                  Vote on which keywords to boost or suppress. Keywords reaching {Math.round(rules.threshold * 100)}% community support take effect.
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-5">
+                <KeywordInput
+                  label="Include keywords"
+                  keywords={includeKeywords}
+                  variant="include"
+                  onChange={(next) => { setIncludeKeywords(next); contentMutation.reset() }}
+                  disabled={locked}
+                  communityVotes={rules.include_keyword_votes}
+                  totalVoters={rules.total_voters}
+                />
+                <KeywordInput
+                  label="Exclude keywords"
+                  keywords={excludeKeywords}
+                  variant="exclude"
+                  onChange={(next) => { setExcludeKeywords(next); contentMutation.reset() }}
+                  disabled={locked}
+                  communityVotes={rules.exclude_keyword_votes}
+                  totalVoters={rules.total_voters}
+                />
+              </div>
+
+              {/* Community rules context */}
+              <div className="rounded-lg bg-biscuit/50 border border-border/60 px-4 py-3 flex flex-col gap-1">
+                <p className="text-xs font-semibold text-foreground/55 uppercase tracking-wide">Active community rules</p>
+                <div className="flex flex-wrap gap-1.5 mt-1">
+                  {rules.include_keywords.map((w) => (
+                    <span key={w} className="text-xs font-mono px-2 py-0.5 rounded-full bg-success/10 border border-success/25 text-success">+{w}</span>
+                  ))}
+                  {rules.exclude_keywords.map((w) => (
+                    <span key={w} className="text-xs font-mono px-2 py-0.5 rounded-full bg-tongue/15 border border-tongue/30 text-tongue-foreground line-through">−{w}</span>
+                  ))}
+                  {rules.include_keywords.length === 0 && rules.exclude_keywords.length === 0 && (
+                    <span className="text-xs text-foreground/40 italic">No active rules yet</span>
+                  )}
+                </div>
+              </div>
+
+              <SubmitRow
+                label="Submit content vote"
+                state={submitStateOf(contentMutation)}
+                votedAt={myVote?.voted_at}
+                onSubmit={submitContent}
+                disabled={locked}
+              />
+            </div>
+          )}
+
+          {/* ── Section 03: Topic preferences ───────────── */}
+          {activeSection === "topics" && (
+            <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-6">
+              <div className="flex flex-col gap-1">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-[10px] font-mono text-foreground/35 uppercase tracking-widest">03 — Topic preferences</span>
+                    <h2 className="text-lg font-semibold text-foreground leading-snug">Topics</h2>
+                    <p className="text-sm text-foreground/50 leading-relaxed">
+                      Slide right to boost a topic, left to reduce it. The vertical marker shows the community average.
+                    </p>
+                  </div>
+                  {touchedTopicCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const reset: Record<string, number> = {}
+                        topics.forEach((t) => { reset[t.slug] = 0.5 })
+                        setTopicValues(reset)
+                        topicsMutation.reset()
+                      }}
+                      className="text-xs text-foreground/40 hover:text-primary transition-colors underline underline-offset-2 flex-shrink-0 mt-1"
+                    >
+                      Reset all
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {topics.length === 0 ? (
+                <EmptyState
+                  heading="No topics configured"
+                  body="The community hasn't set up topic categories for this round yet."
+                  showCorgi={false}
+                />
+              ) : (
+                <div className="flex flex-col gap-5">
+                  {Object.entries(topicGroups).map(([parent, groupTopics]) => (
+                    <TopicGroup
+                      key={parent}
+                      parentSlug={parent}
+                      topics={groupTopics}
+                      values={topicValues}
+                      onChangeAll={(slug, val) => {
+                        setTopicValues((prev) => ({ ...prev, [slug]: val }))
+                        topicsMutation.reset()
+                      }}
+                      touchedCount={groupTopics.filter((t) => Math.abs((topicValues[t.slug] ?? 0.5) - 0.5) > 0.01).length}
+                      disabled={locked}
+                    />
+                  ))}
+                </div>
+              )}
+
+              <SubmitRow
+                label="Submit topic vote"
+                state={submitStateOf(topicsMutation)}
+                votedAt={myVote?.voted_at}
+                onSubmit={submitTopics}
+                disabled={locked}
+              />
+            </div>
+          )}
+
+        </main>
+
+        {/* ── RIGHT RAIL ────────────────────────────────── */}
+        <aside className="hidden lg:flex flex-col gap-0 lg:sticky lg:top-20 rounded-xl border border-border bg-card overflow-hidden">
+
+          {/* Running community weights */}
+          <div className="p-5 flex flex-col gap-3">
+            <p className="text-[10px] text-foreground/40 font-mono uppercase tracking-widest">Live weights · Round #{epoch.id}</p>
+            <div className="flex flex-col gap-3">
+              {Object.entries(communityWeights).map(([key, val]) => (
+                <WeightBar key={key} label={SIGNAL_META[key]?.label ?? key} value={val} size="sm" />
+              ))}
+            </div>
+          </div>
+
+          <div className="h-px bg-border/60 mx-5" />
+
+          {/* Active content filters summary */}
+          <div className="p-5 flex flex-col gap-2.5">
+            <p className="text-[10px] text-foreground/40 font-mono uppercase tracking-widest">Active filters</p>
+            {rules.include_keywords.length === 0 && rules.exclude_keywords.length === 0 ? (
+              <p className="text-xs text-foreground/35">None this round</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {rules.include_keywords.map((w) => (
+                  <span key={w} className="text-[11px] font-mono px-2 py-0.5 rounded-full bg-success/10 border border-success/25 text-success">+{w}</span>
+                ))}
+                {rules.exclude_keywords.map((w) => (
+                  <span key={w} className="text-[11px] font-mono px-2 py-0.5 rounded-full bg-tongue/15 border border-tongue/30 text-tongue-foreground">−{w}</span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="h-px bg-border/60 mx-5" />
+
+          {/* Participation — quiet, not a callout */}
+          <div className="p-5 flex flex-col gap-2">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-foreground/50">{epoch.vote_count.toLocaleString()} of {(epoch.subscriber_count ?? 0).toLocaleString()} voted</span>
+              <span className="font-mono text-foreground/60">{participationPct}%</span>
+            </div>
+            <div className="h-1.5 rounded-full bg-biscuit overflow-hidden">
+              <div
+                className="h-1.5 rounded-full bg-primary/70 transition-all"
+                style={{ width: `${participationPct}%` }}
+              />
+            </div>
+            <p className="text-[10px] text-foreground/40 leading-relaxed">
+              Each vote counts equally.
+            </p>
+          </div>
+
+        </aside>
+      </div>
+    </div>
+  )
+}
+
+/* ─── Page ───────────────────────────────────────────────── */
+
+export default function VotePage() {
+  const { isAuthenticated } = useAuth()
+  const [signInOpen, setSignInOpen] = useState(false)
+
+  const epochQuery = useQuery({
+    queryKey: ["epoch", "current"],
+    queryFn: weightsApi.getCurrentEpoch,
+    retry: false,
+  })
+  const topicsQuery = useQuery({
+    queryKey: ["topics"],
+    queryFn: voteApi.getTopicCatalog,
+    retry: false,
+  })
+  const contentRulesQuery = useQuery({
+    queryKey: ["content-rules"],
+    queryFn: voteApi.getContentRules,
+    retry: false,
+  })
+  const myVoteQuery = useQuery({
+    queryKey: ["vote", "mine"],
+    queryFn: voteApi.getVote,
+    enabled: isAuthenticated,
+    retry: false,
+  })
+
+  // The ballot round is the gating resource; the supporting queries (topics,
+  // rules, my vote) are seeded into the workbench once all have settled so its
+  // interactive state initialises synchronously and correctly.
+  const coreLoading =
+    epochQuery.isLoading ||
+    topicsQuery.isLoading ||
+    contentRulesQuery.isLoading ||
+    (isAuthenticated && myVoteQuery.isLoading)
+
+  let content: React.ReactNode
+  if (coreLoading) {
+    content = (
+      <div className="max-w-6xl mx-auto px-5 py-10">
+        <WeightsSkeleton />
+      </div>
+    )
+  } else if (epochQuery.isError || !epochQuery.data) {
+    content = (
+      <div className="max-w-xl mx-auto px-5 py-20">
+        <ErrorCard
+          heading="Ballot unavailable"
+          body="We couldn't load the current voting round. Try again in a moment."
+          onRetry={() => epochQuery.refetch()}
+        />
+      </div>
+    )
+  } else {
+    content = (
+      <VoteWorkbench
+        epoch={epochQuery.data}
+        myVote={myVoteQuery.data}
+        topics={topicsQuery.data?.topics ?? []}
+        contentRules={contentRulesQuery.data}
+        isAuthenticated={isAuthenticated}
+        onRequireAuth={() => setSignInOpen(true)}
+      />
     )
   }
 
   return (
-    <AppShell user={{ handle: "maya.bsky.social", did: "did:plc:abc123" }}>
-      <div className="max-w-6xl mx-auto px-5 py-8 flex flex-col gap-6">
-
-        {/* ── 3-column workbench ───────────────────────────── */}
-        <div className="grid grid-cols-1 lg:grid-cols-[220px_1fr_240px] gap-6 items-start">
-
-          {/* ── LEFT RAIL ─────────────────────────────────── */}
-          <aside className="flex flex-col gap-4 lg:sticky lg:top-20">
-            <RoundCard epoch={epoch} />
-
-            {/* Section nav — flat list, no card chrome */}
-            <nav className="flex flex-col gap-0.5 px-1" aria-label="Ballot sections">
-              <SectionTab id="weights" active={activeSection === "weights"} label="Ranking weights"   done={weightSubmit === "success"} onClick={() => setActiveSection("weights")} />
-              <SectionTab id="content" active={activeSection === "content"} label="Content rules"      done={contentSubmit === "success"} onClick={() => setActiveSection("content")} />
-              <SectionTab id="topics"  active={activeSection === "topics"}  label="Topic preferences"  done={topicSubmit === "success"}  onClick={() => setActiveSection("topics")} />
-            </nav>
-
-            {/* Back to overview */}
-            <Link href="/dashboard" className="text-xs text-foreground/40 hover:text-foreground/70 transition-colors text-center">
-              ← Back to overview
-            </Link>
-          </aside>
-
-          {/* ── CENTER ───────────────────────────���────────── */}
-          <main className="flex flex-col gap-6 min-w-0">
-
-            {/* ── Section 01: Ranking weights ─────────────── */}
-            {activeSection === "weights" && (
-              <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-6">
-                <div className="flex flex-col gap-1.5">
-                  <span className="text-[10px] font-mono text-foreground/35 uppercase tracking-widest">01 — Ranking weights</span>
-                  <h2 className="text-lg font-semibold text-foreground leading-snug">Signal weights</h2>
-                  <p className="text-sm text-foreground/50 leading-relaxed">
-                    Drag to allocate importance across the five signals. Adjusting one redistributes the rest — they always sum to 100%.
-                  </p>
-                </div>
-
-                {locked ? (
-                  <div className="flex flex-col gap-4">
-                    {signals.map((sig) => (
-                      <WeightBar key={sig.key} label={sig.label} value={sig.value} />
-                    ))}
-                    <p className="text-xs text-foreground/40 italic">Ballot locked — your vote from this round is shown above.</p>
-                  </div>
-                ) : (
-                  <LinkedSlider
-                    signals={signals}
-                    onChange={handleSignalChange}
-                    lastMoved={lastMoved}
-                    prevValues={prevSignalValues.current}
-                    disabled={locked}
-                  />
-                )}
-
-                <SubmitRow
-                  label="Submit weight vote"
-                  state={weightSubmit}
-                  votedAt={MOCK_MY_VOTE.voted_at}
-                  onSubmit={() => mockSubmit(setWeightSubmit)}
-                  disabled={locked}
-                />
-              </div>
-            )}
-
-            {/* ── Section 02: Content rules ────────────────── */}
-            {activeSection === "content" && (
-              <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-6">
-                <div className="flex flex-col gap-1.5">
-                  <span className="text-[10px] font-mono text-foreground/35 uppercase tracking-widest">02 — Content rules</span>
-                  <h2 className="text-lg font-semibold text-foreground leading-snug">Keywords</h2>
-                  <p className="text-sm text-foreground/50 leading-relaxed">
-                    Vote on which keywords to boost or suppress. Keywords reaching {Math.round(MOCK_CONTENT_RULES.threshold * 100)}% community support take effect.
-                  </p>
-                </div>
-
-                <div className="flex flex-col gap-5">
-                  <KeywordInput
-                    label="Include keywords"
-                    keywords={includeKeywords}
-                    variant="include"
-                    onChange={setIncludeKeywords}
-                    disabled={locked}
-                    communityVotes={MOCK_CONTENT_RULES.include_keyword_votes}
-                    totalVoters={MOCK_CONTENT_RULES.total_voters}
-                  />
-                  <KeywordInput
-                    label="Exclude keywords"
-                    keywords={excludeKeywords}
-                    variant="exclude"
-                    onChange={setExcludeKeywords}
-                    disabled={locked}
-                    communityVotes={MOCK_CONTENT_RULES.exclude_keyword_votes}
-                    totalVoters={MOCK_CONTENT_RULES.total_voters}
-                  />
-                </div>
-
-                {/* Community rules context */}
-                <div className="rounded-lg bg-biscuit/50 border border-border/60 px-4 py-3 flex flex-col gap-1">
-                  <p className="text-xs font-semibold text-foreground/55 uppercase tracking-wide">Active community rules</p>
-                  <div className="flex flex-wrap gap-1.5 mt-1">
-                    {MOCK_CONTENT_RULES.include_keywords.map((w) => (
-                      <span key={w} className="text-xs font-mono px-2 py-0.5 rounded-full bg-success/10 border border-success/25 text-success">+{w}</span>
-                    ))}
-                    {MOCK_CONTENT_RULES.exclude_keywords.map((w) => (
-                      <span key={w} className="text-xs font-mono px-2 py-0.5 rounded-full bg-tongue/15 border border-tongue/30 text-tongue-foreground line-through">−{w}</span>
-                    ))}
-                    {MOCK_CONTENT_RULES.include_keywords.length === 0 && MOCK_CONTENT_RULES.exclude_keywords.length === 0 && (
-                      <span className="text-xs text-foreground/40 italic">No active rules yet</span>
-                    )}
-                  </div>
-                </div>
-
-                <SubmitRow
-                  label="Submit content vote"
-                  state={contentSubmit}
-                  votedAt={MOCK_MY_VOTE.voted_at}
-                  onSubmit={() => mockSubmit(setContentSubmit)}
-                  disabled={locked}
-                />
-              </div>
-            )}
-
-            {/* ── Section 03: Topic preferences ───────────── */}
-            {activeSection === "topics" && (
-              <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-6">
-                <div className="flex flex-col gap-1">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex flex-col gap-1.5">
-                      <span className="text-[10px] font-mono text-foreground/35 uppercase tracking-widest">03 — Topic preferences</span>
-                      <h2 className="text-lg font-semibold text-foreground leading-snug">Topics</h2>
-                      <p className="text-sm text-foreground/50 leading-relaxed">
-                        Slide right to boost a topic, left to reduce it. The vertical marker shows the community average.
-                      </p>
-                    </div>
-                    {touchedTopicCount > 0 && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const reset: Record<string, number> = {}
-                          MOCK_TOPICS.forEach((t) => { reset[t.slug] = 0.5 })
-                          setTopicValues(reset)
-                        }}
-                        className="text-xs text-foreground/40 hover:text-primary transition-colors underline underline-offset-2 flex-shrink-0 mt-1"
-                      >
-                        Reset all
-                      </button>
-                    )}
-                  </div>
-                </div>
-
-                {MOCK_TOPICS.length === 0 ? (
-                  <EmptyState
-                    heading="No topics configured"
-                    body="The community hasn't set up topic categories for this round yet."
-                    showCorgi={false}
-                  />
-                ) : (
-                  <div className="flex flex-col gap-5">
-                    {Object.entries(topicGroups).map(([parent, topics]) => (
-                      <TopicGroup
-                        key={parent}
-                        parentSlug={parent}
-                        topics={topics}
-                        values={topicValues}
-                        onChangeAll={(slug, val) => {
-                          setTopicValues((prev) => ({ ...prev, [slug]: val }))
-                          setTopicSubmit("idle")
-                        }}
-                        touchedCount={topics.filter((t) => Math.abs((topicValues[t.slug] ?? 0.5) - 0.5) > 0.01).length}
-                        disabled={locked}
-                      />
-                    ))}
-                  </div>
-                )}
-
-                <SubmitRow
-                  label="Submit topic vote"
-                  state={topicSubmit}
-                  votedAt={MOCK_MY_VOTE.voted_at}
-                  onSubmit={() => mockSubmit(setTopicSubmit)}
-                  disabled={locked}
-                />
-              </div>
-            )}
-
-          </main>
-
-          {/* ── RIGHT RAIL ────────────────────────────────── */}
-          <aside className="hidden lg:flex flex-col gap-0 lg:sticky lg:top-20 rounded-xl border border-border bg-card overflow-hidden">
-
-            {/* Running community weights */}
-            <div className="p-5 flex flex-col gap-3">
-              <p className="text-[10px] text-foreground/40 font-mono uppercase tracking-widest">Live weights · Round #{epoch.id}</p>
-              <div className="flex flex-col gap-3">
-                {Object.entries(communityWeights).map(([key, val]) => (
-                  <WeightBar key={key} label={SIGNAL_META[key]?.label ?? key} value={val} size="sm" />
-                ))}
-              </div>
-            </div>
-
-            <div className="h-px bg-border/60 mx-5" />
-
-            {/* Active content filters summary */}
-            <div className="p-5 flex flex-col gap-2.5">
-              <p className="text-[10px] text-foreground/40 font-mono uppercase tracking-widest">Active filters</p>
-              {MOCK_CONTENT_RULES.include_keywords.length === 0 && MOCK_CONTENT_RULES.exclude_keywords.length === 0 ? (
-                <p className="text-xs text-foreground/35">None this round</p>
-              ) : (
-                <div className="flex flex-wrap gap-1.5">
-                  {MOCK_CONTENT_RULES.include_keywords.map((w) => (
-                    <span key={w} className="text-[11px] font-mono px-2 py-0.5 rounded-full bg-success/10 border border-success/25 text-success">+{w}</span>
-                  ))}
-                  {MOCK_CONTENT_RULES.exclude_keywords.map((w) => (
-                    <span key={w} className="text-[11px] font-mono px-2 py-0.5 rounded-full bg-tongue/15 border border-tongue/30 text-tongue-foreground">−{w}</span>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            <div className="h-px bg-border/60 mx-5" />
-
-            {/* Participation — quiet, not a callout */}
-            <div className="p-5 flex flex-col gap-2">
-              <div className="flex items-center justify-between text-xs">
-                <span className="text-foreground/50">{epoch.vote_count.toLocaleString()} of {epoch.subscriber_count.toLocaleString()} voted</span>
-                <span className="font-mono text-foreground/60">{Math.round((epoch.vote_count / epoch.subscriber_count) * 100)}%</span>
-              </div>
-              <div className="h-1.5 rounded-full bg-biscuit overflow-hidden">
-                <div
-                  className="h-1.5 rounded-full bg-primary/70 transition-all"
-                  style={{ width: `${Math.round((epoch.vote_count / epoch.subscriber_count) * 100)}%` }}
-                />
-              </div>
-              <p className="text-[10px] text-foreground/40 leading-relaxed">
-                Each vote counts equally.
-              </p>
-            </div>
-
-          </aside>
-        </div>
-      </div>
+    <AppShell>
+      {content}
+      <SignInDialog open={signInOpen} onOpenChange={setSignInOpen} />
     </AppShell>
   )
 }

--- a/web-next/components/app-shell.tsx
+++ b/web-next/components/app-shell.tsx
@@ -152,7 +152,7 @@ export function AppShell({ user = null, children }: AppShellProps) {
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => logout()}
+                  onClick={() => { logout().catch(() => {}) }}
                   className="hidden sm:flex text-foreground/55 hover:text-foreground text-xs"
                 >
                   Sign out
@@ -240,7 +240,7 @@ export function AppShell({ user = null, children }: AppShellProps) {
                 <>
                   <span className="px-4 text-xs font-mono text-foreground/45">@{authedUser.handle}</span>
                   <button
-                    onClick={() => { setMobileMenuOpen(false); logout() }}
+                    onClick={() => { setMobileMenuOpen(false); logout().catch(() => {}) }}
                     className="px-4 py-3 text-sm font-medium text-foreground/60 hover:text-foreground text-left rounded-xl hover:bg-accent/60 transition-colors"
                   >
                     Sign out

--- a/web-next/components/app-shell.tsx
+++ b/web-next/components/app-shell.tsx
@@ -5,12 +5,14 @@ import { usePathname } from "next/navigation"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { SignInDialog } from "./sign-in-dialog"
+import { useAuth } from "@/components/auth-provider"
 import { useState, useEffect } from "react"
 import { createPortal } from "react-dom"
 import { cn } from "@/lib/utils"
 
-/** Auth state passed in from a parent / context.
- *  The wiring agent will replace this with a real session hook. */
+/** Legacy shape once passed in by pages. Live auth now drives the user area;
+ *  the prop is retained only for compat (e.g. its optional `isAdmin` flag,
+ *  which the session endpoint does not expose). */
 export interface AppUser {
   handle: string
   did: string
@@ -18,7 +20,7 @@ export interface AppUser {
 }
 
 interface AppShellProps {
-  /** null = logged out, AppUser = logged in */
+  /** Retained for compat. Signed-in/out UI is derived from useAuth(), not this. */
   user?: AppUser | null
   children: React.ReactNode
 }
@@ -59,8 +61,14 @@ const NAV_ITEMS = [
 
 export function AppShell({ user = null, children }: AppShellProps) {
   const pathname = usePathname()
+  const { session, isAuthenticated, logout } = useAuth()
   const [signInOpen, setSignInOpen] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  // Prefer live auth state over the legacy `user` prop for the signed-in area.
+  const authedUser = isAuthenticated && session ? { handle: session.handle, did: session.did } : null
+  // Admin nav stays prop-driven — the session endpoint carries no admin flag.
+  const isAdmin = user?.isAdmin ?? false
 
   // Close mobile menu on route change
   useEffect(() => {
@@ -118,7 +126,7 @@ export function AppShell({ user = null, children }: AppShellProps) {
                 </Link>
               )
             })}
-            {user?.isAdmin && (
+            {isAdmin && (
               <Link
                 href="/admin"
                 aria-current={pathname.startsWith("/admin") ? "page" : undefined}
@@ -135,15 +143,16 @@ export function AppShell({ user = null, children }: AppShellProps) {
 
           {/* Right side — auth state + hamburger */}
           <div className="flex items-center gap-2">
-            {user ? (
+            {authedUser ? (
               /* Logged-in state */
               <div className="flex items-center gap-2">
                 <span className="hidden sm:block text-sm font-mono text-foreground/60">
-                  @{user.handle}
+                  @{authedUser.handle}
                 </span>
                 <Button
                   variant="ghost"
                   size="sm"
+                  onClick={() => logout()}
                   className="hidden sm:flex text-foreground/55 hover:text-foreground text-xs"
                 >
                   Sign out
@@ -211,7 +220,7 @@ export function AppShell({ user = null, children }: AppShellProps) {
                   </Link>
                 )
               })}
-              {user?.isAdmin && (
+              {isAdmin && (
                 <Link
                   href="/admin"
                   aria-current={pathname.startsWith("/admin") ? "page" : undefined}
@@ -227,10 +236,13 @@ export function AppShell({ user = null, children }: AppShellProps) {
               )}
             </nav>
             <div className="flex flex-col gap-2 pb-2">
-              {user ? (
+              {authedUser ? (
                 <>
-                  <span className="px-4 text-xs font-mono text-foreground/45">@{user.handle}</span>
-                  <button className="px-4 py-3 text-sm font-medium text-foreground/60 hover:text-foreground text-left rounded-xl hover:bg-accent/60 transition-colors">
+                  <span className="px-4 text-xs font-mono text-foreground/45">@{authedUser.handle}</span>
+                  <button
+                    onClick={() => { setMobileMenuOpen(false); logout() }}
+                    className="px-4 py-3 text-sm font-medium text-foreground/60 hover:text-foreground text-left rounded-xl hover:bg-accent/60 transition-colors"
+                  >
                     Sign out
                   </button>
                 </>

--- a/web-next/components/auth-provider.tsx
+++ b/web-next/components/auth-provider.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { authApi, type SessionResponse } from "@/lib/api/client"
 
 /** Query key for the current session — invalidated after login/logout. */
@@ -34,27 +34,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     retry: false,
   })
 
-  const loginMutation = useMutation({
-    mutationFn: ({ handle, appPassword }: { handle: string; appPassword: string }) =>
-      authApi.login(handle, appPassword),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY }),
-  })
-
-  const logoutMutation = useMutation({
-    mutationFn: () => authApi.logout(),
-    onSuccess: () => queryClient.resetQueries({ queryKey: SESSION_QUERY_KEY }),
-  })
-
+  // Deliberately NOT a useMutation: mutation variables are retained in the
+  // mutation cache (and surfaced by devtools), which would keep the app
+  // password in memory after login. A plain call leaves no credential residue.
   const login = useCallback(
     async (handle: string, appPassword: string) => {
-      await loginMutation.mutateAsync({ handle, appPassword })
+      await authApi.login(handle, appPassword)
+      await queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY })
     },
-    [loginMutation]
+    [queryClient]
   )
 
+  // Clear the ENTIRE query cache on logout, not just the session query —
+  // authenticated data (my-vote ballot, etc.) must not leak into the next
+  // user's session. Public data simply refetches.
   const logout = useCallback(async () => {
-    await logoutMutation.mutateAsync()
-  }, [logoutMutation])
+    await authApi.logout()
+    queryClient.clear()
+  }, [queryClient])
 
   const session = sessionQuery.data ?? null
   const isAuthenticated = sessionQuery.data?.authenticated === true

--- a/web-next/components/auth-provider.tsx
+++ b/web-next/components/auth-provider.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { authApi, type SessionResponse } from "@/lib/api/client"
+
+/** Query key for the current session — invalidated after login/logout. */
+export const SESSION_QUERY_KEY = ["auth", "session"] as const
+
+interface AuthContextValue {
+  /** The live session, or null when unauthenticated / still resolving. */
+  session: SessionResponse | null
+  /** True only when the backend confirms an authenticated session. */
+  isAuthenticated: boolean
+  /** True while the very first session probe is in flight. */
+  isLoading: boolean
+  /** Log in with a Bluesky handle + app password. Rejects on failure (e.g. 401). */
+  login: (handle: string, appPassword: string) => Promise<void>
+  /** Clear the session cookie and reset auth state. */
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient()
+
+  // Auth state is derived ONLY from the session endpoint. When the user is not
+  // signed in, getSession() rejects (401) and `data` stays undefined — so we
+  // never retry that expected "not authenticated" answer.
+  const sessionQuery = useQuery({
+    queryKey: SESSION_QUERY_KEY,
+    queryFn: authApi.getSession,
+    retry: false,
+  })
+
+  const loginMutation = useMutation({
+    mutationFn: ({ handle, appPassword }: { handle: string; appPassword: string }) =>
+      authApi.login(handle, appPassword),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY }),
+  })
+
+  const logoutMutation = useMutation({
+    mutationFn: () => authApi.logout(),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY }),
+  })
+
+  const login = useCallback(
+    async (handle: string, appPassword: string) => {
+      await loginMutation.mutateAsync({ handle, appPassword })
+    },
+    [loginMutation]
+  )
+
+  const logout = useCallback(async () => {
+    await logoutMutation.mutateAsync()
+  }, [logoutMutation])
+
+  const session = sessionQuery.data ?? null
+  const isAuthenticated = sessionQuery.data?.authenticated === true
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      session,
+      isAuthenticated,
+      isLoading: sessionQuery.isLoading,
+      login,
+      logout,
+    }),
+    [session, isAuthenticated, sessionQuery.isLoading, login, logout]
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext)
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider")
+  }
+  return ctx
+}

--- a/web-next/components/auth-provider.tsx
+++ b/web-next/components/auth-provider.tsx
@@ -42,7 +42,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logoutMutation = useMutation({
     mutationFn: () => authApi.logout(),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY }),
+    onSuccess: () => queryClient.resetQueries({ queryKey: SESSION_QUERY_KEY }),
   })
 
   const login = useCallback(

--- a/web-next/components/providers.tsx
+++ b/web-next/components/providers.tsx
@@ -3,18 +3,21 @@
 import { useState, type ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from '@/components/theme-provider'
+import { AuthProvider } from '@/components/auth-provider'
 
-// App-wide client providers. The AuthProvider is added in the P2.0 auth slice;
-// this scaffold establishes the react-query cache + theme context that the
-// wired pages will consume once their MOCK_* data is replaced with real calls.
+// App-wide client providers. AuthProvider derives session state from the
+// governance auth endpoint and lives INSIDE QueryClientProvider so it can use
+// react-query for the session probe + login/logout mutations.
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient())
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-        {children}
-      </ThemeProvider>
+      <AuthProvider>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+          {children}
+        </ThemeProvider>
+      </AuthProvider>
     </QueryClientProvider>
   )
 }

--- a/web-next/components/sign-in-dialog.tsx
+++ b/web-next/components/sign-in-dialog.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import Image from "next/image"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useAuth } from "@/components/auth-provider"
 
 interface SignInDialogProps {
   open: boolean
@@ -13,16 +14,49 @@ interface SignInDialogProps {
 }
 
 export function SignInDialog({ open, onOpenChange }: SignInDialogProps) {
+  const { login } = useAuth()
   const [handle, setHandle] = useState("")
   const [password, setPassword] = useState("")
   const [showPassword, setShowPassword] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Guards against setting state after the dialog unmounts mid-request. The
+  // previous mock used a setTimeout that could fire post-unmount; the real
+  // login is awaited, so there are no timers to clear — only this async guard.
+  const isMounted = useRef(true)
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  // Reset transient form state whenever the dialog closes so it reopens clean.
+  useEffect(() => {
+    if (!open) {
+      setHandle("")
+      setPassword("")
+      setShowPassword(false)
+      setLoading(false)
+      setError(null)
+    }
+  }, [open])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    setError(null)
     setLoading(true)
-    // auth logic goes here
-    setTimeout(() => setLoading(false), 1500)
+    try {
+      await login(handle, password)
+      if (!isMounted.current) return
+      onOpenChange(false)
+    } catch {
+      if (!isMounted.current) return
+      setError("Check your handle and app password.")
+    } finally {
+      if (isMounted.current) setLoading(false)
+    }
   }
 
   return (
@@ -103,6 +137,12 @@ export function SignInDialog({ open, onOpenChange }: SignInDialogProps) {
               <span className="font-mono text-foreground/60">xxxx-xxxx-xxxx-xxxx</span>.
             </p>
           </div>
+
+          {error && (
+            <p role="alert" className="text-status-error text-sm font-medium leading-relaxed -mt-1">
+              {error}
+            </p>
+          )}
 
           <Button
             type="submit"


### PR DESCRIPTION
## W1 of PROJ-1497 (stacked on #284)
Auth + vote + dashboard now run on the real API: react-query AuthProvider (session-derived state, real login/logout), sign-in dialog with inline 401 feedback + state reset (CR findings), live vote ballot (4 queries, 3 per-section mutations with invalidation, sign-in gate on submit), live dashboard (stats/audit/weights/epoch-history, derived round-diff). All state-kit visuals preserved; shape adaptations documented in PROJ-1523.

Verified against the running local backend: export build green, tsc clean in changed files, zero MOCK_ refs in wired pages, empty-DB renders legitimate ErrorCard/EmptyState.

Merge order: #275 → #284 → this. Closes PROJ-1523.