### PR TITLE
[PROJ-1535] Wire post, history, research-consent, and admin to live backend data

### DIFF
--- a/web-next/app/admin/page.tsx
+++ b/web-next/app/admin/page.tsx
@@ -304,6 +304,14 @@ function PanelWeightsOverride({ status }: { status: AdminStatus }) {
   const [weights, setWeights] = useState<Record<string, number>>(seed)
   const [confirm, setConfirm] = useState(false)
 
+  // Re-seed the sliders whenever the live epoch's weights change, so the
+  // override panel never submits values based on a stale round.
+  const epochWeightsKey = JSON.stringify(epoch?.weights ?? null)
+  useEffect(() => {
+    setWeights(seed())
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [epochWeightsKey])
+
   const total = Object.values(weights).reduce((a, b) => a + b, 0)
   const isValid = Math.abs(total - 1) < 0.001
 
@@ -977,11 +985,11 @@ function AdminLoading() {
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function AdminPage() {
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, session } = useAuth()
   const [signInOpen, setSignInOpen] = useState(false)
 
   const statusQuery = useQuery({
-    queryKey: ["admin", "status"],
+    queryKey: ["admin", "status", session?.did ?? "anon"],
     queryFn: adminApi.getStatus,
     enabled: isAuthenticated,
     retry: false,

--- a/web-next/app/admin/page.tsx
+++ b/web-next/app/admin/page.tsx
@@ -1,71 +1,15 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import axios from "axios"
 import { AppShell } from "@/components/app-shell"
+import { SignInDialog } from "@/components/sign-in-dialog"
+import { useAuth } from "@/components/auth-provider"
 import { WeightBar } from "@/components/ui/weight-bar"
-import { StatusChip } from "@/components/ui/status-chip"
-import { ScoreBreakdown } from "@/components/ui/score-breakdown"
-
-// ── Mock admin user ───────────────────────────────────────────────────────────
-
-const MOCK_USER = { handle: "operator.bsky.social", did: "did:plc:admin001", isAdmin: true }
-
-// ── Mock data (seam-exact field names) ───────────────────────────────────────
-
-const MOCK_EPOCH = {
-  id: 47,
-  phase: "voting" as "voting" | "review" | "running" | "waiting",
-  status: "open",
-  vote_count: 312,
-  subscriber_count: 480,
-  voting_ends_at: "2026-07-01T17:00:00Z",
-  created_at: "2026-06-25T00:00:00Z",
-  weights: { recency: 0.35, engagement: 0.25, bridging: 0.20, source_diversity: 0.15, relevance: 0.05 },
-}
-
-const MOCK_PENDING_WEIGHTS = { recency: 0.30, engagement: 0.30, bridging: 0.20, source_diversity: 0.15, relevance: 0.05 }
-
-const MOCK_CONTENT_FILTERS = {
-  include_keywords: ["ai", "open-source", "science"],
-  exclude_keywords: ["spam", "nsfw"],
-}
-
-const MOCK_TOPICS = [
-  { slug: "machine-learning", name: "Machine learning", parentSlug: "technology", currentWeight: 0.62, enabled: true },
-  { slug: "open-source",      name: "Open source",      parentSlug: "technology", currentWeight: 0.71, enabled: true },
-  { slug: "science",          name: "Science",           parentSlug: null,         currentWeight: 0.50, enabled: true },
-  { slug: "politics",         name: "Politics",          parentSlug: null,         currentWeight: 0.32, enabled: true },
-  { slug: "sports",           name: "Sports",            parentSlug: null,         currentWeight: 0.28, enabled: false },
-]
-
-const MOCK_PARTICIPANTS = [
-  { did: "did:plc:abc1", handle: "alice.bsky.social", voted_at: "2026-06-26T14:10:00Z", is_banned: false },
-  { did: "did:plc:abc2", handle: "bob.bsky.social",   voted_at: "2026-06-26T09:22:00Z", is_banned: false },
-  { did: "did:plc:abc3", handle: "spammer.bsky.social", voted_at: null,               is_banned: true  },
-]
-
-const MOCK_AUDIT = [
-  { id: 995, action: "keyword_added",    actor_did: "did:plc:admin001", epoch_id: 47, details: { keyword: "ai", list: "include" },            created_at: "2026-06-26T15:00:00Z" },
-  { id: 994, action: "topic_disabled",   actor_did: "did:plc:admin001", epoch_id: 47, details: { slug: "sports" },                             created_at: "2026-06-26T14:50:00Z" },
-  { id: 993, action: "weights_applied",  actor_did: null,               epoch_id: 47, details: {},                                             created_at: "2026-06-25T00:00:00Z" },
-  { id: 992, action: "round_opened",     actor_did: "did:plc:admin001", epoch_id: 47, details: {},                                             created_at: "2026-06-25T00:00:00Z" },
-  { id: 991, action: "participant_banned", actor_did: "did:plc:admin001", epoch_id: 46, details: { did: "did:plc:abc3" },                      created_at: "2026-06-24T10:00:00Z" },
-]
-
-const MOCK_FEED_HEALTH = {
-  author_gini: 0.34,
-  vs_chronological_overlap: 0.61,
-  vs_engagement_overlap: 0.44,
-  avg_total: 0.57,
-  median_total: 0.55,
-  avg_bridging: 0.41,
-  total_posts_scored: 1240,
-}
-
-const MOCK_ANNOUNCEMENTS = [
-  { id: 1, title: "Round #47 voting now open", body: "Cast your vote before July 1st 17:00 UTC.", published: true,  created_at: "2026-06-25T00:00:00Z" },
-  { id: 2, title: "New topic group: Science",  body: "We've added a Science topic group.", published: false, created_at: "2026-06-24T09:00:00Z" },
-]
+import { Button } from "@/components/ui/button"
+import { EmptyState, ErrorCard, Skeleton } from "@/components/ui/state-kit"
+import { adminApi, type AdminStatus } from "@/lib/api/admin"
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -74,25 +18,37 @@ const SIGNAL_LABELS: Record<string, string> = {
   source_diversity: "Source diversity", relevance: "Relevance",
 }
 
-const ACTION_COLOR: Record<string, string> = {
-  weights_applied:   "bg-success",
-  round_opened:      "bg-primary",
-  round_closed:      "bg-foreground/40",
-  keyword_added:     "bg-warning",
-  keyword_removed:   "bg-tongue",
-  topic_disabled:    "bg-tongue",
-  topic_enabled:     "bg-success",
-  participant_banned:"bg-status-error",
-  weights_override:  "bg-warning",
-}
+const WEIGHT_KEYS = ["recency", "engagement", "bridging", "source_diversity", "relevance"] as const
 
-function relTime(iso: string) {
+function relTime(iso: string | null) {
+  if (!iso) return "never"
   const diff = Date.now() - new Date(iso).getTime()
   const m = Math.floor(diff / 60000)
+  if (m < 1) return "just now"
   if (m < 60) return `${m}m ago`
   const h = Math.floor(m / 60)
   if (h < 24) return `${h}h ago`
   return `${Math.floor(h / 24)}d ago`
+}
+
+function fmtDateTime(iso: string | null) {
+  if (!iso) return "—"
+  return new Date(iso).toLocaleDateString("en-GB", {
+    day: "numeric", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit", timeZoneName: "short",
+  })
+}
+
+type CurrentEpoch = NonNullable<AdminStatus["system"]["currentEpoch"]>
+type EpochPhase = "running" | "voting" | "review" | "waiting"
+
+/** Read the real `phase` off the current epoch (the status endpoint sends it
+ *  even though the client type omits it), falling back to votingOpen/status. */
+function epochPhase(epoch: CurrentEpoch | null): EpochPhase {
+  if (!epoch) return "waiting"
+  const phase = (epoch as { phase?: string }).phase
+  if (phase === "voting" || phase === "review" || phase === "running") return phase
+  if (epoch.votingOpen) return "voting"
+  return "running"
 }
 
 function SectionHeader({ title, sub }: { title: string; sub?: string }) {
@@ -104,12 +60,26 @@ function SectionHeader({ title, sub }: { title: string; sub?: string }) {
   )
 }
 
-// ── Confirm Modal ─────────────────────────────────────────────────────────────
+// ── Confirm Modal (Escape-to-close + initial focus on Cancel) ──────────────────
 
-function ConfirmModal({ title, body, confirmLabel = "Confirm", danger = false, onConfirm, onCancel }: {
-  title: string; body: string; confirmLabel?: string; danger?: boolean
+function ConfirmModal({
+  title, body, confirmLabel = "Confirm", danger = false, loading = false, onConfirm, onCancel,
+}: {
+  title: string; body: string; confirmLabel?: string; danger?: boolean; loading?: boolean
   onConfirm: () => void; onCancel: () => void
 }) {
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    // Initial focus lands on the safe (Cancel) action, and Escape closes.
+    cancelRef.current?.focus()
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel()
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+  }, [onCancel])
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-labelledby="modal-title">
       <div className="absolute inset-0 bg-foreground/30 backdrop-blur-sm" onClick={onCancel} aria-hidden="true" />
@@ -118,20 +88,23 @@ function ConfirmModal({ title, body, confirmLabel = "Confirm", danger = false, o
         <p className="text-sm text-foreground/60 leading-relaxed">{body}</p>
         <div className="flex items-center justify-end gap-3 pt-1">
           <button
+            ref={cancelRef}
             onClick={onCancel}
-            className="px-4 py-2 rounded-full border border-border text-sm font-medium text-foreground/60 hover:text-foreground hover:border-foreground/40 transition-colors"
+            disabled={loading}
+            className="px-4 py-2 rounded-full border border-border text-sm font-medium text-foreground/60 hover:text-foreground hover:border-foreground/40 transition-colors disabled:opacity-50"
           >
             Cancel
           </button>
           <button
             onClick={onConfirm}
-            className={`px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
+            disabled={loading}
+            className={`px-4 py-2 rounded-full text-sm font-semibold transition-colors disabled:opacity-60 ${
               danger
                 ? "bg-status-error text-white hover:bg-[hsl(8,60%,38%)]"
                 : "bg-primary text-primary-foreground hover:bg-primary-dark"
             }`}
           >
-            {confirmLabel}
+            {loading ? "Working…" : confirmLabel}
           </button>
         </div>
       </div>
@@ -141,13 +114,30 @@ function ConfirmModal({ title, body, confirmLabel = "Confirm", danger = false, o
 
 // ── Panel: Overview ───────────────────────────────────────────────────────────
 
-function PanelOverview() {
+function PanelOverview({ status }: { status: AdminStatus }) {
+  const epoch = status.system.currentEpoch
+  const feed = status.system.feed
+
+  if (!epoch) {
+    return (
+      <div className="flex flex-col gap-6">
+        <SectionHeader title="Overview" sub="Live summary of the current round." />
+        <EmptyState heading="No active round" body="There is no active governance round to summarise yet." showCorgi={false} />
+      </div>
+    )
+  }
+
+  const participation = feed.subscriberCount > 0
+    ? Math.round((epoch.voteCount / feed.subscriberCount) * 100)
+    : 0
+
   const stats = [
-    { label: "Total posts scored", value: MOCK_FEED_HEALTH.total_posts_scored.toLocaleString() },
-    { label: "Votes this round",   value: MOCK_EPOCH.vote_count.toLocaleString() },
-    { label: "Participation",       value: `${Math.round((MOCK_EPOCH.vote_count / MOCK_EPOCH.subscriber_count) * 100)}%` },
-    { label: "Avg score",           value: MOCK_FEED_HEALTH.avg_total.toFixed(2) },
+    { label: "Total posts scored", value: feed.scoredPosts.toLocaleString() },
+    { label: "Votes this round", value: epoch.voteCount.toLocaleString() },
+    { label: "Participation", value: `${participation}%` },
+    { label: "Subscribers", value: feed.subscriberCount.toLocaleString() },
   ]
+
   return (
     <div className="flex flex-col gap-6">
       <SectionHeader title="Overview" sub="Live summary of the current round." />
@@ -161,13 +151,17 @@ function PanelOverview() {
       </div>
       <div className="flex flex-col gap-3">
         <p className="text-[10px] font-mono uppercase tracking-widest text-foreground/40">Applied weights</p>
-        {Object.entries(MOCK_EPOCH.weights).map(([k, v]) => (
-          <WeightBar key={k} label={SIGNAL_LABELS[k] ?? k} value={v} />
-        ))}
+        {Object.keys(epoch.weights).length === 0 ? (
+          <p className="text-sm text-foreground/45 italic">No weights recorded for this round yet.</p>
+        ) : (
+          Object.entries(epoch.weights).map(([k, v]) => (
+            <WeightBar key={k} label={SIGNAL_LABELS[k] ?? k} value={v} />
+          ))
+        )}
       </div>
       <div className="rounded-xl bg-biscuit/50 border border-border px-5 py-4 flex flex-col gap-2">
         <p className="text-xs text-foreground/50">
-          Voting closes <span className="font-mono text-foreground/70">{new Date(MOCK_EPOCH.voting_ends_at).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit", timeZoneName: "short" })}</span>
+          Voting closes <span className="font-mono text-foreground/70">{fmtDateTime(epoch.votingEndsAt)}</span>
         </p>
       </div>
     </div>
@@ -176,26 +170,50 @@ function PanelOverview() {
 
 // ── Panel: Current Round ──────────────────────────────────────────────────────
 
-function PanelCurrentRound() {
-  const [confirm, setConfirm] = useState<null | "close" | "apply">(null)
-  const pct = Math.round((MOCK_EPOCH.vote_count / MOCK_EPOCH.subscriber_count) * 100)
+function PanelCurrentRound({ status }: { status: AdminStatus }) {
+  const queryClient = useQueryClient()
+  const epoch = status.system.currentEpoch
+  const feed = status.system.feed
+  const phase = epochPhase(epoch)
+  const [confirm, setConfirm] = useState<null | "open" | "close" | "apply">(null)
 
-  const LIFECYCLE: Array<{ phase: string; label: string; action?: string; danger?: boolean; body: string }> = [
-    { phase: "running", label: "Running",  action: "Open voting",    body: "This will open Round #47 for member votes. Confirm to proceed." },
-    { phase: "voting",  label: "Voting",   action: "Close voting",   body: "This will close voting for Round #47 and move to review." },
-    { phase: "review",  label: "Review",   action: "Apply weights",  body: "This will apply the aggregated vote weights to the live feed. This action cannot be undone." },
-    { phase: "running", label: "Live",     body: "Weights are live." },
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ["admin", "status"] })
+    void queryClient.invalidateQueries({ queryKey: ["admin", "epochs"] })
+    void queryClient.invalidateQueries({ queryKey: ["admin", "feed-health"] })
+  }
+
+  const openMutation = useMutation({ mutationFn: () => adminApi.openVoting(), onSuccess: () => { invalidate(); setConfirm(null) } })
+  const closeMutation = useMutation({ mutationFn: () => adminApi.closeVoting(), onSuccess: () => { invalidate(); setConfirm(null) } })
+  const applyMutation = useMutation({ mutationFn: () => adminApi.transitionEpoch(), onSuccess: () => { invalidate(); setConfirm(null) } })
+
+  if (!epoch) {
+    return (
+      <div className="flex flex-col gap-6">
+        <SectionHeader title="Current round" sub="Manage the round lifecycle." />
+        <EmptyState heading="No active round" body="There is no active round to manage." showCorgi={false} />
+      </div>
+    )
+  }
+
+  const pct = feed.subscriberCount > 0 ? Math.round((epoch.voteCount / feed.subscriberCount) * 100) : 0
+
+  // One row per lifecycle stage (no duplicate `running` row — only one is active).
+  const LIFECYCLE: Array<{ phase: EpochPhase; label: string; action?: "open" | "close" | "apply"; actionLabel?: string; danger?: boolean }> = [
+    { phase: "running", label: "Running", action: "open", actionLabel: "Open voting" },
+    { phase: "voting", label: "Voting", action: "close", actionLabel: "Close voting" },
+    { phase: "review", label: "Review", action: "apply", actionLabel: "Apply weights", danger: true },
   ]
 
   return (
     <div className="flex flex-col gap-6">
-      <SectionHeader title="Current round" sub="Manage the lifecycle of Round #47." />
+      <SectionHeader title="Current round" sub={`Manage the lifecycle of Round #${epoch.id}.`} />
 
       {/* Participation */}
       <div className="rounded-xl border border-border bg-card p-5 flex flex-col gap-3">
         <div className="flex items-center justify-between gap-3">
           <p className="text-sm font-semibold text-foreground">Participation</p>
-          <span className="text-sm font-mono font-semibold text-foreground tabular-nums">{MOCK_EPOCH.vote_count} / {MOCK_EPOCH.subscriber_count}</span>
+          <span className="text-sm font-mono font-semibold text-foreground tabular-nums">{epoch.voteCount} / {feed.subscriberCount}</span>
         </div>
         <div className="h-2 rounded-full bg-biscuit overflow-hidden">
           <div className="h-2 rounded-full bg-primary transition-all" style={{ width: `${pct}%` }} />
@@ -206,10 +224,10 @@ function PanelCurrentRound() {
       {/* Lifecycle actions */}
       <div className="flex flex-col gap-3">
         <p className="text-[10px] font-mono uppercase tracking-widest text-foreground/40 mb-1">Lifecycle actions</p>
-        {LIFECYCLE.map((lc, i) => {
-          const isCurrentPhase = lc.phase === MOCK_EPOCH.phase
+        {LIFECYCLE.map((lc) => {
+          const isCurrentPhase = lc.phase === phase
           return (
-            <div key={i} className={`rounded-xl border px-5 py-4 flex items-center justify-between gap-4 transition-colors
+            <div key={lc.phase} className={`rounded-xl border px-5 py-4 flex items-center justify-between gap-4 transition-colors
               ${isCurrentPhase ? "border-primary/30 bg-primary/5" : "border-border bg-card opacity-50"}`}>
               <div className="flex items-center gap-3">
                 <div className={`w-2 h-2 rounded-full flex-shrink-0 ${isCurrentPhase ? "bg-primary" : "bg-border"}`} />
@@ -217,14 +235,14 @@ function PanelCurrentRound() {
               </div>
               {lc.action && isCurrentPhase && (
                 <button
-                  onClick={() => setConfirm(i === 1 ? "close" : "apply")}
+                  onClick={() => setConfirm(lc.action!)}
                   className={`px-4 py-1.5 rounded-full text-xs font-semibold transition-colors ${
                     lc.danger
                       ? "bg-status-error/10 text-status-error border border-status-error/30 hover:bg-status-error/20"
                       : "bg-primary/10 text-primary border border-primary/20 hover:bg-primary/20"
                   }`}
                 >
-                  {lc.action}
+                  {lc.actionLabel}
                 </button>
               )}
             </div>
@@ -232,22 +250,34 @@ function PanelCurrentRound() {
         })}
       </div>
 
+      {confirm === "open" && (
+        <ConfirmModal
+          title={`Open voting for Round #${epoch.id}?`}
+          body="This will open the round for member votes."
+          confirmLabel="Open voting"
+          loading={openMutation.isPending}
+          onConfirm={() => openMutation.mutate()}
+          onCancel={() => setConfirm(null)}
+        />
+      )}
       {confirm === "close" && (
         <ConfirmModal
-          title="Close voting for Round #47?"
+          title={`Close voting for Round #${epoch.id}?`}
           body="This will close voting and move the round to review. Members will no longer be able to submit votes."
           confirmLabel="Close voting"
-          onConfirm={() => setConfirm(null)}
+          loading={closeMutation.isPending}
+          onConfirm={() => closeMutation.mutate()}
           onCancel={() => setConfirm(null)}
         />
       )}
       {confirm === "apply" && (
         <ConfirmModal
           title="Apply aggregated weights to live feed?"
-          body="This will immediately update the feed ranking with the community vote results. This cannot be undone."
+          body="This will apply the community vote results and transition to the next round. This cannot be undone."
           confirmLabel="Apply weights"
           danger
-          onConfirm={() => setConfirm(null)}
+          loading={applyMutation.isPending}
+          onConfirm={() => applyMutation.mutate()}
           onCancel={() => setConfirm(null)}
         />
       )}
@@ -257,32 +287,60 @@ function PanelCurrentRound() {
 
 // ── Panel: Weights Override ───────────────────────────────────────────────────
 
-function PanelWeightsOverride() {
-  const [weights, setWeights] = useState({ ...MOCK_PENDING_WEIGHTS })
+function PanelWeightsOverride({ status }: { status: AdminStatus }) {
+  const queryClient = useQueryClient()
+  const epoch = status.system.currentEpoch
+
+  // Seed from the live epoch weights (fall back to a neutral zeroed vector).
+  const seed = (): Record<string, number> => {
+    const base: Record<string, number> = {}
+    for (const k of WEIGHT_KEYS) base[k] = epoch?.weights[k] ?? 0
+    return base
+  }
+
+  const [weights, setWeights] = useState<Record<string, number>>(seed)
   const [confirm, setConfirm] = useState(false)
+
   const total = Object.values(weights).reduce((a, b) => a + b, 0)
   const isValid = Math.abs(total - 1) < 0.001
 
+  const overrideMutation = useMutation({
+    mutationFn: () => adminApi.updateWeights(weights),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "status"] })
+      setConfirm(false)
+    },
+  })
+
   function setWeight(key: string, val: number) {
     setWeights((prev) => ({ ...prev, [key]: Math.max(0, Math.min(1, val)) }))
+  }
+
+  if (!epoch) {
+    return (
+      <div className="flex flex-col gap-6">
+        <SectionHeader title="Weights override" sub="Manually override the community-voted weights." />
+        <EmptyState heading="No active round" body="There is no active round whose weights can be overridden." showCorgi={false} />
+      </div>
+    )
   }
 
   return (
     <div className="flex flex-col gap-6">
       <SectionHeader title="Weights override" sub="Manually override the community-voted weights. Use with care." />
       <div className="flex flex-col gap-4">
-        {Object.entries(weights).map(([k, v]) => (
+        {WEIGHT_KEYS.map((k) => (
           <div key={k} className="flex items-center gap-4">
             <span className="text-sm font-medium text-foreground w-36 flex-shrink-0">{SIGNAL_LABELS[k] ?? k}</span>
             <input
               type="range"
               min={0} max={100} step={1}
-              value={Math.round(v * 100)}
+              value={Math.round((weights[k] ?? 0) * 100)}
               onChange={(e) => setWeight(k, Number(e.target.value) / 100)}
               className="flex-1 accent-primary"
               aria-label={SIGNAL_LABELS[k]}
             />
-            <span className="text-sm font-mono font-semibold text-foreground tabular-nums w-10 text-right">{Math.round(v * 100)}%</span>
+            <span className="text-sm font-mono font-semibold text-foreground tabular-nums w-10 text-right">{Math.round((weights[k] ?? 0) * 100)}%</span>
           </div>
         ))}
       </div>
@@ -291,9 +349,12 @@ function PanelWeightsOverride() {
         <span className="font-mono font-semibold">{(total * 100).toFixed(0)}%</span>
         <span className="text-foreground/50 ml-1">{isValid ? "weights sum to 100% — ready to apply" : "weights must sum to 100%"}</span>
       </div>
+      {overrideMutation.isError && (
+        <p className="text-sm text-status-error">Failed to override weights. Please try again.</p>
+      )}
       <div className="flex justify-end gap-3">
         <button
-          onClick={() => setWeights({ ...MOCK_PENDING_WEIGHTS })}
+          onClick={() => setWeights(seed())}
           className="px-4 py-2 rounded-full border border-border text-sm font-medium text-foreground/60 hover:text-foreground transition-colors"
         >
           Reset to vote results
@@ -312,7 +373,8 @@ function PanelWeightsOverride() {
           body="This will immediately replace the aggregated vote weights with the values you've set. Members will see the new weights in the dashboard."
           confirmLabel="Apply override"
           danger
-          onConfirm={() => setConfirm(false)}
+          loading={overrideMutation.isPending}
+          onConfirm={() => overrideMutation.mutate()}
           onCancel={() => setConfirm(false)}
         />
       )}
@@ -322,24 +384,33 @@ function PanelWeightsOverride() {
 
 // ── Panel: Content Filters ────────────────────────────────────────────────────
 
-function PanelContentFilters() {
-  const [include, setInclude] = useState(MOCK_CONTENT_FILTERS.include_keywords)
-  const [exclude, setExclude] = useState(MOCK_CONTENT_FILTERS.exclude_keywords)
+function PanelContentFilters({ status }: { status: AdminStatus }) {
+  const queryClient = useQueryClient()
+  const include = status.system.contentRules.includeKeywords
+  const exclude = status.system.contentRules.excludeKeywords
+
   const [addInclude, setAddInclude] = useState("")
   const [addExclude, setAddExclude] = useState("")
   const [removingConfirm, setRemovingConfirm] = useState<{ list: "include" | "exclude"; kw: string } | null>(null)
 
-  function addKw(list: "include" | "exclude") {
-    const val = list === "include" ? addInclude.trim().toLowerCase() : addExclude.trim().toLowerCase()
-    if (!val) return
-    if (list === "include") { setInclude((p) => [...p, val]); setAddInclude("") }
-    else { setExclude((p) => [...p, val]); setAddExclude("") }
-  }
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ["admin", "status"] })
 
-  function removeKw(list: "include" | "exclude", kw: string) {
-    if (list === "include") setInclude((p) => p.filter((k) => k !== kw))
-    else setExclude((p) => p.filter((k) => k !== kw))
-    setRemovingConfirm(null)
+  const addMutation = useMutation({
+    mutationFn: ({ list, keyword }: { list: "include" | "exclude"; keyword: string }) => adminApi.addKeyword(list, keyword),
+    onSuccess: (_data, vars) => {
+      void invalidate()
+      if (vars.list === "include") setAddInclude(""); else setAddExclude("")
+    },
+  })
+  const removeMutation = useMutation({
+    mutationFn: ({ list, keyword }: { list: "include" | "exclude"; keyword: string }) => adminApi.removeKeyword(list, keyword, true),
+    onSuccess: () => { void invalidate(); setRemovingConfirm(null) },
+  })
+
+  function submitAdd(list: "include" | "exclude") {
+    const val = (list === "include" ? addInclude : addExclude).trim().toLowerCase()
+    if (!val) return
+    addMutation.mutate({ list, keyword: val })
   }
 
   return (
@@ -348,10 +419,10 @@ function PanelContentFilters() {
 
       {(["include", "exclude"] as const).map((list) => {
         const keywords = list === "include" ? include : exclude
-        const addVal   = list === "include" ? addInclude : addExclude
-        const setAdd   = list === "include" ? setAddInclude : setAddExclude
-        const chipBg   = list === "include" ? "bg-success/10 border-success/20 text-success" : "bg-tongue/15 border-tongue/30 text-tongue-foreground"
-        const prefix   = list === "include" ? "+" : "−"
+        const addVal = list === "include" ? addInclude : addExclude
+        const setAdd = list === "include" ? setAddInclude : setAddExclude
+        const chipBg = list === "include" ? "bg-success/10 border-success/20 text-success" : "bg-tongue/15 border-tongue/30 text-tongue-foreground"
+        const prefix = list === "include" ? "+" : "−"
 
         return (
           <div key={list} className="flex flex-col gap-3">
@@ -378,13 +449,13 @@ function PanelContentFilters() {
                 type="text"
                 value={addVal}
                 onChange={(e) => setAdd(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && addKw(list)}
+                onKeyDown={(e) => e.key === "Enter" && submitAdd(list)}
                 placeholder={`Add ${list} keyword…`}
                 className="flex-1 rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-foreground/35 focus:outline-none focus:ring-2 focus:ring-primary/40"
               />
               <button
-                onClick={() => addKw(list)}
-                disabled={!addVal.trim()}
+                onClick={() => submitAdd(list)}
+                disabled={!addVal.trim() || addMutation.isPending}
                 className="px-4 py-2 rounded-lg bg-primary/10 text-primary border border-primary/20 text-sm font-medium hover:bg-primary/20 transition-colors disabled:opacity-40 disabled:pointer-events-none"
               >
                 Add
@@ -394,13 +465,18 @@ function PanelContentFilters() {
         )
       })}
 
+      {addMutation.isError && (
+        <p className="text-sm text-status-error">Failed to add keyword. Please try again.</p>
+      )}
+
       {removingConfirm && (
         <ConfirmModal
           title={`Remove "${removingConfirm.kw}" from ${removingConfirm.list} list?`}
           body="This keyword will no longer be used to filter feed content."
           confirmLabel="Remove keyword"
           danger
-          onConfirm={() => removeKw(removingConfirm.list, removingConfirm.kw)}
+          loading={removeMutation.isPending}
+          onConfirm={() => removeMutation.mutate({ list: removingConfirm.list, keyword: removingConfirm.kw })}
           onCancel={() => setRemovingConfirm(null)}
         />
       )}
@@ -408,64 +484,87 @@ function PanelContentFilters() {
   )
 }
 
-// ── Panel: Topics CRUD ────────────────────────────────────────────────────────
+// ── Panel: Topics ─────────────────────────────────────────────────────────────
 
 function PanelTopics() {
-  const [topics, setTopics] = useState(MOCK_TOPICS)
-  const [confirmToggle, setConfirmToggle] = useState<typeof MOCK_TOPICS[0] | null>(null)
+  const queryClient = useQueryClient()
+  const topicsQuery = useQuery({ queryKey: ["admin", "topics"], queryFn: adminApi.getTopics, retry: false })
+  const [confirmDisable, setConfirmDisable] = useState<{ slug: string; name: string } | null>(null)
 
-  function toggleTopic(slug: string, enabled: boolean) {
-    setTopics((prev) => prev.map((t) => t.slug === slug ? { ...t, enabled } : t))
-    setConfirmToggle(null)
-  }
+  const disableMutation = useMutation({
+    mutationFn: (slug: string) => adminApi.deactivateTopic(slug),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "topics"] })
+      setConfirmDisable(null)
+    },
+  })
 
   return (
     <div className="flex flex-col gap-6">
-      <SectionHeader title="Topics" sub="Enable or disable topic groups used in relevance scoring." />
-      <div className="rounded-xl border border-border overflow-hidden">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border bg-biscuit/30">
-              <th className="text-left px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">Topic</th>
-              <th className="text-left px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal hidden sm:table-cell">Group</th>
-              <th className="text-right px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">Weight</th>
-              <th className="text-right px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {topics.map((t) => (
-              <tr key={t.slug} className="border-b border-border/50 last:border-b-0 hover:bg-biscuit/20 transition-colors">
-                <td className="px-4 py-3 font-medium text-foreground">{t.name}</td>
-                <td className="px-4 py-3 text-foreground/45 text-xs font-mono hidden sm:table-cell">{t.parentSlug ?? "—"}</td>
-                <td className="px-4 py-3 text-right font-mono text-sm tabular-nums text-foreground/70">{Math.round(t.currentWeight * 100)}%</td>
-                <td className="px-4 py-3 text-right">
-                  <button
-                    onClick={() => setConfirmToggle(t)}
-                    className={`text-xs font-semibold px-3 py-1 rounded-full border transition-colors ${
-                      t.enabled
-                        ? "bg-success/10 border-success/20 text-success hover:bg-success/20"
-                        : "bg-biscuit border-border text-foreground/45 hover:bg-biscuit/80"
-                    }`}
-                  >
-                    {t.enabled ? "Enabled" : "Disabled"}
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <SectionHeader title="Topics" sub="Active topic groups used in relevance scoring." />
 
-      {confirmToggle && (
+      {topicsQuery.isLoading ? (
+        <div className="rounded-xl border border-border overflow-hidden divide-y divide-border/60" aria-busy="true">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between px-4 py-3.5">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-6 w-20 rounded-full" />
+            </div>
+          ))}
+        </div>
+      ) : topicsQuery.isError ? (
+        <ErrorCard heading="Topics unavailable" body="We couldn't load the topic catalog." onRetry={() => void topicsQuery.refetch()} />
+      ) : (topicsQuery.data ?? []).length === 0 ? (
+        <EmptyState heading="No topics configured" body="No topic groups have been created yet." showCorgi={false} />
+      ) : (
+        <div className="rounded-xl border border-border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-biscuit/30">
+                <th className="text-left px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">Topic</th>
+                <th className="text-left px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal hidden sm:table-cell">Group</th>
+                <th className="text-right px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">Weight</th>
+                <th className="text-right px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(topicsQuery.data ?? []).map((t) => (
+                <tr key={t.slug} className="border-b border-border/50 last:border-b-0 hover:bg-biscuit/20 transition-colors">
+                  <td className="px-4 py-3 font-medium text-foreground">{t.name}</td>
+                  <td className="px-4 py-3 text-foreground/45 text-xs font-mono hidden sm:table-cell">{t.parentSlug ?? "—"}</td>
+                  <td className="px-4 py-3 text-right font-mono text-sm tabular-nums text-foreground/70">
+                    {t.currentWeight != null ? `${Math.round(t.currentWeight * 100)}%` : "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    {t.isActive ? (
+                      <button
+                        onClick={() => setConfirmDisable({ slug: t.slug, name: t.name })}
+                        className="text-xs font-semibold px-3 py-1 rounded-full border bg-success/10 border-success/20 text-success hover:bg-success/20 transition-colors"
+                      >
+                        Enabled
+                      </button>
+                    ) : (
+                      <span className="text-xs font-semibold px-3 py-1 rounded-full border bg-biscuit border-border text-foreground/45">
+                        Disabled
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {confirmDisable && (
         <ConfirmModal
-          title={`${confirmToggle.enabled ? "Disable" : "Enable"} "${confirmToggle.name}"?`}
-          body={confirmToggle.enabled
-            ? "This topic will no longer affect relevance scoring. Members' topic votes for this group will be ignored."
-            : "This topic will be re-activated and included in relevance scoring."}
-          confirmLabel={confirmToggle.enabled ? "Disable topic" : "Enable topic"}
-          danger={confirmToggle.enabled}
-          onConfirm={() => toggleTopic(confirmToggle.slug, !confirmToggle.enabled)}
-          onCancel={() => setConfirmToggle(null)}
+          title={`Disable "${confirmDisable.name}"?`}
+          body="This topic will no longer affect relevance scoring. Members' topic votes for this group will be ignored."
+          confirmLabel="Disable topic"
+          danger
+          loading={disableMutation.isPending}
+          onConfirm={() => disableMutation.mutate(confirmDisable.slug)}
+          onCancel={() => setConfirmDisable(null)}
         />
       )}
     </div>
@@ -474,67 +573,108 @@ function PanelTopics() {
 
 // ── Panel: Audit Log ──────────────────────────────────────────────────────────
 
+const AUDIT_PAGE_SIZE = 25
+
 function PanelAuditLog() {
+  const [limit, setLimit] = useState(AUDIT_PAGE_SIZE)
   const [expanded, setExpanded] = useState<number | null>(null)
+  const auditQuery = useQuery({
+    queryKey: ["admin", "audit-log", limit],
+    queryFn: () => adminApi.getAuditLog({ limit }),
+    retry: false,
+  })
+
+  const entries = auditQuery.data?.entries ?? []
+  const total = auditQuery.data?.total ?? 0
 
   return (
     <div className="flex flex-col gap-6">
       <SectionHeader title="Audit log" sub="All admin actions, newest first." />
-      <div className="rounded-xl border border-border overflow-hidden">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border bg-biscuit/30">
-              <th className="text-left px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">Action</th>
-              <th className="text-left px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal hidden md:table-cell">Actor</th>
-              <th className="text-right px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal hidden sm:table-cell">Round</th>
-              <th className="text-right px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">When</th>
-            </tr>
-          </thead>
-          <tbody>
-            {MOCK_AUDIT.map((entry) => {
-              const isExpanded = expanded === entry.id
-              const dot = ACTION_COLOR[entry.action] ?? "bg-foreground/30"
-              const hasDetails = Object.keys(entry.details).length > 0
-              return (
-                <>
-                  <tr
-                    key={entry.id}
-                    className="border-b border-border/50 last:border-b-0 hover:bg-biscuit/20 transition-colors cursor-pointer"
-                    onClick={() => hasDetails && setExpanded(isExpanded ? null : entry.id)}
-                  >
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <div className={`w-2 h-2 rounded-full flex-shrink-0 ${dot}`} aria-hidden="true" />
-                        <span className="font-mono text-xs text-foreground/80">{entry.action}</span>
-                        {hasDetails && (
-                          <svg
-                            width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"
-                            className={`text-foreground/30 transition-transform ${isExpanded ? "rotate-180" : ""}`}
-                          >
-                            <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                          </svg>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-xs font-mono text-foreground/50 hidden md:table-cell">
-                      {entry.actor_did ? entry.actor_did.slice(-8) : <span className="italic text-foreground/30">system</span>}
-                    </td>
-                    <td className="px-4 py-3 text-right font-mono text-xs text-foreground/50 hidden sm:table-cell">#{entry.epoch_id}</td>
-                    <td className="px-4 py-3 text-right text-xs text-foreground/50 tabular-nums" title={entry.created_at}>{relTime(entry.created_at)}</td>
-                  </tr>
-                  {isExpanded && (
-                    <tr key={`${entry.id}-details`} className="border-b border-border/30 bg-biscuit/20">
-                      <td colSpan={4} className="px-6 py-3">
-                        <pre className="text-xs font-mono text-foreground/60 whitespace-pre-wrap">{JSON.stringify(entry.details, null, 2)}</pre>
+
+      {auditQuery.isLoading ? (
+        <div className="rounded-xl border border-border overflow-hidden divide-y divide-border/60" aria-busy="true">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between px-4 py-3.5">
+              <Skeleton className="h-4 w-44" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          ))}
+        </div>
+      ) : auditQuery.isError ? (
+        <ErrorCard heading="Audit log unavailable" body="We couldn't load the admin audit log." onRetry={() => void auditQuery.refetch()} />
+      ) : entries.length === 0 ? (
+        <EmptyState heading="No audit entries yet" body="Admin actions will appear here once activity begins." showCorgi={false} />
+      ) : (
+        <div className="rounded-xl border border-border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-biscuit/30">
+                <th className="text-left px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">Action</th>
+                <th className="text-left px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal hidden md:table-cell">Actor</th>
+                <th className="text-right px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal hidden sm:table-cell">Round</th>
+                <th className="text-right px-4 py-3 text-[10px] font-mono uppercase tracking-widest text-foreground/40 font-normal">When</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => {
+                const isExpanded = expanded === entry.id
+                const hasDetails = entry.details != null && Object.keys(entry.details).length > 0
+                return (
+                  <>
+                    <tr
+                      key={entry.id}
+                      className="border-b border-border/50 last:border-b-0 hover:bg-biscuit/20 transition-colors cursor-pointer"
+                      onClick={() => hasDetails && setExpanded(isExpanded ? null : entry.id)}
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <div className="w-2 h-2 rounded-full flex-shrink-0 bg-primary/50" aria-hidden="true" />
+                          <span className="font-mono text-xs text-foreground/80">{entry.action}</span>
+                          {hasDetails && (
+                            <svg
+                              width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"
+                              className={`text-foreground/30 transition-transform ${isExpanded ? "rotate-180" : ""}`}
+                            >
+                              <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                            </svg>
+                          )}
+                        </div>
                       </td>
+                      <td className="px-4 py-3 text-xs font-mono text-foreground/50 hidden md:table-cell">
+                        {entry.actor ? entry.actor.slice(-8) : <span className="italic text-foreground/30">system</span>}
+                      </td>
+                      <td className="px-4 py-3 text-right font-mono text-xs text-foreground/50 hidden sm:table-cell">
+                        {entry.epochId != null ? `#${entry.epochId}` : "—"}
+                      </td>
+                      <td className="px-4 py-3 text-right text-xs text-foreground/50 tabular-nums" title={entry.timestamp}>{relTime(entry.timestamp)}</td>
                     </tr>
-                  )}
-                </>
-              )
-            })}
-          </tbody>
-        </table>
-      </div>
+                    {isExpanded && (
+                      <tr key={`${entry.id}-details`} className="border-b border-border/30 bg-biscuit/20">
+                        <td colSpan={4} className="px-6 py-3">
+                          <pre className="text-xs font-mono text-foreground/60 whitespace-pre-wrap">{JSON.stringify(entry.details, null, 2)}</pre>
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                )
+              })}
+            </tbody>
+          </table>
+          <div className="px-4 py-3 border-t border-border/60 flex items-center justify-between">
+            <span className="text-xs text-foreground/40 font-mono">{total} total · {entries.length} shown</span>
+            {entries.length < total && (
+              <button
+                type="button"
+                onClick={() => setLimit((l) => l + AUDIT_PAGE_SIZE)}
+                disabled={auditQuery.isFetching}
+                className="text-xs font-medium text-primary hover:text-primary-dark transition-colors disabled:opacity-40"
+              >
+                {auditQuery.isFetching ? "Loading…" : "Load more"}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -542,46 +682,61 @@ function PanelAuditLog() {
 // ── Panel: Feed Health ────────────────────────────────────────────────────────
 
 function PanelFeedHealth() {
-  const h = MOCK_FEED_HEALTH
-  const metrics = [
-    { label: "vs Chronological", value: `${Math.round(h.vs_chronological_overlap * 100)}%`, hint: "Overlap with time-sorted feed" },
-    { label: "vs Engagement-only", value: `${Math.round(h.vs_engagement_overlap * 100)}%`, hint: "Overlap with likes-sorted feed" },
-    { label: "Author Gini", value: h.author_gini.toFixed(2), hint: "Author concentration (lower = more diverse)" },
-    { label: "Avg score", value: h.avg_total.toFixed(2), hint: "Mean total post score" },
-    { label: "Median score", value: h.median_total.toFixed(2), hint: "Median total post score" },
-    { label: "Avg bridging", value: h.avg_bridging.toFixed(2), hint: "Mean bridging signal across posts" },
-  ]
+  const healthQuery = useQuery({ queryKey: ["admin", "feed-health"], queryFn: adminApi.getFeedHealth, retry: false })
 
   return (
     <div className="flex flex-col gap-6">
-      <SectionHeader title="Feed health" sub="Transparency metrics for the current round." />
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {metrics.map((m) => (
-          <div key={m.label} className="rounded-xl border border-border bg-card px-5 py-4 flex flex-col gap-1.5">
-            <span className="text-[10px] font-mono uppercase tracking-widest text-foreground/40">{m.label}</span>
-            <span className="text-2xl font-mono font-bold text-foreground tabular-nums">{m.value}</span>
-            <span className="text-xs text-foreground/45 leading-relaxed">{m.hint}</span>
-          </div>
-        ))}
-      </div>
+      <SectionHeader title="Feed health" sub="Ingestion, scoring, and subscriber vitals." />
 
-      {/* Gini bar */}
-      <div className="flex flex-col gap-2">
-        <p className="text-[10px] font-mono uppercase tracking-widest text-foreground/40">Author concentration</p>
-        <div className="flex items-center gap-3">
-          <span className="text-xs text-foreground/45 w-14">Diverse</span>
-          <div className="flex-1 h-2.5 rounded-full bg-biscuit overflow-hidden">
-            <div
-              className="h-2.5 rounded-full bg-primary transition-all"
-              style={{ width: `${h.author_gini * 100}%` }}
-            />
-          </div>
-          <span className="text-xs text-foreground/45 w-14 text-right">Concentrated</span>
+      {healthQuery.isLoading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" aria-busy="true">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="rounded-xl border border-border bg-card px-5 py-4 flex flex-col gap-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-7 w-16" />
+              <Skeleton className="h-3 w-32" />
+            </div>
+          ))}
         </div>
-        <p className="text-xs text-foreground/40 text-center">
-          Gini {h.author_gini.toFixed(2)} — {h.author_gini < 0.4 ? "healthy diversity" : "concentration detected"}
-        </p>
-      </div>
+      ) : healthQuery.isError || !healthQuery.data ? (
+        <ErrorCard heading="Feed health unavailable" body="We couldn't load feed health metrics." onRetry={() => void healthQuery.refetch()} />
+      ) : (
+        (() => {
+          const h = healthQuery.data
+          const metrics = [
+            { label: "Total posts", value: h.database.totalPosts.toLocaleString(), hint: `${h.database.postsLast24h.toLocaleString()} in last 24h` },
+            { label: "Posts (7d)", value: h.database.postsLast7d.toLocaleString(), hint: "Ingested in the last 7 days" },
+            { label: "Posts scored", value: h.scoring.postsScored.toLocaleString(), hint: `Last run ${relTime(h.scoring.lastRun)}` },
+            { label: "Posts filtered", value: h.scoring.postsFiltered.toLocaleString(), hint: "Removed by content rules" },
+            { label: "Subscribers", value: h.subscribers.total.toLocaleString(), hint: `${h.subscribers.withVotes.toLocaleString()} voted · ${h.subscribers.activeLastWeek.toLocaleString()} active/wk` },
+            { label: "Feed size", value: (h.feedSize ?? 0).toLocaleString(), hint: "Posts in the live ranked feed" },
+          ]
+          return (
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {metrics.map((m) => (
+                  <div key={m.label} className="rounded-xl border border-border bg-card px-5 py-4 flex flex-col gap-1.5">
+                    <span className="text-[10px] font-mono uppercase tracking-widest text-foreground/40">{m.label}</span>
+                    <span className="text-2xl font-mono font-bold text-foreground tabular-nums">{m.value}</span>
+                    <span className="text-xs text-foreground/45 leading-relaxed">{m.hint}</span>
+                  </div>
+                ))}
+              </div>
+
+              {/* Jetstream status strip */}
+              <div className={`flex items-center gap-3 px-5 py-4 rounded-xl border text-sm ${h.jetstream.connected ? "bg-success/10 border-success/20 text-success" : "bg-status-error/10 border-status-error/25 text-status-error"}`}>
+                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${h.jetstream.connected ? "bg-success animate-pulse" : "bg-status-error"}`} aria-hidden="true" />
+                <span className="font-semibold">Jetstream {h.jetstream.connected ? "connected" : "disconnected"}</span>
+                <span className="text-foreground/50 ml-1">
+                  {h.jetstream.connected
+                    ? `${h.jetstream.eventsLast5min.toLocaleString()} events in last 5 min`
+                    : `down for ${h.jetstream.disconnectedForSeconds ?? 0}s · last event ${relTime(h.jetstream.lastEvent)}`}
+                </span>
+              </div>
+            </>
+          )
+        })()
+      )}
     </div>
   )
 }
@@ -589,225 +744,310 @@ function PanelFeedHealth() {
 // ── Panel: Announcements ──────────────────────────────────────────────────────
 
 function PanelAnnouncements() {
-  const [items, setItems] = useState(MOCK_ANNOUNCEMENTS)
-  const [confirmDelete, setConfirmDelete] = useState<number | null>(null)
-  const [draft, setDraft] = useState({ title: "", body: "" })
-  const [adding, setAdding] = useState(false)
+  const queryClient = useQueryClient()
+  const announcementsQuery = useQuery({ queryKey: ["admin", "announcements"], queryFn: adminApi.getAnnouncements, retry: false })
 
-  function togglePublish(id: number) {
-    setItems((prev) => prev.map((a) => a.id === id ? { ...a, published: !a.published } : a))
-  }
+  const [content, setContent] = useState("")
+  const [includeEpochLink, setIncludeEpochLink] = useState(true)
+  const [confirmPost, setConfirmPost] = useState(false)
 
-  function deleteItem(id: number) {
-    setItems((prev) => prev.filter((a) => a.id !== id))
-    setConfirmDelete(null)
-  }
+  const postMutation = useMutation({
+    mutationFn: () => adminApi.postAnnouncement({ content: content.trim(), includeEpochLink }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "announcements"] })
+      setContent("")
+      setConfirmPost(false)
+    },
+  })
 
-  function addAnnouncement() {
-    if (!draft.title.trim() || !draft.body.trim()) return
-    setItems((prev) => [{ id: Date.now(), ...draft, published: false, created_at: new Date().toISOString() }, ...prev])
-    setDraft({ title: "", body: "" })
-    setAdding(false)
-  }
+  const items = announcementsQuery.data?.announcements ?? []
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between gap-4 pb-4 border-b border-border mb-1">
-        <div>
-          <h2 className="text-base font-semibold text-foreground">Announcements</h2>
-          <p className="text-xs text-foreground/50">Community-facing notices shown on the dashboard.</p>
+      <SectionHeader title="Announcements" sub="Community-facing notices posted to the feed's Bluesky account." />
+
+      {/* Composer */}
+      <div className="rounded-xl border border-border bg-biscuit/30 p-5 flex flex-col gap-3">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Write an announcement to post to Bluesky…"
+          rows={3}
+          className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-foreground/35 focus:outline-none focus:ring-2 focus:ring-primary/40 resize-none"
+        />
+        <div className="flex items-center justify-between gap-3">
+          <label className="flex items-center gap-2 text-xs text-foreground/60">
+            <input type="checkbox" checked={includeEpochLink} onChange={(e) => setIncludeEpochLink(e.target.checked)} className="accent-primary" />
+            Include a link to the current round
+          </label>
+          <button
+            onClick={() => setConfirmPost(true)}
+            disabled={!content.trim() || postMutation.isPending}
+            className="px-4 py-2 rounded-full bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary-dark transition-colors disabled:opacity-40 disabled:pointer-events-none"
+          >
+            Post announcement
+          </button>
         </div>
-        <button
-          onClick={() => setAdding(!adding)}
-          className="px-4 py-2 rounded-full bg-primary/10 text-primary border border-primary/20 text-sm font-medium hover:bg-primary/20 transition-colors"
-        >
-          {adding ? "Cancel" : "+ New"}
-        </button>
+        {postMutation.isError && (
+          <p className="text-sm text-status-error">Failed to post the announcement. Please try again.</p>
+        )}
       </div>
 
-      {adding && (
-        <div className="rounded-xl border border-border bg-biscuit/30 p-5 flex flex-col gap-3">
-          <input
-            type="text"
-            value={draft.title}
-            onChange={(e) => setDraft((d) => ({ ...d, title: e.target.value }))}
-            placeholder="Title"
-            className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-foreground/35 focus:outline-none focus:ring-2 focus:ring-primary/40"
-          />
-          <textarea
-            value={draft.body}
-            onChange={(e) => setDraft((d) => ({ ...d, body: e.target.value }))}
-            placeholder="Body text"
-            rows={3}
-            className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-foreground/35 focus:outline-none focus:ring-2 focus:ring-primary/40 resize-none"
-          />
-          <div className="flex justify-end gap-2">
-            <button
-              onClick={addAnnouncement}
-              disabled={!draft.title.trim() || !draft.body.trim()}
-              className="px-4 py-2 rounded-full bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary-dark transition-colors disabled:opacity-40 disabled:pointer-events-none"
-            >
-              Save draft
-            </button>
-          </div>
+      {/* List */}
+      {announcementsQuery.isLoading ? (
+        <div className="flex flex-col gap-3" aria-busy="true">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="rounded-xl border border-border bg-card px-5 py-4 flex flex-col gap-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          ))}
+        </div>
+      ) : announcementsQuery.isError ? (
+        <ErrorCard heading="Announcements unavailable" body="We couldn't load recent announcements." onRetry={() => void announcementsQuery.refetch()} />
+      ) : items.length === 0 ? (
+        <EmptyState heading="No announcements yet" body="Posted announcements will appear here." showCorgi={false} />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {items.map((a) => (
+            <div key={a.id} className="rounded-xl border border-border bg-card px-5 py-4 flex items-start gap-4">
+              <div className="flex-1 flex flex-col gap-1 min-w-0">
+                <p className="text-sm text-foreground/80 leading-relaxed">{a.content}</p>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-[10px] font-mono text-foreground/30">{relTime(a.postedAt)}</span>
+                  {a.type && <span className="text-[10px] font-mono text-foreground/30">· {a.type}</span>}
+                </div>
+              </div>
+              {a.postUrl && (
+                <a
+                  href={a.postUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs font-medium text-primary hover:text-primary-dark transition-colors flex-shrink-0"
+                >
+                  View ↗
+                </a>
+              )}
+            </div>
+          ))}
         </div>
       )}
 
-      <div className="flex flex-col gap-3">
-        {items.map((a) => (
-          <div key={a.id} className="rounded-xl border border-border bg-card px-5 py-4 flex items-start gap-4">
-            <div className="flex-1 flex flex-col gap-1 min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-semibold text-foreground">{a.title}</span>
-                <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full border ${a.published ? "bg-success/10 text-success border-success/20" : "bg-biscuit text-foreground/45 border-border"}`}>
-                  {a.published ? "Published" : "Draft"}
-                </span>
-              </div>
-              <p className="text-xs text-foreground/55 leading-relaxed">{a.body}</p>
-              <span className="text-[10px] font-mono text-foreground/30">{relTime(a.created_at)}</span>
-            </div>
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <button
-                onClick={() => togglePublish(a.id)}
-                className="text-xs font-medium text-foreground/50 hover:text-primary transition-colors"
-              >
-                {a.published ? "Unpublish" : "Publish"}
-              </button>
-              <button
-                onClick={() => setConfirmDelete(a.id)}
-                aria-label="Delete"
-                className="text-foreground/30 hover:text-status-error transition-colors"
-              >
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                  <path d="M3 4h10M6 4V2.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 .5.5V4M5 4l.5 8.5a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5L11 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
-                </svg>
-              </button>
-            </div>
-          </div>
-        ))}
-        {items.length === 0 && <p className="text-sm text-foreground/35 italic text-center py-8">No announcements yet.</p>}
-      </div>
-
-      {confirmDelete !== null && (
+      {confirmPost && (
         <ConfirmModal
-          title="Delete this announcement?"
-          body="This announcement will be permanently removed. If published, members will no longer see it."
-          confirmLabel="Delete"
-          danger
-          onConfirm={() => deleteItem(confirmDelete)}
-          onCancel={() => setConfirmDelete(null)}
+          title="Post this announcement to Bluesky?"
+          body="This will publish the announcement to the feed's Bluesky account, where all members can see it."
+          confirmLabel="Post announcement"
+          loading={postMutation.isPending}
+          onConfirm={() => postMutation.mutate()}
+          onCancel={() => setConfirmPost(false)}
         />
       )}
     </div>
   )
 }
 
-// ── Phase banner ──────────────────────────────────────────────────────────────
+// ── Phase banner meta ─────────────────────────────────────────────────────────
 
-const PHASE_META = {
-  running:  { label: "Running",      color: "bg-success/15 border-success/25 text-success",       dot: "bg-success" },
-  voting:   { label: "Voting open",  color: "bg-primary/10 border-primary/20 text-primary",       dot: "bg-primary animate-pulse" },
-  review:   { label: "Under review", color: "bg-warning/15 border-warning/25 text-warning",       dot: "bg-warning" },
-  waiting:  { label: "Waiting",      color: "bg-biscuit border-border text-foreground/50",         dot: "bg-foreground/30" },
+const PHASE_META: Record<EpochPhase, { label: string; color: string; dot: string }> = {
+  running: { label: "Running", color: "bg-success/15 border-success/25 text-success", dot: "bg-success" },
+  voting: { label: "Voting open", color: "bg-primary/10 border-primary/20 text-primary", dot: "bg-primary animate-pulse" },
+  review: { label: "Under review", color: "bg-warning/15 border-warning/25 text-warning", dot: "bg-warning" },
+  waiting: { label: "Waiting", color: "bg-biscuit border-border text-foreground/50", dot: "bg-foreground/30" },
 }
 
 // ── Nav items ─────────────────────────────────────────────────────────────────
 
 const NAV_PANELS = [
-  { id: "overview",        label: "Overview" },
-  { id: "current-round",   label: "Current round" },
-  { id: "weights",         label: "Weights override" },
-  { id: "filters",         label: "Content filters" },
-  { id: "topics",          label: "Topics" },
-  { id: "audit",           label: "Audit log" },
-  { id: "feed-health",     label: "Feed health" },
-  { id: "announcements",   label: "Announcements" },
+  { id: "overview", label: "Overview" },
+  { id: "current-round", label: "Current round" },
+  { id: "weights", label: "Weights override" },
+  { id: "filters", label: "Content filters" },
+  { id: "topics", label: "Topics" },
+  { id: "audit", label: "Audit log" },
+  { id: "feed-health", label: "Feed health" },
+  { id: "announcements", label: "Announcements" },
 ]
 
-// ── Main page ─────────────────────────────────────────────────────────────────
+// ── Authenticated admin console ───────────────────────────────────────────────
 
-export default function AdminPage() {
+function AdminConsole({ status }: { status: AdminStatus }) {
   const [activePanel, setActivePanel] = useState("overview")
-  const phase = MOCK_EPOCH.phase
+  const epoch = status.system.currentEpoch
+  const phase = epochPhase(epoch)
   const phaseMeta = PHASE_META[phase]
 
   const panels: Record<string, React.ReactNode> = {
-    "overview":      <PanelOverview />,
-    "current-round": <PanelCurrentRound />,
-    "weights":       <PanelWeightsOverride />,
-    "filters":       <PanelContentFilters />,
-    "topics":        <PanelTopics />,
-    "audit":         <PanelAuditLog />,
-    "feed-health":   <PanelFeedHealth />,
+    "overview": <PanelOverview status={status} />,
+    "current-round": <PanelCurrentRound status={status} />,
+    "weights": <PanelWeightsOverride status={status} />,
+    "filters": <PanelContentFilters status={status} />,
+    "topics": <PanelTopics />,
+    "audit": <PanelAuditLog />,
+    "feed-health": <PanelFeedHealth />,
     "announcements": <PanelAnnouncements />,
   }
 
   return (
-    <AppShell user={MOCK_USER}>
-      <div className="flex flex-col min-h-[calc(100vh-3.5rem)]">
-
-        {/* ── Governance phase banner ───────────────────────────── */}
-        <div className={`w-full border-b px-5 py-2.5 flex items-center gap-3 ${phaseMeta.color}`}>
-          <div className={`w-2 h-2 rounded-full flex-shrink-0 ${phaseMeta.dot}`} aria-hidden="true" />
-          <span className="text-xs font-semibold">Round #{MOCK_EPOCH.id} · {phaseMeta.label}</span>
-          <span className="text-xs opacity-60 hidden sm:block">
-            {phase === "voting" ? `Closes ${new Date(MOCK_EPOCH.voting_ends_at).toLocaleDateString("en-GB", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit", timeZoneName: "short" })}` : ""}
-          </span>
+    <div className="flex flex-col min-h-[calc(100vh-3.5rem)]">
+      {/* ── Governance phase banner ───────────────────────────── */}
+      <div className={`w-full border-b px-5 py-2.5 flex items-center gap-3 ${phaseMeta.color}`}>
+        <div className={`w-2 h-2 rounded-full flex-shrink-0 ${phaseMeta.dot}`} aria-hidden="true" />
+        <span className="text-xs font-semibold">
+          {epoch ? `Round #${epoch.id} · ${phaseMeta.label}` : "No active round"}
+        </span>
+        <span className="text-xs opacity-60 hidden sm:block">
+          {epoch && phase === "voting" && epoch.votingEndsAt ? `Closes ${fmtDateTime(epoch.votingEndsAt)}` : ""}
+        </span>
+        {epoch && (
           <span className="ml-auto text-[10px] font-mono opacity-50 hidden md:block">
-            {MOCK_EPOCH.vote_count} / {MOCK_EPOCH.subscriber_count} voted
+            {epoch.voteCount} / {status.system.feed.subscriberCount} voted
           </span>
-        </div>
+        )}
+      </div>
 
-        {/* Mobile panel nav — sits above the flex row so it spans full width */}
-        <div className="md:hidden w-full border-b border-border bg-card px-4 py-3 flex gap-2 overflow-x-auto flex-shrink-0">
+      {/* Mobile panel nav */}
+      <div className="md:hidden w-full border-b border-border bg-card px-4 py-3 flex gap-2 overflow-x-auto flex-shrink-0">
+        {NAV_PANELS.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => setActivePanel(p.id)}
+            className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-medium transition-colors border
+              ${activePanel === p.id
+                ? "bg-primary/10 text-primary border-primary/20"
+                : "text-foreground/55 border-border hover:text-foreground"
+              }`}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── 2-col layout: sidebar + content ─────────────────────── */}
+      <div className="flex flex-1 min-h-0">
+        <nav
+          className="hidden md:flex flex-col w-52 flex-shrink-0 border-r border-border bg-card px-3 py-5 gap-0.5 sticky top-[calc(3.5rem+2.5rem)] self-start"
+          style={{ maxHeight: "calc(100vh - 3.5rem - 2.5rem)", overflowY: "auto" }}
+          aria-label="Admin panels"
+        >
+          <span className="text-[9px] font-mono uppercase tracking-widest text-foreground/30 px-3 pb-2">Admin console</span>
           {NAV_PANELS.map((p) => (
             <button
               key={p.id}
               onClick={() => setActivePanel(p.id)}
-              className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-medium transition-colors border
+              aria-current={activePanel === p.id ? "page" : undefined}
+              className={`text-left px-3 py-2 rounded-lg text-sm font-medium transition-colors
                 ${activePanel === p.id
-                  ? "bg-primary/10 text-primary border-primary/20"
-                  : "text-foreground/55 border-border hover:text-foreground"
+                  ? "bg-primary/10 text-primary"
+                  : "text-foreground/60 hover:text-foreground hover:bg-biscuit/60"
                 }`}
             >
               {p.label}
             </button>
           ))}
-        </div>
+        </nav>
 
-        {/* ── 2-col layout: sidebar + content ─────────────────────── */}
-        <div className="flex flex-1 min-h-0">
+        <main className="flex-1 min-w-0 px-4 sm:px-6 py-7 max-w-4xl">
+          {panels[activePanel]}
+        </main>
+      </div>
+    </div>
+  )
+}
 
-          {/* Sidebar nav — desktop only */}
-          <nav
-            className="hidden md:flex flex-col w-52 flex-shrink-0 border-r border-border bg-card px-3 py-5 gap-0.5 sticky top-[calc(3.5rem+2.5rem)] self-start"
-            style={{ maxHeight: "calc(100vh - 3.5rem - 2.5rem)", overflowY: "auto" }}
-            aria-label="Admin panels"
+// ── Gating UIs ────────────────────────────────────────────────────────────────
+
+function AdminLoading() {
+  return (
+    <div className="max-w-4xl mx-auto w-full px-5 py-10 flex flex-col gap-6" aria-busy="true">
+      <Skeleton className="h-8 w-48" />
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-xl" />
+        ))}
+      </div>
+      <Skeleton className="h-40 rounded-xl" />
+    </div>
+  )
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function AdminPage() {
+  const { isAuthenticated } = useAuth()
+  const [signInOpen, setSignInOpen] = useState(false)
+
+  const statusQuery = useQuery({
+    queryKey: ["admin", "status"],
+    queryFn: adminApi.getStatus,
+    enabled: isAuthenticated,
+    retry: false,
+  })
+
+  let body: React.ReactNode
+
+  if (!isAuthenticated) {
+    body = (
+      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
+        <div className="w-full max-w-[440px] flex flex-col items-center text-center gap-6">
+          <div className="flex flex-col gap-2">
+            <h1 className="font-display text-xl font-bold text-foreground tracking-normal">Admin sign-in required</h1>
+            <p className="text-sm text-foreground/60 leading-relaxed">
+              The admin console is restricted to feed operators. Sign in with an authorised Bluesky account to continue.
+            </p>
+          </div>
+          <Button
+            onClick={() => setSignInOpen(true)}
+            className="bg-primary text-primary-foreground hover:bg-primary-dark rounded-full px-8 text-sm shadow-[0_2px_8px_rgba(200,97,44,0.3)] hover:shadow-[0_4px_14px_rgba(200,97,44,0.4)] transition-all"
           >
-            <span className="text-[9px] font-mono uppercase tracking-widest text-foreground/30 px-3 pb-2">Admin console</span>
-            {NAV_PANELS.map((p) => (
-              <button
-                key={p.id}
-                onClick={() => setActivePanel(p.id)}
-                aria-current={activePanel === p.id ? "page" : undefined}
-                className={`text-left px-3 py-2 rounded-lg text-sm font-medium transition-colors
-                  ${activePanel === p.id
-                    ? "bg-primary/10 text-primary"
-                    : "text-foreground/60 hover:text-foreground hover:bg-biscuit/60"
-                  }`}
-              >
-                {p.label}
-              </button>
-            ))}
-          </nav>
-
-          {/* Panel content */}
-          <main className="flex-1 min-w-0 px-4 sm:px-6 py-7 max-w-4xl">
-            {panels[activePanel]}
-          </main>
-
+            Connect Bluesky
+          </Button>
         </div>
       </div>
+    )
+  } else if (statusQuery.isLoading) {
+    body = <AdminLoading />
+  } else if (statusQuery.isError) {
+    const code = axios.isAxiosError(statusQuery.error) ? statusQuery.error.response?.status : undefined
+    body = code === 401 || code === 403 ? (
+      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
+        <div className="w-full max-w-md">
+          <EmptyState
+            heading="Access denied"
+            body="Your account isn't authorised to view the admin console. If you believe this is a mistake, contact a feed operator."
+            showCorgi={false}
+          />
+        </div>
+      </div>
+    ) : (
+      <div className="max-w-md mx-auto px-5 py-20">
+        <ErrorCard
+          heading="Admin console unavailable"
+          body="We couldn't load the admin console. Try again in a moment."
+          onRetry={() => void statusQuery.refetch()}
+        />
+      </div>
+    )
+  } else if (!statusQuery.data?.isAdmin) {
+    body = (
+      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
+        <div className="w-full max-w-md">
+          <EmptyState
+            heading="Access denied"
+            body="Your account isn't authorised to view the admin console."
+            showCorgi={false}
+          />
+        </div>
+      </div>
+    )
+  } else {
+    body = <AdminConsole status={statusQuery.data} />
+  }
+
+  return (
+    <AppShell>
+      {body}
+      <SignInDialog open={signInOpen} onOpenChange={setSignInOpen} />
     </AppShell>
   )
 }

--- a/web-next/app/admin/page.tsx
+++ b/web-next/app/admin/page.tsx
@@ -48,7 +48,9 @@ function epochPhase(epoch: CurrentEpoch | null): EpochPhase {
   const phase = (epoch as { phase?: string }).phase
   if (phase === "results") return "review"
   if (phase === "voting" || phase === "review" || phase === "running") return phase
-  if (epoch.votingOpen) return "voting"
+  // Fall back to `status` (what AdminStatus.system.currentEpoch actually exposes)
+  if (epoch.status === "results") return "review"
+  if (epoch.status === "voting" || epoch.votingOpen) return "voting"
   return "running"
 }
 

--- a/web-next/app/admin/page.tsx
+++ b/web-next/app/admin/page.tsx
@@ -46,6 +46,7 @@ type EpochPhase = "running" | "voting" | "review" | "waiting"
 function epochPhase(epoch: CurrentEpoch | null): EpochPhase {
   if (!epoch) return "waiting"
   const phase = (epoch as { phase?: string }).phase
+  if (phase === "results") return "review"
   if (phase === "voting" || phase === "review" || phase === "running") return phase
   if (epoch.votingOpen) return "voting"
   return "running"
@@ -1009,7 +1010,18 @@ export default function AdminPage() {
     body = <AdminLoading />
   } else if (statusQuery.isError) {
     const code = axios.isAxiosError(statusQuery.error) ? statusQuery.error.response?.status : undefined
-    body = code === 401 || code === 403 ? (
+    body = code === 401 ? (
+      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
+        <div className="w-full max-w-md">
+          <EmptyState
+            heading="Session expired"
+            body="Your session has ended. Sign in again to access the admin console."
+            showCorgi={false}
+            action={{ label: "Sign in", onClick: () => setSignInOpen(true) }}
+          />
+        </div>
+      </div>
+    ) : code === 403 ? (
       <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
         <div className="w-full max-w-md">
           <EmptyState

--- a/web-next/app/admin/page.tsx
+++ b/web-next/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import {Fragment, useEffect, useRef, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import axios from "axios"
 import { AppShell } from "@/components/app-shell"
@@ -74,11 +74,11 @@ function ConfirmModal({
     // Initial focus lands on the safe (Cancel) action, and Escape closes.
     cancelRef.current?.focus()
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onCancel()
+      if (e.key === "Escape" && !loading) onCancel()
     }
     document.addEventListener("keydown", onKey)
     return () => document.removeEventListener("keydown", onKey)
-  }, [onCancel])
+  }, [onCancel, loading])
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-labelledby="modal-title">
@@ -582,6 +582,7 @@ function PanelAuditLog() {
     queryKey: ["admin", "audit-log", limit],
     queryFn: () => adminApi.getAuditLog({ limit }),
     retry: false,
+    placeholderData: (prev) => prev,
   })
 
   const entries = auditQuery.data?.entries ?? []
@@ -620,9 +621,8 @@ function PanelAuditLog() {
                 const isExpanded = expanded === entry.id
                 const hasDetails = entry.details != null && Object.keys(entry.details).length > 0
                 return (
-                  <>
+                  <Fragment key={entry.id}>
                     <tr
-                      key={entry.id}
                       className="border-b border-border/50 last:border-b-0 hover:bg-biscuit/20 transition-colors cursor-pointer"
                       onClick={() => hasDetails && setExpanded(isExpanded ? null : entry.id)}
                     >
@@ -655,7 +655,7 @@ function PanelAuditLog() {
                         </td>
                       </tr>
                     )}
-                  </>
+                  </Fragment>
                 )
               })}
             </tbody>

--- a/web-next/app/admin/page.tsx
+++ b/web-next/app/admin/page.tsx
@@ -18,7 +18,7 @@ const SIGNAL_LABELS: Record<string, string> = {
   source_diversity: "Source diversity", relevance: "Relevance",
 }
 
-const WEIGHT_KEYS = ["recency", "engagement", "bridging", "source_diversity", "relevance"] as const
+const WEIGHT_KEYS = ["recency", "engagement", "bridging", "sourceDiversity", "relevance"] as const
 
 function relTime(iso: string | null) {
   if (!iso) return "never"
@@ -184,9 +184,9 @@ function PanelCurrentRound({ status }: { status: AdminStatus }) {
     void queryClient.invalidateQueries({ queryKey: ["admin", "feed-health"] })
   }
 
-  const openMutation = useMutation({ mutationFn: () => adminApi.openVoting(), onSuccess: () => { invalidate(); setConfirm(null) } })
-  const closeMutation = useMutation({ mutationFn: () => adminApi.closeVoting(), onSuccess: () => { invalidate(); setConfirm(null) } })
-  const applyMutation = useMutation({ mutationFn: () => adminApi.transitionEpoch(), onSuccess: () => { invalidate(); setConfirm(null) } })
+  const openMutation = useMutation({ mutationFn: () => adminApi.transitionEpoch(), onSuccess: () => { invalidate(); setConfirm(null) } })
+  const closeMutation = useMutation({ mutationFn: () => adminApi.endVoting(false), onSuccess: () => { invalidate(); setConfirm(null) } })
+  const applyMutation = useMutation({ mutationFn: () => adminApi.approveResults(), onSuccess: () => { invalidate(); setConfirm(null) } })
 
   if (!epoch) {
     return (
@@ -255,7 +255,7 @@ function PanelCurrentRound({ status }: { status: AdminStatus }) {
         <ConfirmModal
           title={`Open voting for Round #${epoch.id}?`}
           body="This will open the round for member votes."
-          confirmLabel="Open voting"
+          confirmLabel="Advance round"
           loading={openMutation.isPending}
           onConfirm={() => openMutation.mutate()}
           onCancel={() => setConfirm(null)}

--- a/web-next/app/history/page.tsx
+++ b/web-next/app/history/page.tsx
@@ -1,14 +1,16 @@
 "use client"
 
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
 import { AppShell } from "@/components/app-shell"
 import { WeightBar } from "@/components/ui/weight-bar"
 import { ScoreRadar, type RadarSignal } from "@/components/ui/score-radar"
 import { StatusChip } from "@/components/ui/status-chip"
 import { WeightsSkeleton, EmptyState, ErrorCard, Skeleton } from "@/components/ui/state-kit"
+import { transparencyApi, type EpochResponse, type AuditLogEntry } from "@/lib/api/client"
 
-/* ─── Mock data (exact field names from the brief seam) ── */
+/* ─── Constants ────────────────────────────────────────── */
 
 const WEIGHT_LABELS: Record<string, string> = {
   recency: "Recency",
@@ -18,121 +20,56 @@ const WEIGHT_LABELS: Record<string, string> = {
   relevance: "Relevance",
 }
 
-type Phase = "voting" | "review" | "running" | "live" | "waiting" | "closed"
+const AUDIT_PAGE_SIZE = 25
 
-interface Epoch {
+/* ─── Derived view model ────────────────────────────────────
+ * The API has no per-round diff endpoint, so — like the dashboard's
+ * deriveRoundDiff — we compute prev-weights and keyword deltas from the
+ * adjacent (next-older) epoch in the fetched history. */
+
+interface EpochView {
   id: number
   status: string
-  phase: Phase
+  phase: string
   vote_count: number
   subscriber_count: number
   created_at: string
   closed_at: string | null
   weights: Record<string, number>
   prev_weights?: Record<string, number>
-  keywords_added?: { include: string[]; exclude: string[] }
-  keywords_removed?: { include: string[]; exclude: string[] }
+  keywords_added: { include: string[]; exclude: string[] }
+  keywords_removed: { include: string[]; exclude: string[] }
 }
 
-interface AuditEntry {
-  id: number
-  action: string
-  actor_did: string | null
-  epoch_id: number
-  details: Record<string, unknown>
-  created_at: string
+function deriveEpochViews(epochs: EpochResponse[]): EpochView[] {
+  const sorted = [...epochs].sort((a, b) => b.id - a.id)
+  return sorted.map((epoch, i) => {
+    const prev = sorted[i + 1] // next-older round, or undefined for the oldest
+    const currInc = epoch.content_rules?.include_keywords ?? []
+    const prevInc = prev?.content_rules?.include_keywords ?? []
+    const currExc = epoch.content_rules?.exclude_keywords ?? []
+    const prevExc = prev?.content_rules?.exclude_keywords ?? []
+    return {
+      id: epoch.id,
+      status: epoch.status,
+      phase: epoch.phase ?? epoch.status,
+      vote_count: epoch.vote_count,
+      subscriber_count: epoch.subscriber_count ?? 0,
+      created_at: epoch.created_at,
+      closed_at: epoch.closed_at ?? null,
+      weights: epoch.weights as Record<string, number>,
+      prev_weights: prev ? (prev.weights as Record<string, number>) : undefined,
+      keywords_added: {
+        include: currInc.filter((w) => !prevInc.includes(w)),
+        exclude: currExc.filter((w) => !prevExc.includes(w)),
+      },
+      keywords_removed: {
+        include: prevInc.filter((w) => !currInc.includes(w)),
+        exclude: prevExc.filter((w) => !currExc.includes(w)),
+      },
+    }
+  })
 }
-
-const MOCK_EPOCHS: Epoch[] = [
-  {
-    id: 47,
-    status: "voting",
-    phase: "voting",
-    vote_count: 312,
-    subscriber_count: 480,
-    created_at: "2026-06-25T00:00:00Z",
-    closed_at: null,
-    weights: { recency: 0.35, engagement: 0.25, bridging: 0.20, source_diversity: 0.15, relevance: 0.05 },
-    prev_weights: { recency: 0.30, engagement: 0.30, bridging: 0.20, source_diversity: 0.10, relevance: 0.10 },
-    keywords_added:   { include: ["ai", "governance"], exclude: [] },
-    keywords_removed: { include: [],                   exclude: ["nft", "crypto"] },
-  },
-  {
-    id: 46,
-    status: "closed",
-    phase: "closed",
-    vote_count: 289,
-    subscriber_count: 461,
-    created_at: "2026-06-18T00:00:00Z",
-    closed_at: "2026-06-24T17:00:00Z",
-    weights: { recency: 0.30, engagement: 0.30, bridging: 0.20, source_diversity: 0.10, relevance: 0.10 },
-    prev_weights: { recency: 0.30, engagement: 0.30, bridging: 0.20, source_diversity: 0.10, relevance: 0.10 },
-    keywords_added:   { include: [], exclude: ["nft"] },
-    keywords_removed: { include: [], exclude: [] },
-  },
-  {
-    id: 45,
-    status: "closed",
-    phase: "closed",
-    vote_count: 304,
-    subscriber_count: 448,
-    created_at: "2026-06-11T00:00:00Z",
-    closed_at: "2026-06-17T17:00:00Z",
-    weights: { recency: 0.30, engagement: 0.30, bridging: 0.20, source_diversity: 0.10, relevance: 0.10 },
-    prev_weights: { recency: 0.25, engagement: 0.35, bridging: 0.20, source_diversity: 0.10, relevance: 0.10 },
-    keywords_added:   { include: [], exclude: [] },
-    keywords_removed: { include: [], exclude: [] },
-  },
-  {
-    id: 44,
-    status: "closed",
-    phase: "closed",
-    vote_count: 271,
-    subscriber_count: 431,
-    created_at: "2026-06-04T00:00:00Z",
-    closed_at: "2026-06-10T17:00:00Z",
-    weights: { recency: 0.25, engagement: 0.35, bridging: 0.20, source_diversity: 0.10, relevance: 0.10 },
-    prev_weights: { recency: 0.25, engagement: 0.35, bridging: 0.20, source_diversity: 0.10, relevance: 0.10 },
-    keywords_added:   { include: [], exclude: [] },
-    keywords_removed: { include: [], exclude: [] },
-  },
-  {
-    id: 43,
-    status: "closed",
-    phase: "closed",
-    vote_count: 258,
-    subscriber_count: 415,
-    created_at: "2026-05-28T00:00:00Z",
-    closed_at: "2026-06-03T17:00:00Z",
-    weights: { recency: 0.25, engagement: 0.35, bridging: 0.20, source_diversity: 0.10, relevance: 0.10 },
-    prev_weights: undefined, // oldest — no diff
-    keywords_added:   { include: [], exclude: [] },
-    keywords_removed: { include: [], exclude: [] },
-  },
-]
-
-const MOCK_AUDIT: AuditEntry[] = [
-  { id: 991, action: "weights_applied",  actor_did: null,               epoch_id: 47, details: {},                                     created_at: "2026-06-25T00:00:00Z" },
-  { id: 990, action: "vote_submitted",   actor_did: "did:plc:abc123",   epoch_id: 47, details: { handle: "maya.bsky.social" },         created_at: "2026-06-24T18:32:00Z" },
-  { id: 989, action: "vote_submitted",   actor_did: "did:plc:def456",   epoch_id: 47, details: { handle: "alicia.bsky.social" },       created_at: "2026-06-24T16:11:00Z" },
-  { id: 988, action: "epoch_opened",     actor_did: null,               epoch_id: 47, details: {},                                     created_at: "2026-06-24T00:00:00Z" },
-  { id: 987, action: "keywords_updated", actor_did: null,               epoch_id: 47, details: { added: ["ai"], removed: ["nft"] },    created_at: "2026-06-25T00:01:00Z" },
-  { id: 986, action: "weights_applied",  actor_did: null,               epoch_id: 46, details: {},                                     created_at: "2026-06-18T00:00:00Z" },
-  { id: 985, action: "epoch_closed",     actor_did: null,               epoch_id: 46, details: {},                                     created_at: "2026-06-24T17:00:00Z" },
-  { id: 984, action: "vote_submitted",   actor_did: "did:plc:ghi789",   epoch_id: 46, details: { handle: "jordyn.bsky.social" },       created_at: "2026-06-23T09:15:00Z" },
-]
-
-const ACTION_META: Record<string, { label: string; color: string }> = {
-  weights_applied:  { label: "Weights applied",  color: "bg-primary/60"   },
-  vote_submitted:   { label: "Vote submitted",   color: "bg-success/60"   },
-  epoch_opened:     { label: "Epoch opened",     color: "bg-foreground/25" },
-  epoch_closed:     { label: "Epoch closed",     color: "bg-foreground/25" },
-  keywords_updated: { label: "Keywords updated", color: "bg-warning/60"   },
-}
-
-/* ─── Types ────────────────────────────────────────────── */
-
-type PageState = "loading" | "loaded" | "error" | "empty"
 
 /* ─── Helpers ──────────────────────────────────────────── */
 
@@ -153,7 +90,7 @@ function fmtRelative(iso: string) {
   return `${days}d ago`
 }
 
-function weightDiff(epoch: Epoch) {
+function weightDiff(epoch: EpochView) {
   if (!epoch.prev_weights) return []
   const EPSILON = 0.005
   return Object.keys(epoch.weights)
@@ -166,15 +103,6 @@ function weightDiff(epoch: Epoch) {
     .filter((d) => Math.abs(d.delta) > EPSILON)
 }
 
-function toRadarSignals(epoch: Epoch): RadarSignal[] {
-  return Object.entries(epoch.weights).map(([key, weight]) => ({
-    key,
-    label: WEIGHT_LABELS[key] ?? key,
-    post:       weight, // on the ledger, post = applied weight (no per-post score here)
-    governance: weight,
-  }))
-}
-
 /* ─── Sub-components ───────────────────────────────────── */
 
 function EpochCard({
@@ -182,11 +110,12 @@ function EpochCard({
   selected,
   onClick,
 }: {
-  epoch: Epoch
+  epoch: EpochView
   selected: boolean
   onClick: () => void
 }) {
-  const participation = epoch.subscriber_count ? Math.round((epoch.vote_count / epoch.subscriber_count) * 100) : 0
+  // NaN-guard: subscriber_count can be 0 for a fresh round.
+  const participation = epoch.subscriber_count > 0 ? Math.round((epoch.vote_count / epoch.subscriber_count) * 100) : 0
 
   return (
     <button
@@ -301,25 +230,25 @@ function KeywordDiffRow({ word, variant }: { word: string; variant: "add-include
   )
 }
 
-function AuditRow({ entry }: { entry: AuditEntry }) {
-  const meta = ACTION_META[entry.action] ?? { label: entry.action, color: "bg-foreground/20" }
+function AuditRow({ entry }: { entry: AuditLogEntry }) {
   const hasDetails = Object.keys(entry.details).length > 0
   const [expanded, setExpanded] = useState(false)
+  const handle = typeof entry.details.handle === "string" ? entry.details.handle : entry.actor_did
 
   return (
     <div className="group">
       <div className="flex items-start gap-4 px-5 py-3 hover:bg-biscuit/25 transition-colors">
         {/* Action dot */}
         <div className="flex flex-col items-center gap-1 pt-1 flex-shrink-0">
-          <div className={`w-2 h-2 rounded-full ${meta.color}`} aria-hidden="true" />
+          <div className="w-2 h-2 rounded-full bg-primary/50" aria-hidden="true" />
         </div>
         {/* Content */}
         <div className="flex-1 min-w-0 flex flex-col gap-0.5">
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm font-medium text-foreground">{meta.label}</span>
-            {entry.actor_did && (
+            <span className="text-sm font-medium text-foreground font-mono">{entry.action}</span>
+            {handle && (
               <span className="text-xs font-mono text-foreground/45 truncate max-w-[200px]">
-                {typeof entry.details.handle === "string" ? entry.details.handle : "" ?? entry.actor_did}
+                {handle}
               </span>
             )}
           </div>
@@ -340,13 +269,9 @@ function AuditRow({ entry }: { entry: AuditEntry }) {
         </div>
         {/* Right: epoch + timestamp */}
         <div className="flex flex-col items-end gap-0.5 flex-shrink-0">
-          <button
-            type="button"
-            className="text-xs font-mono text-primary/70 hover:text-primary transition-colors"
-            title={`Select epoch #${entry.epoch_id}`}
-          >
-            #{entry.epoch_id}
-          </button>
+          <span className="text-xs font-mono text-foreground/50" title={`Round ${entry.epoch_id ?? "—"}`}>
+            #{entry.epoch_id ?? "—"}
+          </span>
           <time
             dateTime={entry.created_at}
             className="text-[10px] font-mono text-foreground/35"
@@ -362,13 +287,13 @@ function AuditRow({ entry }: { entry: AuditEntry }) {
 
 /* ─── Detail panel ─────────────────────────────────────── */
 
-function DetailPanel({ epoch }: { epoch: Epoch }) {
+function DetailPanel({ epoch, epochAudit }: { epoch: EpochView; epochAudit: AuditLogEntry[] }) {
   const diffs = weightDiff(epoch)
   const hasKeywordChanges =
-    (epoch.keywords_added?.include.length ?? 0) +
-    (epoch.keywords_added?.exclude.length ?? 0) +
-    (epoch.keywords_removed?.include.length ?? 0) +
-    (epoch.keywords_removed?.exclude.length ?? 0) > 0
+    epoch.keywords_added.include.length +
+    epoch.keywords_added.exclude.length +
+    epoch.keywords_removed.include.length +
+    epoch.keywords_removed.exclude.length > 0
 
   const radarSignals: RadarSignal[] = Object.entries(epoch.weights).map(([key, w]) => ({
     key,
@@ -377,12 +302,12 @@ function DetailPanel({ epoch }: { epoch: Epoch }) {
     governance: w,
   }))
 
-  const epochAudit = MOCK_AUDIT.filter((e) => e.epoch_id === epoch.id)
+  const participation = epoch.subscriber_count > 0 ? Math.round((epoch.vote_count / epoch.subscriber_count) * 100) : 0
 
   return (
     <div className="flex flex-col gap-8">
 
-      {/* ── Header ───────────────────────────────────���───── */}
+      {/* ── Header ────────────────────────────────────────── */}
       <div className="flex items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-3">
@@ -393,7 +318,7 @@ function DetailPanel({ epoch }: { epoch: Epoch }) {
           </div>
           <p className="text-sm text-foreground/50">
             {epoch.vote_count.toLocaleString()} votes of {epoch.subscriber_count.toLocaleString()} members
-            {" · "}{epoch.subscriber_count ? Math.round((epoch.vote_count / epoch.subscriber_count) * 100) : 0}% participation
+            {" · "}{participation}% participation
           </p>
           <p className="text-xs font-mono text-foreground/35 mt-0.5">
             {fmtDate(epoch.created_at, "long")}
@@ -401,7 +326,7 @@ function DetailPanel({ epoch }: { epoch: Epoch }) {
           </p>
         </div>
         <Link
-          href={`/post?uri=${encodeURIComponent("at://demo")}`}
+          href="/dashboard"
           className="text-xs font-medium text-primary hover:text-primary-dark transition-colors underline underline-offset-2 flex-shrink-0 mt-1"
         >
           Explain a post →
@@ -469,16 +394,16 @@ function DetailPanel({ epoch }: { epoch: Epoch }) {
           </p>
         ) : (
           <div className="flex flex-wrap gap-2">
-            {epoch.keywords_added?.include.map((w) => (
+            {epoch.keywords_added.include.map((w) => (
               <KeywordDiffRow key={`ai-${w}`} word={w} variant="add-include" />
             ))}
-            {epoch.keywords_added?.exclude.map((w) => (
+            {epoch.keywords_added.exclude.map((w) => (
               <KeywordDiffRow key={`ae-${w}`} word={w} variant="add-exclude" />
             ))}
-            {epoch.keywords_removed?.include.map((w) => (
+            {epoch.keywords_removed.include.map((w) => (
               <KeywordDiffRow key={`ri-${w}`} word={w} variant="remove-include" />
             ))}
-            {epoch.keywords_removed?.exclude.map((w) => (
+            {epoch.keywords_removed.exclude.map((w) => (
               <KeywordDiffRow key={`re-${w}`} word={w} variant="remove-exclude" />
             ))}
           </div>
@@ -496,7 +421,7 @@ function DetailPanel({ epoch }: { epoch: Epoch }) {
         {epochAudit.length === 0 ? (
           <EmptyState
             heading="No audit events"
-            body="Evaluated the audit log — no events recorded for this round."
+            body="No recent audit events recorded for this round."
             showCorgi={false}
           />
         ) : (
@@ -538,14 +463,32 @@ function DetailPanelSkeleton() {
 /* ─── Page ─────────────────────────────────────────────── */
 
 export default function HistoryPage() {
-  const [pageState, setPageState] = useState<PageState>("loaded")
-  const [selectedId, setSelectedId] = useState<number>(MOCK_EPOCHS[0].id)
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [auditLimit, setAuditLimit] = useState(AUDIT_PAGE_SIZE)
 
-  const epochs = MOCK_EPOCHS
-  const selectedEpoch = epochs.find((e) => e.id === selectedId) ?? epochs[0]
+  const epochsQuery = useQuery({
+    queryKey: ["epochs", 20],
+    queryFn: () => transparencyApi.getEpochHistory(20),
+    retry: false,
+  })
+  const auditQuery = useQuery({
+    queryKey: ["transparency", "audit", auditLimit],
+    queryFn: () => transparencyApi.getAuditLog({ limit: auditLimit }),
+    retry: false,
+  })
+
+  const epochViews = useMemo(
+    () => deriveEpochViews(epochsQuery.data?.epochs ?? []),
+    [epochsQuery.data]
+  )
+  const selectedEpoch = epochViews.find((e) => e.id === selectedId) ?? epochViews[0]
+
+  const auditEntries = auditQuery.data?.entries ?? []
+  const auditTotal = auditQuery.data?.pagination.total ?? 0
+  const auditHasMore = auditQuery.data?.pagination.has_more ?? false
 
   return (
-    <AppShell user={null} activePath="/history">
+    <AppShell>
       <div className="max-w-6xl mx-auto px-5 py-10 flex flex-col gap-8">
 
         {/* ── Page header ──────────────────────────────────── */}
@@ -569,41 +512,44 @@ export default function HistoryPage() {
           </Link>
         </div>
 
-        {/* ── Dev state switcher (hidden in production) ────── */}
-        <div className="flex items-center gap-2 hidden" aria-hidden="true">
-          {(["loading", "loaded", "error", "empty"] as PageState[]).map((s) => (
-            <button
-              key={s}
-              onClick={() => setPageState(s)}
-              className={`text-xs px-2 py-1 rounded border ${pageState === s ? "bg-primary text-primary-foreground border-primary" : "border-border text-foreground/50"}`}
-            >
-              {s}
-            </button>
-          ))}
-        </div>
-
-        {/* ── Error state ───────────────────────────────────── */}
-        {pageState === "error" && (
+        {/* ── Rounds region (driven by the epochs query) ───── */}
+        {epochsQuery.isLoading ? (
+          <div className="flex flex-col lg:flex-row gap-6 items-start">
+            <aside className="w-full lg:w-56 lg:flex-shrink-0 flex flex-col gap-2" aria-label="Loading rounds">
+              <p className="text-[10px] font-mono text-foreground/40 uppercase tracking-widest px-1 mb-1">
+                Rounds · newest first
+              </p>
+              <div className="flex flex-col gap-2">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
+                    <div className="flex justify-between">
+                      <Skeleton className="h-6 w-10" />
+                      <Skeleton className="h-5 w-16" />
+                    </div>
+                    <Skeleton className="h-3 w-20" />
+                    <Skeleton className="h-1 w-full rounded-full" />
+                  </div>
+                ))}
+              </div>
+            </aside>
+            <main className="w-full lg:flex-1 min-w-0 rounded-xl border border-border bg-card p-4 sm:p-6 lg:p-7">
+              <DetailPanelSkeleton />
+            </main>
+          </div>
+        ) : epochsQuery.isError ? (
           <ErrorCard
             heading="Ledger unavailable"
             body="We couldn't load governance history. The transparency record is still intact — try again shortly."
-            onRetry={() => setPageState("loaded")}
+            onRetry={() => void epochsQuery.refetch()}
           />
-        )}
-
-        {/* ── Empty state ───────────────────────────────────── */}
-        {pageState === "empty" && (
+        ) : epochViews.length === 0 ? (
           <EmptyState
             heading="No rounds yet"
             body="Governance history will appear here once the first round is complete."
-            action={{ label: "Go to overview", onClick: () => {} }}
+            showCorgi={false}
           />
-        )}
-
-        {/* ── Main 2-column layout ─────────────────────────── */}
-        {(pageState === "loading" || pageState === "loaded") && (
+        ) : (
           <div className="flex flex-col lg:flex-row gap-6 items-start">
-
             {/* ── LEFT: epoch timeline ─────────────────────── */}
             <aside
               className="w-full lg:w-56 lg:flex-shrink-0 flex flex-col gap-2 lg:sticky lg:top-20"
@@ -612,58 +558,62 @@ export default function HistoryPage() {
               <p className="text-[10px] font-mono text-foreground/40 uppercase tracking-widest px-1 mb-1">
                 Rounds · newest first
               </p>
-
-              {pageState === "loading" ? (
-                <div className="flex flex-col gap-2">
-                  {Array.from({ length: 4 }).map((_, i) => (
-                    <div key={i} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
-                      <div className="flex justify-between">
-                        <Skeleton className="h-6 w-10" />
-                        <Skeleton className="h-5 w-16" />
-                      </div>
-                      <Skeleton className="h-3 w-20" />
-                      <Skeleton className="h-1 w-full rounded-full" />
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <nav className="flex flex-row lg:flex-col gap-2 overflow-x-auto pb-2 lg:pb-0" aria-label="Select a round">
-                  {epochs.map((epoch) => (
-                    <div key={epoch.id} className="flex-shrink-0 w-44 sm:w-48 lg:w-auto">
-                      <EpochCard
-                        epoch={epoch}
-                        selected={epoch.id === selectedId}
-                        onClick={() => setSelectedId(epoch.id)}
-                      />
-                    </div>
-                  ))}
-                </nav>
-              )}
+              <nav className="flex flex-row lg:flex-col gap-2 overflow-x-auto pb-2 lg:pb-0" aria-label="Select a round">
+                {epochViews.map((epoch) => (
+                  <div key={epoch.id} className="flex-shrink-0 w-44 sm:w-48 lg:w-auto">
+                    <EpochCard
+                      epoch={epoch}
+                      selected={epoch.id === selectedEpoch.id}
+                      onClick={() => setSelectedId(epoch.id)}
+                    />
+                  </div>
+                ))}
+              </nav>
             </aside>
 
             {/* ── RIGHT: detail panel ──────────────────────── */}
             <main className="w-full lg:flex-1 min-w-0 rounded-xl border border-border bg-card p-4 sm:p-6 lg:p-7">
-              {pageState === "loading" ? (
-                <DetailPanelSkeleton />
-              ) : (
-                <DetailPanel epoch={selectedEpoch} />
-              )}
+              <DetailPanel
+                epoch={selectedEpoch}
+                epochAudit={auditEntries.filter((e) => e.epoch_id === selectedEpoch.id)}
+              />
             </main>
-
           </div>
         )}
 
         {/* ── Full audit table (all epochs) ────────────────── */}
-        {pageState === "loaded" && (
-          <section aria-label="Full audit log">
-            <div className="flex items-center justify-between mb-4">
-              <p className="text-[10px] font-mono text-foreground/40 uppercase tracking-widest">
-                Full audit log · {MOCK_AUDIT.length} of 120 entries
-              </p>
-              <span className="text-xs text-foreground/35 font-mono">
-                Showing 50 most recent
-              </span>
+        <section aria-label="Full audit log">
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-[10px] font-mono text-foreground/40 uppercase tracking-widest">
+              Full audit log · {auditEntries.length} of {auditTotal} entries
+            </p>
+            <span className="text-xs text-foreground/35 font-mono">
+              Showing {auditEntries.length} most recent
+            </span>
+          </div>
+
+          {auditQuery.isLoading ? (
+            <div className="rounded-xl border border-border bg-card divide-y divide-border/60 overflow-hidden" aria-busy="true">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="flex items-center justify-between gap-4 px-5 py-3.5">
+                  <Skeleton className="h-4 w-44" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+              ))}
             </div>
+          ) : auditQuery.isError ? (
+            <ErrorCard
+              heading="Audit log unavailable"
+              body="We couldn't load the full audit log. Try again shortly."
+              onRetry={() => void auditQuery.refetch()}
+            />
+          ) : auditTotal === 0 ? (
+            <EmptyState
+              heading="No audit entries yet"
+              body="Governance events will appear here once activity begins."
+              showCorgi={false}
+            />
+          ) : (
             <div className="rounded-xl border border-border bg-card overflow-hidden">
               {/* Table header */}
               <div className="grid grid-cols-[1fr_auto_auto] gap-4 px-5 py-2.5 bg-biscuit/40 border-b border-border">
@@ -672,23 +622,27 @@ export default function HistoryPage() {
                 <span className="text-[10px] font-semibold text-foreground/40 uppercase tracking-wide w-20 text-right">Time</span>
               </div>
               <div className="divide-y divide-border/60">
-                {MOCK_AUDIT.map((entry) => (
+                {auditEntries.map((entry) => (
                   <AuditRow key={entry.id} entry={entry} />
                 ))}
               </div>
-              {/* Pagination hint */}
+              {/* Pagination */}
               <div className="px-5 py-3 border-t border-border/60 flex items-center justify-between">
-                <span className="text-xs text-foreground/40 font-mono">120 total · 50 shown</span>
-                <button
-                  type="button"
-                  className="text-xs font-medium text-primary hover:text-primary-dark transition-colors"
-                >
-                  Load more
-                </button>
+                <span className="text-xs text-foreground/40 font-mono">{auditTotal} total · {auditEntries.length} shown</span>
+                {auditHasMore && (
+                  <button
+                    type="button"
+                    onClick={() => setAuditLimit((l) => l + AUDIT_PAGE_SIZE)}
+                    disabled={auditQuery.isFetching}
+                    className="text-xs font-medium text-primary hover:text-primary-dark transition-colors disabled:opacity-40"
+                  >
+                    {auditQuery.isFetching ? "Loading…" : "Load more"}
+                  </button>
+                )}
               </div>
             </div>
-          </section>
-        )}
+          )}
+        </section>
 
       </div>
     </AppShell>

--- a/web-next/app/history/page.tsx
+++ b/web-next/app/history/page.tsx
@@ -287,7 +287,7 @@ function AuditRow({ entry }: { entry: AuditLogEntry }) {
 
 /* ─── Detail panel ─────────────────────────────────────── */
 
-function DetailPanel({ epoch, epochAudit }: { epoch: EpochView; epochAudit: AuditLogEntry[] }) {
+function DetailPanel({ epoch, epochAudit, auditWindowNote }: { epoch: EpochView; epochAudit: AuditLogEntry[]; auditWindowNote?: string }) {
   const diffs = weightDiff(epoch)
   const hasKeywordChanges =
     epoch.keywords_added.include.length +
@@ -416,7 +416,7 @@ function DetailPanel({ epoch, epochAudit }: { epoch: EpochView; epochAudit: Audi
       {/* ── Per-round audit events ────────────────────────── */}
       <section aria-label={`Audit events for round ${epoch.id}`}>
         <p className="text-[10px] font-mono text-foreground/40 uppercase tracking-widest mb-2">
-          Audit events · Round #{epoch.id}
+          Audit events · Round #{epoch.id}{auditWindowNote ? ` (${auditWindowNote})` : ""}
         </p>
         {epochAudit.length === 0 ? (
           <EmptyState
@@ -475,6 +475,7 @@ export default function HistoryPage() {
     queryKey: ["transparency", "audit", auditLimit],
     queryFn: () => transparencyApi.getAuditLog({ limit: auditLimit }),
     retry: false,
+    placeholderData: (prev) => prev,
   })
 
   const epochViews = useMemo(
@@ -575,7 +576,7 @@ export default function HistoryPage() {
             <main className="w-full lg:flex-1 min-w-0 rounded-xl border border-border bg-card p-4 sm:p-6 lg:p-7">
               <DetailPanel
                 epoch={selectedEpoch}
-                epochAudit={auditEntries.filter((e) => e.epoch_id === selectedEpoch.id)}
+                epochAudit={auditEntries.filter((e) => e.epoch_id === selectedEpoch.id)} auditWindowNote={`from the ${auditEntries.length} most recent loaded events`}
               />
             </main>
           </div>

--- a/web-next/app/history/page.tsx
+++ b/web-next/app/history/page.tsx
@@ -44,7 +44,8 @@ interface EpochView {
 function deriveEpochViews(epochs: EpochResponse[]): EpochView[] {
   const sorted = [...epochs].sort((a, b) => b.id - a.id)
   return sorted.map((epoch, i) => {
-    const prev = sorted[i + 1] // next-older round, or undefined for the oldest
+    const prev = sorted[i + 1]
+    const prevLoaded = i + 1 < sorted.length // next-older round, or undefined for the oldest
     const currInc = epoch.content_rules?.include_keywords ?? []
     const prevInc = prev?.content_rules?.include_keywords ?? []
     const currExc = epoch.content_rules?.exclude_keywords ?? []
@@ -59,14 +60,16 @@ function deriveEpochViews(epochs: EpochResponse[]): EpochView[] {
       closed_at: epoch.closed_at ?? null,
       weights: epoch.weights as Record<string, number>,
       prev_weights: prev ? (prev.weights as Record<string, number>) : undefined,
-      keywords_added: {
+      // For the oldest loaded round the previous round isn't in the window —
+      // report no diffs rather than fabricating "added everything".
+      keywords_added: prevLoaded ? {
         include: currInc.filter((w) => !prevInc.includes(w)),
         exclude: currExc.filter((w) => !prevExc.includes(w)),
-      },
-      keywords_removed: {
+      } : { include: [], exclude: [] },
+      keywords_removed: prevLoaded ? {
         include: prevInc.filter((w) => !currInc.includes(w)),
         exclude: prevExc.filter((w) => !currExc.includes(w)),
-      },
+      } : { include: [], exclude: [] },
     }
   })
 }

--- a/web-next/app/post/page.tsx
+++ b/web-next/app/post/page.tsx
@@ -2,49 +2,16 @@
 
 import { Suspense, useState } from "react"
 import Link from "next/link"
-import { useSearchParams } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
+import { useQuery } from "@tanstack/react-query"
+import axios from "axios"
 import { AppShell } from "@/components/app-shell"
 import { ScoreBreakdown, type ScoreComponent } from "@/components/ui/score-breakdown"
 import { ScoreRadar, type RadarSignal } from "@/components/ui/score-radar"
 import { WeightBar } from "@/components/ui/weight-bar"
 import { Skeleton, EmptyState, ErrorCard } from "@/components/ui/state-kit"
 import { Button } from "@/components/ui/button"
-
-/* ─── Mock data — exact field names from the brief seam ─── */
-
-const MOCK_EXPLANATION = {
-  post_uri: "at://did:plc:abc123/app.bsky.feed.post/xyz789",
-  epoch_id: 47,
-  epoch_description: "Community round 47",
-  total_score: 0.57,
-  rank: 3,
-  components: {
-    recency:          { raw_score: 0.82, weight: 0.35, weighted: 0.287 },
-    engagement:       { raw_score: 0.61, weight: 0.25, weighted: 0.153 },
-    bridging:         { raw_score: 0.44, weight: 0.20, weighted: 0.088 },
-    source_diversity: { raw_score: 0.29, weight: 0.15, weighted: 0.044 },
-    relevance:        { raw_score: 0.40, weight: 0.05, weighted: 0.020,
-      topicBreakdown: {
-        "machine-learning": { postScore: 0.80, communityWeight: 0.62, contribution: 0.012 },
-        "open-source":      { postScore: 0.65, communityWeight: 0.45, contribution: 0.007 },
-      },
-    },
-  },
-  governance_weights: {
-    recency: 0.35,
-    engagement: 0.25,
-    bridging: 0.20,
-    source_diversity: 0.15,
-    relevance: 0.05,
-  },
-  counterfactual: {
-    pure_engagement_rank: 9,
-    community_governed_rank: 3,
-    difference: 6,
-  },
-  scored_at: "2026-06-26T12:00:00Z",
-  component_details: null,
-}
+import { transparencyApi } from "@/lib/api/client"
 
 /* ─── Signal metadata ──────────────────────────────────── */
 
@@ -301,14 +268,41 @@ function PostExplanationSkeleton() {
 /* ─── Page ─────────────────────────────────────────────── */
 
 function PostExplanationInner() {
+  const router = useRouter()
   const searchParams = useSearchParams()
   const uri = searchParams.get("uri") ?? ""
-  const [pageState, setPageState] = useState<PageState>(
-    uri ? "loaded" : "missing-uri"
-  )
   const [copied, setCopied] = useState(false)
 
-  const explanation = MOCK_EXPLANATION
+  // Real explanation fetch. Disabled until a URI is present. A 404 from the
+  // backend means the post has no score in the active round (or there is no
+  // active round) — a legitimate "couldn't explain" state, distinct from a
+  // transport/server failure which surfaces as the retryable error card.
+  const postQuery = useQuery({
+    queryKey: ["post-explain", uri],
+    queryFn: () => transparencyApi.getPostExplanation(uri),
+    enabled: uri !== "",
+    retry: false,
+  })
+
+  const explanation = postQuery.data
+
+  const derivedState: PageState = !uri
+    ? "missing-uri"
+    : postQuery.isLoading
+      ? "loading"
+      : postQuery.isError
+        ? axios.isAxiosError(postQuery.error) && postQuery.error.response?.status === 404
+          ? "null-explanation"
+          : "error"
+        : explanation
+          ? "loaded"
+          : "loading"
+
+  // Dev-only override lets the state switcher below preview each chrome; in
+  // production the switcher is not rendered, so the override is always null.
+  const [devOverride, setDevOverride] = useState<PageState | null>(null)
+  const pageState = devOverride ?? derivedState
+
   const decodedUri = uri ? formatUri(uri) : null
   const bskyUrl = decodedUri ? blueskyUrl(uri) : null
 
@@ -320,35 +314,36 @@ function PostExplanationInner() {
     }).catch(() => {})
   }
 
-  /* Build component array for ScoreBreakdown */
-  const scoreComponents: ScoreComponent[] = Object.entries(explanation.components).map(
-    ([key, c]) => ({
-      key,
-      label: SIGNAL_META[key]?.label ?? key,
-      raw_score: c.raw_score,
-      weight: c.weight,
-      weighted: c.weighted,
-    })
-  )
+  /* Build component array for ScoreBreakdown (only when loaded) */
+  const scoreComponents: ScoreComponent[] = explanation
+    ? Object.entries(explanation.components).map(([key, c]) => ({
+        key,
+        label: SIGNAL_META[key]?.label ?? key,
+        raw_score: c.raw_score,
+        weight: c.weight,
+        weighted: c.weighted,
+      }))
+    : []
 
   /* Build radar signals */
-  const radarSignals: RadarSignal[] = Object.entries(explanation.components).map(
-    ([key, c]) => ({
-      key,
-      label: SIGNAL_META[key]?.label ?? key,
-      post: c.raw_score,
-      governance: explanation.governance_weights[key as keyof typeof explanation.governance_weights] ?? 0,
-    })
-  )
+  const radarSignals: RadarSignal[] = explanation
+    ? Object.entries(explanation.components).map(([key, c]) => ({
+        key,
+        label: SIGNAL_META[key]?.label ?? key,
+        post: c.raw_score,
+        governance:
+          explanation.governance_weights[key as keyof typeof explanation.governance_weights] ?? 0,
+      }))
+    : []
 
   /* Collect topic breakdown rows from relevance component */
-  const topicBreakdown = explanation.components.relevance?.topicBreakdown ?? {}
+  const topicBreakdown = explanation?.components.relevance?.topicBreakdown ?? {}
   const hasTopics = Object.keys(topicBreakdown).length > 0
 
-  const cf = explanation.counterfactual
+  const cf = explanation?.counterfactual
 
   return (
-    <AppShell user={null}>
+    <AppShell>
       <div className="max-w-4xl mx-auto px-5 py-8 flex flex-col gap-6">
 
         {/* ── Back nav + URI header ──────────────────────── */}
@@ -413,7 +408,7 @@ function PostExplanationInner() {
             <EmptyState
               heading="No post URI provided"
               body="Paste an AT-URI or Bluesky post URL into the Explain a ranking field on the overview page."
-              action={{ label: "Back to overview", onClick: () => {} }}
+              action={{ label: "Back to overview", onClick: () => router.push("/dashboard") }}
             />
           </div>
         )}
@@ -426,7 +421,7 @@ function PostExplanationInner() {
           <ErrorCard
             heading="Could not load explanation"
             body="We were unable to retrieve the score breakdown for this post. It may not have been scored in the current round."
-            onRetry={() => setPageState("loaded")}
+            onRetry={() => { setDevOverride(null); void postQuery.refetch() }}
           />
         )}
 
@@ -437,13 +432,13 @@ function PostExplanationInner() {
               heading="This post could not be explained"
               body="The scoring model ran but did not produce a breakdown for this post. This can happen when a post was filtered before scoring or was scored in a different round."
               showCorgi
-              action={{ label: "Back to overview", onClick: () => {} }}
+              action={{ label: "Back to overview", onClick: () => router.push("/dashboard") }}
             />
           </div>
         )}
 
         {/* ── State: loaded ──────────────────────────────── */}
-        {pageState === "loaded" && (
+        {pageState === "loaded" && explanation && cf && (
           <>
             {/* Hero: rank + total score + round */}
             <div className="rounded-xl border border-border bg-card p-6 flex items-center gap-6">
@@ -479,7 +474,7 @@ function PostExplanationInner() {
                 <ScoreBreakdown
                   components={scoreComponents}
                   total_score={explanation.total_score}
-                  epochLabel={explanation.epoch_description}
+                  epochLabel={explanation.epoch_description ?? undefined}
                 />
                 {/* Inline contribution cue per brief opportunity */}
                 <p className="text-[11px] text-foreground/40 italic mt-4 leading-relaxed">
@@ -597,7 +592,7 @@ function PostExplanationInner() {
                 {(["loaded", "loading", "error", "missing-uri", "null-explanation"] as PageState[]).map((s) => (
                   <button
                     key={s}
-                    onClick={() => setPageState(s)}
+                    onClick={() => setDevOverride(s)}
                     className={`text-[10px] px-2 py-0.5 rounded border font-mono transition-colors
                       ${pageState === s
                         ? "bg-primary text-primary-foreground border-primary"

--- a/web-next/app/research-consent/page.tsx
+++ b/web-next/app/research-consent/page.tsx
@@ -109,7 +109,7 @@ export default function ResearchConsentPage() {
 
   const agreed = justSubmitted ? submitMutation.variables === true : stored?.consent === true
   const recordedAt = justSubmitted
-    ? submittedAt
+    ? (stored?.consentedAt ? new Date(stored.consentedAt) : submittedAt)
     : stored?.consentedAt
       ? new Date(stored.consentedAt)
       : null

--- a/web-next/app/research-consent/page.tsx
+++ b/web-next/app/research-consent/page.tsx
@@ -3,17 +3,13 @@
 import { useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Button } from "@/components/ui/button"
 import { AppShell } from "@/components/app-shell"
-
-/* Mock seam — exact field names from the brief */
-const MOCK_CONSENT = {
-  consent: null as null | boolean,
-  consentedAt: null as null | string,
-  consentVersion: null as null | string,
-}
-
-type ConsentState = "idle" | "saving-agree" | "saving-decline" | "success-agree" | "success-decline" | "error"
+import { SignInDialog } from "@/components/sign-in-dialog"
+import { useAuth } from "@/components/auth-provider"
+import { ErrorCard, Skeleton } from "@/components/ui/state-kit"
+import { consentApi } from "@/lib/api/client"
 
 /* ── Sub-components ──────────────────────────────────────────── */
 
@@ -56,106 +52,196 @@ function Spinner() {
   )
 }
 
+function StepDot({ label, done, active }: { label: string; done?: boolean; active?: boolean }) {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <div
+        className={`w-2 h-2 rounded-full transition-colors
+          ${done ? "bg-success" : active ? "bg-primary" : "bg-border"}`}
+        aria-hidden="true"
+      />
+      <span className={`text-[10px] font-mono ${active ? "text-foreground/70" : "text-foreground/35"}`}>
+        {label}
+      </span>
+    </div>
+  )
+}
+
 /* ── Page ─────────────────────────────────────────────────────── */
 
 export default function ResearchConsentPage() {
-  const [state, setState] = useState<ConsentState>("idle")
+  const { isAuthenticated } = useAuth()
+  const queryClient = useQueryClient()
+  const [signInOpen, setSignInOpen] = useState(false)
 
-  const isSaving = state === "saving-agree" || state === "saving-decline"
-  const isDone   = state === "success-agree" || state === "success-decline"
+  // Timestamp captured AT submission success — never read from `new Date()` at
+  // render time (prior CR finding: a render-time clock drifts on re-render and
+  // misrepresents when consent was actually recorded).
+  const [submittedAt, setSubmittedAt] = useState<Date | null>(null)
 
-  function handleAgree() {
-    setState("saving-agree")
-    setTimeout(() => setState("success-agree"), 1400)
-  }
+  // Current stored consent. Only fetched once authenticated; a 401 would be an
+  // expected "not signed in" answer, but `enabled` keeps us from asking at all.
+  const consentQuery = useQuery({
+    queryKey: ["research-consent"],
+    queryFn: consentApi.getStatus,
+    enabled: isAuthenticated,
+    retry: false,
+  })
 
-  function handleDecline() {
-    setState("saving-decline")
-    setTimeout(() => setState("success-decline"), 1400)
-  }
+  // POST the decision, then invalidate the status query so a revisit reflects
+  // the stored answer. No setTimeout anywhere → nothing to clean up on unmount.
+  const submitMutation = useMutation({
+    mutationFn: (consent: boolean) => consentApi.submit(consent),
+    onSuccess: () => {
+      setSubmittedAt(new Date())
+      void queryClient.invalidateQueries({ queryKey: ["research-consent"] })
+    },
+  })
 
-  /* ── Success confirmation ─────────────────────────────────── */
-  if (isDone) {
-    const agreed = state === "success-agree"
-    return (
-      <AppShell user={{ handle: "maya.bsky.social", did: "did:plc:abc123" }}>
-        <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
-          <div className="w-full max-w-[440px] flex flex-col items-center text-center gap-6">
-            {/* Icon */}
-            <div className={`w-14 h-14 rounded-full flex items-center justify-center
-              ${agreed ? "bg-success/10 border border-success/25" : "bg-biscuit border border-border"}`}>
-              {agreed ? (
-                <svg width="22" height="22" viewBox="0 0 22 22" fill="none" aria-hidden="true">
-                  <path d="M4 11l5 5 9-9" stroke="hsl(var(--status-success))" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              ) : (
-                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-                  <path d="M9 3v6M9 12v1.5" stroke="hsl(var(--text-body, var(--foreground)))" strokeWidth="1.75" strokeLinecap="round" />
-                </svg>
-              )}
-            </div>
+  const isSaving = submitMutation.isPending
+  const savingAgree = isSaving && submitMutation.variables === true
+  const savingDecline = isSaving && submitMutation.variables === false
 
-            {/* Copy */}
-            <div className="flex flex-col gap-2">
-              <h1 className="font-display text-xl font-bold text-foreground tracking-normal">
-                {agreed ? "Thanks for participating" : "No problem at all"}
-              </h1>
-              <p className="text-sm text-foreground/60 leading-relaxed">
-                {agreed
-                  ? "Your consent has been recorded. This doesn't change how you vote or how the feed works — it just lets us include your activity in aggregate research."
-                  : "Your preference has been saved. Participation is entirely optional and has no effect on your voting rights or feed experience."}
-              </p>
-            </div>
+  const stored = consentQuery.data
+  const hasStoredDecision = stored != null && stored.consent !== null
+  const justSubmitted = submitMutation.isSuccess
+  const isDone = justSubmitted || hasStoredDecision
 
-            {/* Consent receipt (brief opportunity — show what was recorded) */}
-            {agreed && (
-              <div className="w-full rounded-xl border border-border bg-card px-5 py-4 flex flex-col gap-2 text-left">
-                <p className="text-[10px] font-mono uppercase tracking-widest text-foreground/40">Consent receipt</p>
-                <div className="flex flex-col gap-1.5">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-foreground/50">Decision</span>
-                    <span className="text-xs font-mono text-success font-semibold">Agreed</span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-foreground/50">Version</span>
-                    <span className="text-xs font-mono text-foreground/70">v1.0</span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-foreground/50">Recorded at</span>
-                    <span className="text-xs font-mono text-foreground/70">
-                      {new Date().toLocaleString([], { dateStyle: "medium", timeStyle: "short" })}
-                    </span>
-                  </div>
+  const agreed = justSubmitted ? submitMutation.variables === true : stored?.consent === true
+  const recordedAt = justSubmitted
+    ? submittedAt
+    : stored?.consentedAt
+      ? new Date(stored.consentedAt)
+      : null
+  const consentVersion = stored?.consentVersion ?? null
+
+  /* ── Content selection ────────────────────────────────────── */
+  let content: React.ReactNode
+
+  if (!isAuthenticated) {
+    /* Unauthenticated → sign-in prompt (SignInDialog pattern from vote page) */
+    content = (
+      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
+        <div className="w-full max-w-[440px] flex flex-col items-center text-center gap-6">
+          <Image src="/images/corgi-icon.svg" alt="Corgi" width={51} height={36} className="w-[51px] h-9" />
+          <div className="flex flex-col gap-2">
+            <h1 className="font-display text-xl font-bold text-foreground tracking-normal">
+              Sign in to manage research participation
+            </h1>
+            <p className="text-sm text-foreground/60 leading-relaxed">
+              Your research consent is tied to your Bluesky account. Connect your account to view or change your decision.
+            </p>
+          </div>
+          <Button
+            onClick={() => setSignInOpen(true)}
+            className="bg-primary text-primary-foreground hover:bg-primary-dark rounded-full px-8 text-sm shadow-[0_2px_8px_rgba(200,97,44,0.3)] hover:shadow-[0_4px_14px_rgba(200,97,44,0.4)] transition-all"
+          >
+            Connect Bluesky
+          </Button>
+        </div>
+      </div>
+    )
+  } else if (consentQuery.isLoading) {
+    /* Authenticated, loading the stored decision */
+    content = (
+      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
+        <div className="w-full max-w-[480px] rounded-2xl border border-border bg-card p-8 flex flex-col gap-5" aria-busy="true">
+          <Skeleton className="h-9 w-9 rounded-full self-center" />
+          <Skeleton className="h-6 w-48 self-center" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-11 w-full rounded-full mt-2" />
+          <Skeleton className="h-11 w-full rounded-full" />
+        </div>
+      </div>
+    )
+  } else if (consentQuery.isError) {
+    content = (
+      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
+        <div className="w-full max-w-[480px]">
+          <ErrorCard
+            heading="Couldn't load your consent status"
+            body="We couldn't retrieve your current research participation preference. Try again in a moment."
+            onRetry={() => void consentQuery.refetch()}
+          />
+        </div>
+      </div>
+    )
+  } else if (isDone) {
+    /* ── Success / current-decision confirmation ─────────────── */
+    content = (
+      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
+        <div className="w-full max-w-[440px] flex flex-col items-center text-center gap-6">
+          {/* Icon */}
+          <div className={`w-14 h-14 rounded-full flex items-center justify-center
+            ${agreed ? "bg-success/10 border border-success/25" : "bg-biscuit border border-border"}`}>
+            {agreed ? (
+              <svg width="22" height="22" viewBox="0 0 22 22" fill="none" aria-hidden="true">
+                <path d="M4 11l5 5 9-9" stroke="hsl(var(--status-success))" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            ) : (
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+                <path d="M9 3v6M9 12v1.5" stroke="hsl(var(--text-body, var(--foreground)))" strokeWidth="1.75" strokeLinecap="round" />
+              </svg>
+            )}
+          </div>
+
+          {/* Copy */}
+          <div className="flex flex-col gap-2">
+            <h1 className="font-display text-xl font-bold text-foreground tracking-normal">
+              {agreed ? "Thanks for participating" : "No problem at all"}
+            </h1>
+            <p className="text-sm text-foreground/60 leading-relaxed">
+              {agreed
+                ? "Your consent has been recorded. This doesn't change how you vote or how the feed works — it just lets us include your activity in aggregate research."
+                : "Your preference has been saved. Participation is entirely optional and has no effect on your voting rights or feed experience."}
+            </p>
+          </div>
+
+          {/* Consent receipt — reflects what the backend recorded */}
+          {agreed && (
+            <div className="w-full rounded-xl border border-border bg-card px-5 py-4 flex flex-col gap-2 text-left">
+              <p className="text-[10px] font-mono uppercase tracking-widest text-foreground/40">Consent receipt</p>
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-foreground/50">Decision</span>
+                  <span className="text-xs font-mono text-success font-semibold">Agreed</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-foreground/50">Version</span>
+                  <span className="text-xs font-mono text-foreground/70">{consentVersion ?? "—"}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-foreground/50">Recorded at</span>
+                  <span className="text-xs font-mono text-foreground/70">
+                    {recordedAt ? recordedAt.toLocaleString([], { dateStyle: "medium", timeStyle: "short" }) : "—"}
+                  </span>
                 </div>
               </div>
-            )}
+            </div>
+          )}
 
-            {/* Withdrawal note */}
-            <p className="text-xs text-foreground/45 leading-relaxed max-w-xs">
-              You can change this at any time by contacting{" "}
-              <a href="mailto:hello@corgi.network" className="text-primary hover:underline underline-offset-2">
-                hello@corgi.network
-              </a>.
-            </p>
+          {/* Withdrawal note */}
+          <p className="text-xs text-foreground/45 leading-relaxed max-w-xs">
+            You can change this at any time by contacting{" "}
+            <a href="mailto:hello@corgi.network" className="text-primary hover:underline underline-offset-2">
+              hello@corgi.network
+            </a>.
+          </p>
 
-            {/* CTA */}
-            <Button
-              asChild
-              className="bg-primary text-primary-foreground hover:bg-primary-dark rounded-full px-8 text-sm shadow-[0_2px_8px_rgba(200,97,44,0.3)] hover:shadow-[0_4px_14px_rgba(200,97,44,0.4)] transition-all"
-            >
-              <Link href="/vote">
-                {agreed ? "Go to ballot →" : "Go to ballot →"}
-              </Link>
-            </Button>
-          </div>
+          {/* CTA */}
+          <Button
+            asChild
+            className="bg-primary text-primary-foreground hover:bg-primary-dark rounded-full px-8 text-sm shadow-[0_2px_8px_rgba(200,97,44,0.3)] hover:shadow-[0_4px_14px_rgba(200,97,44,0.4)] transition-all"
+          >
+            <Link href="/vote">Go to ballot →</Link>
+          </Button>
         </div>
-      </AppShell>
+      </div>
     )
-  }
-
-  /* ── Main consent card ────────────────────────────────────── */
-  return (
-    <AppShell user={{ handle: "maya.bsky.social", did: "did:plc:abc123" }}>
+  } else {
+    /* ── Main consent card ────────────────────────────────────── */
+    content = (
       <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-5 py-16">
         <div className="w-full max-w-[480px] flex flex-col gap-0">
 
@@ -164,13 +250,7 @@ export default function ResearchConsentPage() {
 
             {/* Card header */}
             <div className="flex flex-col items-center gap-4 pt-8 pb-6 px-8 text-center border-b border-border/60">
-              <Image
-                src="/images/corgi-icon.svg"
-                alt="Corgi"
-                width={51}
-                height={36}
-                className="w-[51px] h-9"
-              />
+              <Image src="/images/corgi-icon.svg" alt="Corgi" width={51} height={36} className="w-[51px] h-9" />
               <div className="flex flex-col gap-1.5">
                 <h1 className="font-display text-xl font-bold text-foreground tracking-normal">
                   Research participation
@@ -209,7 +289,7 @@ export default function ResearchConsentPage() {
               </DisclosureSection>
 
               {/* Error state */}
-              {state === "error" && (
+              {submitMutation.isError && (
                 <div className="rounded-lg bg-status-error/5 border border-status-error/25 px-4 py-3 text-sm text-status-error">
                   Something went wrong saving your preference. Please try again.
                 </div>
@@ -218,11 +298,11 @@ export default function ResearchConsentPage() {
               {/* Action row — symmetric buttons */}
               <div className="flex flex-col gap-3 pt-1">
                 <Button
-                  onClick={handleAgree}
+                  onClick={() => submitMutation.mutate(true)}
                   disabled={isSaving}
                   className="w-full bg-primary text-primary-foreground hover:bg-primary-dark rounded-full py-2.5 text-sm font-medium shadow-[0_2px_8px_rgba(200,97,44,0.3)] hover:shadow-[0_4px_14px_rgba(200,97,44,0.4)] transition-all disabled:opacity-60"
                 >
-                  {state === "saving-agree" ? (
+                  {savingAgree ? (
                     <span className="flex items-center justify-center gap-2">
                       <Spinner />
                       Saving…
@@ -232,12 +312,12 @@ export default function ResearchConsentPage() {
                   )}
                 </Button>
                 <Button
-                  onClick={handleDecline}
+                  onClick={() => submitMutation.mutate(false)}
                   disabled={isSaving}
                   variant="outline"
                   className="w-full border-border text-foreground/65 hover:text-foreground hover:bg-biscuit/50 rounded-full py-2.5 text-sm font-medium transition-all disabled:opacity-60"
                 >
-                  {state === "saving-decline" ? (
+                  {savingDecline ? (
                     <span className="flex items-center justify-center gap-2">
                       <Spinner />
                       Saving…
@@ -259,7 +339,7 @@ export default function ResearchConsentPage() {
             </div>
           </div>
 
-          {/* Step indicator (brief opportunity: Sign in → Consent → Vote) */}
+          {/* Step indicator: Sign in → Consent → Vote */}
           <div className="flex items-center justify-center gap-2 mt-6" aria-label="Setup progress">
             <StepDot label="Sign in" done />
             <div className="w-8 h-px bg-border" aria-hidden="true" />
@@ -269,21 +349,13 @@ export default function ResearchConsentPage() {
           </div>
         </div>
       </div>
-    </AppShell>
-  )
-}
+    )
+  }
 
-function StepDot({ label, done, active }: { label: string; done?: boolean; active?: boolean }) {
   return (
-    <div className="flex flex-col items-center gap-1.5">
-      <div
-        className={`w-2 h-2 rounded-full transition-colors
-          ${done ? "bg-success" : active ? "bg-primary" : "bg-border"}`}
-        aria-hidden="true"
-      />
-      <span className={`text-[10px] font-mono ${active ? "text-foreground/70" : "text-foreground/35"}`}>
-        {label}
-      </span>
-    </div>
+    <AppShell>
+      {content}
+      <SignInDialog open={signInOpen} onOpenChange={setSignInOpen} />
+    </AppShell>
   )
 }

--- a/web-next/components/app-shell.tsx
+++ b/web-next/components/app-shell.tsx
@@ -76,7 +76,7 @@ export function AppShell({ user = null, children }: AppShellProps) {
   // A non-admin session returns 403 (retry:false keeps it a single probe), so
   // `data` stays undefined and the fallback keeps the Admin link hidden.
   const adminStatusQuery = useQuery({
-    queryKey: ["admin", "status"],
+    queryKey: ["admin", "status", session?.did ?? "anon"],
     staleTime: 5 * 60_000,
     queryFn: adminApi.getStatus,
     enabled: isAuthenticated,

--- a/web-next/components/app-shell.tsx
+++ b/web-next/components/app-shell.tsx
@@ -77,6 +77,7 @@ export function AppShell({ user = null, children }: AppShellProps) {
   // `data` stays undefined and the fallback keeps the Admin link hidden.
   const adminStatusQuery = useQuery({
     queryKey: ["admin", "status"],
+    staleTime: 5 * 60_000,
     queryFn: adminApi.getStatus,
     enabled: isAuthenticated,
     retry: false,

--- a/web-next/components/app-shell.tsx
+++ b/web-next/components/app-shell.tsx
@@ -6,6 +6,8 @@ import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { SignInDialog } from "./sign-in-dialog"
 import { useAuth } from "@/components/auth-provider"
+import { useQuery } from "@tanstack/react-query"
+import { adminApi } from "@/lib/api/admin"
 import { useState, useEffect } from "react"
 import { createPortal } from "react-dom"
 import { cn } from "@/lib/utils"
@@ -67,8 +69,20 @@ export function AppShell({ user = null, children }: AppShellProps) {
 
   // Prefer live auth state over the legacy `user` prop for the signed-in area.
   const authedUser = isAuthenticated && session ? { handle: session.handle, did: session.did } : null
-  // Admin nav stays prop-driven — the session endpoint carries no admin flag.
-  const isAdmin = user?.isAdmin ?? false
+
+  // Admin nav is now driven by the real admin-status endpoint (shared cache key
+  // with the admin page). The session endpoint carries no admin flag, so the
+  // legacy `user.isAdmin` prop is only a fallback until the query resolves.
+  // A non-admin session returns 403 (retry:false keeps it a single probe), so
+  // `data` stays undefined and the fallback keeps the Admin link hidden.
+  const adminStatusQuery = useQuery({
+    queryKey: ["admin", "status"],
+    queryFn: adminApi.getStatus,
+    enabled: isAuthenticated,
+    retry: false,
+    select: (data) => data.isAdmin,
+  })
+  const isAdmin = adminStatusQuery.data ?? (user?.isAdmin ?? false)
 
   // Close mobile menu on route change
   useEffect(() => {


### PR DESCRIPTION
## W2+W3 of PROJ-1497 — completes the page wiring
- **post**: `?uri=` → real explanation; 404 (NoActiveEpoch/NotFound) → null-explanation state; other errors → ErrorCard+retry.
- **history**: epochs (limit 20) + paginated audit; per-epoch weight/keyword diffs derived from adjacent epochs; NaN guards.
- **research-consent**: real GET/POST; timestamp captured at submission (prior CR finding); sign-in prompt when unauthenticated.
- **admin**: gated by `adminApi.getStatus` (sign-in / access-denied / panels); lifecycle+weights+filters+topics+audit+feed-health+announcements wired; ConfirmModal Escape+focus and LIFECYCLE de-dup (prior CR findings); panels adapted to real API field names.
- **app-shell**: Admin nav driven by the admin-status query (closes the #286 deferred finding).

## Verification (live local backend)
Static export green (14/14); tsc empty in changed files; zero MOCK_ refs in the four pages; all admin routes confirmed 401-gated (exist); 401/403/404/empty all render legitimate states.

After this + #291 (deploy both-builds), only the founder cutover steps remain (login smoke, env flip).

Closes PROJ-1535.