### PR TITLE
[PROJ-1532] Build the web-next static export on every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,10 @@ jobs:
             # Build the web-next static export too, so cutover (WEB_DIST_DIR /
             # WEB_ROUTING_MODE env flip) is a pure config change with a fresh
             # build already on disk. Serving still defaults to web/dist.
-            cd web-next && npm ci && npm run build
+            cd web-next && npm ci
+            # One retry absorbs transient failures (e.g. the next/font fetch);
+            # a second failure is real and should stop the deploy.
+            npm run build || { echo "web-next build failed; retrying once..."; npm run build; }
             cd ..
             cd cli && npm ci && npx tsc
             cd ..
@@ -92,12 +95,12 @@ jobs:
               git checkout "$PREV_COMMIT"
               npm ci --ignore-scripts
               npm run build
-              # Rebuild both frontends at the rolled-back commit so the served
-              # assets match the running code (mirrors the forward build path).
-              cd web && npm ci && npm run build
-              cd ..
-              cd web-next && npm ci && npm run build
-              cd ..
+              # Best-effort frontend rebuilds at the rolled-back commit: the
+              # previous good build artifacts are still on disk (gitignored,
+              # untouched by checkout), so a rebuild failure must never block
+              # the service restart that completes the rollback.
+              (cd web && npm ci && npm run build) || echo "WARNING: web rollback rebuild failed; serving prior artifacts"
+              (cd web-next && npm ci && npm run build) || echo "WARNING: web-next rollback rebuild failed; serving prior artifacts"
               sudo systemctl restart bluesky-feed
               sleep 5
               echo "Rollback complete. Current health:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,12 @@ jobs:
               git checkout "$PREV_COMMIT"
               npm ci --ignore-scripts
               npm run build
+              # Rebuild both frontends at the rolled-back commit so the served
+              # assets match the running code (mirrors the forward build path).
+              cd web && npm ci && npm run build
+              cd ..
+              cd web-next && npm ci && npm run build
+              cd ..
               sudo systemctl restart bluesky-feed
               sleep 5
               echo "Rollback complete. Current health:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,11 @@ jobs:
             trap - EXIT
             cd web && npm ci && npm run build
             cd ..
+            # Build the web-next static export too, so cutover (WEB_DIST_DIR /
+            # WEB_ROUTING_MODE env flip) is a pure config change with a fresh
+            # build already on disk. Serving still defaults to web/dist.
+            cd web-next && npm ci && npm run build
+            cd ..
             cd cli && npm ci && npx tsc
             cd ..
             sudo systemctl restart bluesky-feed


### PR DESCRIPTION
P3 pre-cutover step of PROJ-1497. Adds one build step (mirroring the adjacent `web/` pattern) so `web-next/out` is always present and fresh on the VPS — proving the VPS build path (incl. next/font fetch) while prod keeps serving `web/dist` under the default env. Cutover then = the two-env-var systemd flip, rollback = revert the vars. No serve-path, systemd, or nginx changes.

Closes PROJ-1532.