### PR TITLE
[PROJ-1486] A5: three-way baseline feed comparison + feed-space quality metrics

### DIFF
--- a/src/harness/baseline-comparison.ts
+++ b/src/harness/baseline-comparison.ts
@@ -118,7 +118,7 @@ import { validateVote, type VoteValidationContext } from './vote-validation.js';
 import { createDefaultGovernanceWeightRecord } from '../config/votable-params.js';
 import { weightsToVotePayload, normalizeWeights } from '../governance/governance.types.js';
 import type { GovernanceWeights } from '../shared/api-types.js';
-import type { FeedEntry, FeedPostInfo } from './feed-metrics.js';
+import { buildCorpusTopicSupport, type FeedEntry, type FeedPostInfo } from './feed-metrics.js';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -347,6 +347,24 @@ async function seedGovernedVotes(
   population: Population,
   epochId: number
 ): Promise<void> {
+  // Config-precondition guard: if reads are long-table-sourced but dual-write
+  // is off, `aggregateVotes` (src/governance/aggregation.ts) reads
+  // `governance_vote_weights` — a table this function never wrote a row into
+  // — and sees 0 eligible weight votes no matter how many votes are seeded
+  // below. Left unchecked, that surfaces downstream as
+  // `runBaselineComparison`'s generic "aggregateVotes returned null ... no
+  // eligible weight votes" error, which points an operator at
+  // participation-rate config instead of the real cause: these two flags
+  // disagreeing. Fail here, before any vote is seeded, naming both flags.
+  if (modules.config.GOVERNANCE_LONGTABLE_READ_ENABLED && !modules.config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED) {
+    throw new Error(
+      'seedGovernedVotes: GOVERNANCE_LONGTABLE_READ_ENABLED is on but GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED is ' +
+        'off — aggregateVotes will read the (empty) governance_vote_weights long table and see 0 eligible weight ' +
+        'votes regardless of how many votes are seeded here. Enable GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED (or ' +
+        'disable GOVERNANCE_LONGTABLE_READ_ENABLED) so seeded votes are visible to the real aggregation path.'
+    );
+  }
+
   if (population.votes.length === 0) {
     throw new Error(
       'seedGovernedVotes: population.votes is empty — the community-governed regime needs at least one ' +
@@ -663,16 +681,11 @@ export async function runBaselineComparison(
     await closeRegimeEpoch(db, epochId);
   }
 
-  const corpusTopicSupport: Record<string, number> = {};
-  for (const post of corpusPostInfo) {
-    const entries = Object.entries(post.topicVector);
-    if (entries.length === 0) continue;
-    entries.sort(([slugA, weightA], [slugB, weightB]) =>
-      weightB !== weightA ? weightB - weightA : slugA < slugB ? -1 : slugA > slugB ? 1 : 0
-    );
-    const topSlug = entries[0][0];
-    corpusTopicSupport[topSlug] = (corpusTopicSupport[topSlug] ?? 0) + 1;
-  }
+  // Dominant-topic tie-break is centralized in feed-metrics.ts's
+  // buildCorpusTopicSupport (via dominantTopic) — reuse it here instead of
+  // reimplementing the same sort/tie-break inline, so there is exactly one
+  // place that decides a post's dominant topic.
+  const corpusTopicSupport: Record<string, number> = buildCorpusTopicSupport(corpusPostInfo);
 
   return {
     population,

--- a/src/harness/baseline-comparison.ts
+++ b/src/harness/baseline-comparison.ts
@@ -1,0 +1,726 @@
+/**
+ * Three-Way Baseline Comparison (A5 / PROJ-1486)
+ *
+ * The question this experiment answers: on ONE fixed synthetic corpus, is the
+ * REAL community-governed feed better than an engagement-maximizing feed, and
+ * at what cost? A2 (personas.ts) gave the governance harness realistic voter
+ * archetypes; A3 (simulation.ts) drove multi-epoch convergence in WEIGHT
+ * space; A4 (strategyproofness.ts) asked whether that voting process is
+ * manipulable. This module is the first place the harness compares the
+ * OUTCOME of governance against a baseline in FEED space — the ranked list of
+ * posts a subscriber actually sees — rather than only in weight space.
+ *
+ * Three regimes, same corpus, same real scoring pipeline:
+ *
+ *   1. **no-governance**  — the engine's own bootstrap default
+ *      (`createDefaultGovernanceWeightRecord()`: 0.2 across all 5
+ *      components).
+ *   2. **engagement-only** — all weight on `engagement`, 0 elsewhere, run
+ *      through the real `normalizeWeights` (governance.types.ts) so it is
+ *      scored with exactly the weight vector the real vote/aggregation path
+ *      would ever produce for an all-engagement report, not a hand-rolled
+ *      shortcut.
+ *   3. **community-governed** — the REAL aggregated outcome: A2 persona
+ *      votes (`generatePopulation`) are seeded into a fresh epoch and run
+ *      through the REAL `aggregateVotes` -> `forceEpochTransition`, exactly
+ *      as `Simulation.runEpochVoteCycle` (simulation.ts) does. This is the
+ *      one regime whose weight vector is never hand-specified.
+ *
+ * For all three, the SAME fixed corpus (subscribers/posts/engagement/topics)
+ * is seeded exactly once, and each regime's weights are scored by the REAL,
+ * unmodified `runScoringPipeline` (src/scoring/pipeline.js) into its own
+ * epoch's `post_scores` rows — never a harness-side re-implementation of
+ * scoring. Regimes 1/2 set their epoch's weight columns directly (no vote
+ * aggregation involved — there is no "vote" for a fixed baseline weight
+ * vector); regime 3 is the only one that ever calls `aggregateVotes`.
+ *
+ * Each regime gets its OWN epoch (never reusing/mutating one epoch across
+ * regimes) so `post_scores.epoch_id` cleanly separates the three rankings,
+ * and `readRankedFeed` below reads back exactly that: `post_scores` rows for
+ * one `epoch_id`, ordered by `total_score DESC` then `post_uri ASC` for a
+ * total order (same tie-break `Simulation.fetchTopScoredPosts` uses). This
+ * mirrors the harness's established "drive the real engine, read back what it
+ * persisted" convention (simulation.ts, strategyproofness.ts) rather than
+ * reading Redis's `feed:current` — `writeToRedisFromDb` (pipeline.ts)
+ * additionally applies `FEED_MIN_RELEVANCE`/`FEED_DEDUP_ENABLED`/
+ * `FEED_MAX_POSTS`, which are presentation-layer concerns orthogonal to "how
+ * did this weight vector rank the corpus"; reading `post_scores` directly
+ * keeps the three regimes comparable on ranking alone.
+ *
+ * Results (measured against one fixed corpus — 60 subscribers, 200 posts, a
+ * 4-persona-equal-mix electorate, seed 90210 — real `runScoringPipeline`,
+ * top-K = 50; see `tests/harness/baseline-comparison.sim.ts`):
+ *
+ * | regime              | recency | engagement | bridging | sourceDiv | relevance | authorHHI | authorGini |
+ * |---------------------|---------|------------|----------|-----------|-----------|-----------|------------|
+ * | no-governance       | 0.200   | 0.200      | 0.200    | 0.200     | 0.200     | 0.0216    | 0.038      |
+ * | engagement-only     | 0       | 1.000      | 0        | 0         | 0         | 0.0352    | 0.201      |
+ * | community-governed  | 0.313   | 0.120      | 0.314    | 0.117     | 0.136     | 0.0248    | 0.104      |
+ *
+ * Pairwise rank churn (normalized rank displacement / Kendall-tau distance,
+ * over each pair's shared post set):
+ *
+ * | pair                              | displacement | kendall-tau | shared/50 |
+ * |------------------------------------|--------------|-------------|-----------|
+ * | no-governance vs engagement-only   | 0.302        | 0.311       | 10        |
+ * | no-governance vs community-governed| 0.079        | 0.109       | 45        |
+ * | engagement-only vs community-governed | 0.367     | 0.389       | 9         |
+ *
+ * `distortionRatio(communityGoverned, engagementOnly, engagementOnly.scoreByUri)`
+ * = **0.882**: scored by the engagement-only regime's OWN yardstick, the
+ * governed feed's post set still captures about 88% of the engagement
+ * regime's own best-case quality mass.
+ *
+ * Reading (bounded to this corpus/seed): the real aggregated community
+ * outcome puts substantial weight on `bridging`/`recency` and comparatively
+ * little on `engagement` (0.12) — the electorate's mixed persona preferences
+ * pull the outcome well away from the engagement-only corner (rank
+ * displacement 0.367 between those two, the largest of the three pairs, and
+ * only 9 of 50 posts even overlap). That divergence buys a real reduction in
+ * author concentration relative to engagement-only (HHI 0.0248 vs 0.0352,
+ * Gini 0.104 vs 0.201 — governance is NOT the most concentrated of the
+ * three regimes here), at a moderate, partial cost in the engagement
+ * regime's own terms (distortion ratio 0.882, not 1.0 and not near-0).
+ * `minorityTopicExposure` is 0 for every regime at a 0.15 tail threshold on
+ * this corpus specifically because its topic distribution (science 40,
+ * politics 30, music 26, software-development 26, sports 25 — see
+ * `corpusTopicSupport`) has no topic below that threshold; this is an honest
+ * reading of a corpus without a genuine tail topic, not evidence the metric
+ * is broken (see feed-metrics.test.ts for cases where it is non-zero).
+ *
+ * Bounded claim only: every number above (and everything `feed-metrics.ts`
+ * computes from this module's output) is measured against THIS fixed
+ * synthetic corpus, THIS seed, and THESE three regimes. It is not a claim
+ * about governance vs. engagement optimization in general, about a
+ * different corpus/population, or about real Bluesky content.
+ */
+
+import type { QueryableDb } from './simulation.js';
+import type { Rng, Clock } from './rng.js';
+import { generatePopulation, TOPIC_SLUGS, type Population, type PostSeed } from './population.js';
+import type { PopulationConfig } from './scenario.js';
+import { validateVote, type VoteValidationContext } from './vote-validation.js';
+import { createDefaultGovernanceWeightRecord } from '../config/votable-params.js';
+import { weightsToVotePayload, normalizeWeights } from '../governance/governance.types.js';
+import type { GovernanceWeights } from '../shared/api-types.js';
+import type { FeedEntry, FeedPostInfo } from './feed-metrics.js';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export type RegimeName = 'no-governance' | 'engagement-only' | 'community-governed';
+
+export const REGIME_NAMES: readonly RegimeName[] = ['no-governance', 'engagement-only', 'community-governed'];
+
+export interface BaselineComparisonDeps {
+  db: QueryableDb;
+  rng: Rng;
+  clock: Clock;
+}
+
+export interface RegimeResult {
+  regime: RegimeName;
+  epochId: number;
+  weights: GovernanceWeights;
+  /** Ranked top-K feed for this regime, read back from `post_scores`. */
+  feed: FeedEntry[];
+  /** `post_uri -> total_score`, for every scored post in this regime's epoch
+   *  (not just the top-K feed) — the full quality surface `distortionRatio`
+   *  (feed-metrics.ts) needs to score another regime's feed by this regime's
+   *  own yardstick. */
+  scoreByUri: Map<string, number>;
+}
+
+export interface BaselineComparisonResult {
+  population: Population;
+  corpusTopicSupport: Record<string, number>;
+  corpusPostInfo: FeedPostInfo[];
+  regimes: Record<RegimeName, RegimeResult>;
+}
+
+/**
+ * Deferred import of the governance/scoring modules this experiment drives —
+ * same rationale as simulation.ts's / strategyproofness.ts's own
+ * `loadGovernanceModules`: these transitively import `src/config.ts` /
+ * `src/db/client.ts` / `src/db/redis.ts`, which have import-time side
+ * effects (env parsing, opening a Redis connection). Deferring means merely
+ * importing this file never triggers those; only calling
+ * `runBaselineComparison` does.
+ */
+async function loadGovernanceModules() {
+  const { aggregateVotes } = await import('../governance/aggregation.js');
+  const { forceEpochTransition } = await import('../governance/epoch-manager.js');
+  const { runScoringPipeline, __resetPipelineState } = await import('../scoring/pipeline.js');
+  const { writeVoteWeights } = await import('../governance/weight-longtable.js');
+  const { config } = await import('../config.js');
+  return {
+    aggregateVotes,
+    forceEpochTransition,
+    runScoringPipeline,
+    __resetPipelineState,
+    writeVoteWeights,
+    config,
+  };
+}
+
+type GovernanceModules = Awaited<ReturnType<typeof loadGovernanceModules>>;
+
+/** Max rows per batched `INSERT ... VALUES (...),(...)` — same bound
+ *  simulation.ts's `insertBatched` uses, kept local here to avoid depending
+ *  on that file's private helpers (see this file's header: A5 follows A4's
+ *  precedent of a self-contained harness module rather than reaching into
+ *  `Simulation`'s private methods). */
+const INSERT_BATCH_SIZE = 500;
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function valuesClause(rowCount: number, colCount: number): string {
+  const rows: string[] = [];
+  for (let r = 0; r < rowCount; r++) {
+    const base = r * colCount;
+    const placeholders = Array.from({ length: colCount }, (_, c) => `$${base + c + 1}`);
+    rows.push(`(${placeholders.join(', ')})`);
+  }
+  return rows.join(', ');
+}
+
+async function insertBatched<T>(
+  db: QueryableDb,
+  items: readonly T[],
+  buildQuery: (batch: T[]) => { text: string; params: unknown[] }
+): Promise<void> {
+  for (const batch of chunk(items, INSERT_BATCH_SIZE)) {
+    if (batch.length === 0) continue;
+    const { text, params } = buildQuery(batch);
+    await db.query(text, params);
+  }
+}
+
+/**
+ * Seed the fixed corpus ONCE: subscribers, posts + engagement, and active
+ * topic slugs. No votes here — mirrors `Simulation.seedCorpus`'s split
+ * (simulation.ts), reimplemented here (not imported — it is a private
+ * method) at the same low level `strategyproofness.ts` already uses for its
+ * own vote inserts.
+ */
+async function seedCorpus(db: QueryableDb, population: Population): Promise<void> {
+  await insertBatched(db, population.subscribers, (batch) => ({
+    text: `INSERT INTO subscribers (did) VALUES ${valuesClause(batch.length, 1)} ON CONFLICT (did) DO NOTHING`,
+    params: batch.map((s) => s.did),
+  }));
+
+  await insertBatched(db, population.posts, (batch) => ({
+    text: `INSERT INTO posts (uri, cid, author_did, text, created_at, has_media, embed_url, topic_vector)
+           VALUES ${valuesClause(batch.length, 8)}
+           ON CONFLICT (uri) DO NOTHING`,
+    params: batch.flatMap((post) => [
+      post.uri,
+      post.cid,
+      post.authorDid,
+      post.text,
+      post.createdAt.toISOString(),
+      post.hasMedia,
+      post.embedUrl,
+      JSON.stringify(post.topicVector),
+    ]),
+  }));
+
+  await insertBatched(db, population.posts, (batch) => ({
+    text: `INSERT INTO post_engagement (post_uri, like_count, repost_count, reply_count)
+           VALUES ${valuesClause(batch.length, 4)}
+           ON CONFLICT (post_uri) DO UPDATE SET
+             like_count = EXCLUDED.like_count,
+             repost_count = EXCLUDED.repost_count,
+             reply_count = EXCLUDED.reply_count`,
+    params: batch.flatMap((post) => [post.uri, post.likeCount, post.repostCount, post.replyCount]),
+  }));
+
+  const slugLabel = (slug: string): string =>
+    slug.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+  await insertBatched(db, TOPIC_SLUGS, (batch) => ({
+    text: `INSERT INTO topic_catalog (slug, name, is_active)
+           VALUES ${valuesClause(batch.length, 3)}
+           ON CONFLICT (slug) DO UPDATE SET is_active = TRUE`,
+    params: batch.flatMap((slug) => [slug, slugLabel(slug), true]),
+  }));
+}
+
+/**
+ * Insert a fresh epoch with the given weight vector directly on its weight
+ * columns (`status = 'active'`, `phase = 'voting'`) — the "fixed-weight
+ * injection" lever the no-governance and engagement-only regimes use INSTEAD
+ * of vote aggregation: there is no vote to aggregate for a hand-specified
+ * baseline vector, so this bypasses `aggregateVotes`/`forceEpochTransition`
+ * entirely and writes the vector straight onto a new epoch row, mirroring
+ * `Simulation.ensureActiveEpoch`'s INSERT shape (simulation.ts) but for an
+ * arbitrary caller-supplied vector instead of only the bootstrap default.
+ *
+ * `phase = 'voting'` is set for consistency with every other epoch this
+ * harness creates (vote-validation.ts only accepts votes into that phase) —
+ * irrelevant here since this regime casts no votes, but keeps every epoch
+ * this module creates uniform.
+ */
+async function insertFixedWeightEpoch(
+  db: QueryableDb,
+  weights: GovernanceWeights,
+  description: string
+): Promise<number> {
+  const payload = weightsToVotePayload(weights);
+  const inserted = await db.query<{ id: number }>(
+    `INSERT INTO governance_epochs (
+      status, phase, recency_weight, engagement_weight, bridging_weight,
+      source_diversity_weight, relevance_weight, vote_count, description
+    ) VALUES ('active', 'voting', $1, $2, $3, $4, $5, 0, $6)
+    RETURNING id`,
+    [
+      payload.recency_weight,
+      payload.engagement_weight,
+      payload.bridging_weight,
+      payload.source_diversity_weight,
+      payload.relevance_weight,
+      description,
+    ]
+  );
+  return inserted.rows[0].id;
+}
+
+/**
+ * Insert a fresh 'voting'-phase epoch, seeded with the bootstrap-equal 0.2
+ * vector on its (NOT NULL) weight columns — a placeholder only, since this
+ * epoch's weights are about to be overwritten by `forceEpochTransition`
+ * aggregating the votes seeded into it — for the community-governed regime
+ * to cast A2 persona votes into.
+ */
+async function insertVotingEpoch(db: QueryableDb, description: string): Promise<number> {
+  const bootstrap = weightsToVotePayload(createDefaultGovernanceWeightRecord() as GovernanceWeights);
+  const inserted = await db.query<{ id: number }>(
+    `INSERT INTO governance_epochs (
+      status, phase, recency_weight, engagement_weight, bridging_weight,
+      source_diversity_weight, relevance_weight, vote_count, description
+    ) VALUES ('active', 'voting', $1, $2, $3, $4, $5, 0, $6)
+    RETURNING id`,
+    [
+      bootstrap.recency_weight,
+      bootstrap.engagement_weight,
+      bootstrap.bridging_weight,
+      bootstrap.source_diversity_weight,
+      bootstrap.relevance_weight,
+      description,
+    ]
+  );
+  return inserted.rows[0].id;
+}
+
+/**
+ * Seed `population.votes` (A2 persona-driven weight votes — see
+ * `generatePopulation`/`personas.ts`) into `epochId`, validating each vote
+ * against the real `POST /api/governance/vote` route rules first
+ * (`vote-validation.ts`) exactly as `Simulation.insertVotes` does, then
+ * dual-writing into the `governance_vote_weights` long table when enabled —
+ * without the dual-write, `aggregateVotes` would see zero eligible votes
+ * whenever `GOVERNANCE_LONGTABLE_READ_ENABLED` is on (the production
+ * default).
+ */
+async function seedGovernedVotes(
+  db: QueryableDb,
+  modules: Pick<GovernanceModules, 'writeVoteWeights' | 'config'>,
+  population: Population,
+  epochId: number
+): Promise<void> {
+  if (population.votes.length === 0) {
+    throw new Error(
+      'seedGovernedVotes: population.votes is empty — the community-governed regime needs at least one ' +
+        'eligible weight vote for aggregateVotes to produce a real outcome. Increase voteParticipationRate / ' +
+        'castsWeightVoteRate in the population config.'
+    );
+  }
+
+  const ctx: VoteValidationContext = {
+    subscriberDids: new Set(population.subscribers.map((s) => s.did)),
+    activeTopicSlugs: new Set(TOPIC_SLUGS),
+    epochPhase: 'voting',
+  };
+  const failures: string[] = [];
+  for (const vote of population.votes) {
+    const weightFields = vote.weights ? weightsToVotePayload(vote.weights) : {};
+    const result = validateVote(
+      {
+        voterDid: vote.voterDid,
+        ...weightFields,
+        include_keywords: vote.includeKeywords,
+        exclude_keywords: vote.excludeKeywords,
+        topic_weights: vote.topicWeights,
+      },
+      ctx
+    );
+    if (!result.valid) {
+      failures.push(`${vote.voterDid}: ${result.errors.join('; ')}`);
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `seedGovernedVotes: ${failures.length} generated vote(s) would be rejected by the real vote route:\n` +
+        failures.slice(0, 10).join('\n')
+    );
+  }
+
+  const rows = population.votes.map((vote) => ({
+    voter_did: vote.voterDid,
+    recency_weight: vote.weights?.recency ?? null,
+    engagement_weight: vote.weights?.engagement ?? null,
+    bridging_weight: vote.weights?.bridging ?? null,
+    source_diversity_weight: vote.weights?.sourceDiversity ?? null,
+    relevance_weight: vote.weights?.relevance ?? null,
+    include_keywords: vote.includeKeywords.length > 0 ? vote.includeKeywords : null,
+    exclude_keywords: vote.excludeKeywords.length > 0 ? vote.excludeKeywords : null,
+    topic_weight_votes: Object.keys(vote.topicWeights).length > 0 ? vote.topicWeights : null,
+  }));
+
+  const voteIdByVoterDid = new Map<string, string>();
+  for (const batch of chunk(rows, INSERT_BATCH_SIZE)) {
+    const inserted = await db.query<{ id: string; voter_did: string }>(
+      `INSERT INTO governance_votes (
+        voter_did, epoch_id,
+        recency_weight, engagement_weight, bridging_weight,
+        source_diversity_weight, relevance_weight,
+        include_keywords, exclude_keywords, topic_weight_votes
+      )
+      SELECT
+        x.voter_did, $2::int,
+        x.recency_weight, x.engagement_weight, x.bridging_weight,
+        x.source_diversity_weight, x.relevance_weight,
+        x.include_keywords, x.exclude_keywords, x.topic_weight_votes
+      FROM jsonb_to_recordset($1::jsonb) AS x(
+        voter_did text,
+        recency_weight float8,
+        engagement_weight float8,
+        bridging_weight float8,
+        source_diversity_weight float8,
+        relevance_weight float8,
+        include_keywords text[],
+        exclude_keywords text[],
+        topic_weight_votes jsonb
+      )
+      ON CONFLICT (voter_did, epoch_id) DO NOTHING
+      RETURNING id, voter_did`,
+      [JSON.stringify(batch), epochId]
+    );
+    for (const row of inserted.rows) {
+      voteIdByVoterDid.set(row.voter_did, row.id);
+    }
+  }
+
+  if (voteIdByVoterDid.size !== rows.length) {
+    throw new Error(
+      `seedGovernedVotes: ${rows.length - voteIdByVoterDid.size} of ${rows.length} generated vote(s) were ` +
+        `not inserted into governance_votes for epoch ${epochId} (ON CONFLICT skipped them) — unexpected for ` +
+        'a freshly-created epoch with unique voter DIDs.'
+    );
+  }
+
+  if (!modules.config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED) {
+    return;
+  }
+  for (const vote of population.votes) {
+    if (!vote.weights) continue;
+    const voteId = voteIdByVoterDid.get(vote.voterDid);
+    if (voteId) {
+      await modules.writeVoteWeights(voteId, vote.weights);
+    }
+  }
+}
+
+/** Read back the epoch's persisted weight vector — mirrors
+ *  `Simulation.fetchEpochWeightsAndTopics`'s read-back convention (never
+ *  recompute, always read what the real engine wrote). */
+async function fetchEpochWeights(db: QueryableDb, epochId: number): Promise<GovernanceWeights> {
+  const result = await db.query<{
+    recency_weight: number;
+    engagement_weight: number;
+    bridging_weight: number;
+    source_diversity_weight: number;
+    relevance_weight: number;
+  }>(
+    `SELECT recency_weight, engagement_weight, bridging_weight, source_diversity_weight, relevance_weight
+     FROM governance_epochs WHERE id = $1`,
+    [epochId]
+  );
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error(`fetchEpochWeights: epoch ${epochId} not found`);
+  }
+  return {
+    recency: Number(row.recency_weight),
+    engagement: Number(row.engagement_weight),
+    bridging: Number(row.bridging_weight),
+    sourceDiversity: Number(row.source_diversity_weight),
+    relevance: Number(row.relevance_weight),
+  };
+}
+
+/**
+ * Read back one regime's ranked feed from `post_scores` — same table/order
+ * `Simulation.fetchTopScoredPosts` reads (simulation.ts), see this file's
+ * header for why `post_scores` (not Redis `feed:current`) is the read-back
+ * source of truth here. Also returns every scored post's `total_score`
+ * (`scoreByUri`, unbounded by `limit`) — `feed-metrics.ts`'s
+ * `distortionRatio` needs a regime's FULL scoring surface, not just its own
+ * top-K, to score another regime's feed by this regime's yardstick.
+ */
+async function readRegimeResults(
+  db: QueryableDb,
+  epochId: number,
+  limit: number
+): Promise<{ feed: FeedEntry[]; scoreByUri: Map<string, number> }> {
+  const result = await db.query<{ post_uri: string; total_score: number | string }>(
+    `SELECT post_uri, total_score FROM post_scores WHERE epoch_id = $1 ORDER BY total_score DESC, post_uri ASC`,
+    [epochId]
+  );
+
+  const scoreByUri = new Map<string, number>();
+  for (const row of result.rows) {
+    scoreByUri.set(row.post_uri, Number(row.total_score));
+  }
+
+  const feed = result.rows.slice(0, limit).map((row, index) => ({
+    uri: row.post_uri,
+    rank: index + 1,
+  }));
+
+  return { feed, scoreByUri };
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`runBaselineComparison: "${label}" did not complete within ${timeoutMs}ms`)),
+      timeoutMs
+    );
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const DEFAULT_STEP_TIMEOUT_MS = 30_000;
+const DEFAULT_FEED_TOP_K = 50;
+
+export interface RunBaselineComparisonOptions {
+  populationConfig: PopulationConfig;
+  /** How many top-ranked posts to read back per regime (feed-space K). */
+  topK?: number;
+  pipelineStepTimeoutMs?: number;
+}
+
+/**
+ * Seed one fixed corpus, then score it under all three regimes (see file
+ * header), returning each regime's epoch id, weight vector, ranked top-K
+ * feed, and full scoring surface, plus the corpus's own post/topic-support
+ * data that `feed-metrics.ts`'s minority-topic/author metrics join against.
+ */
+export async function runBaselineComparison(
+  deps: BaselineComparisonDeps,
+  options: RunBaselineComparisonOptions
+): Promise<BaselineComparisonResult> {
+  const { db, rng, clock } = deps;
+  const topK = options.topK ?? DEFAULT_FEED_TOP_K;
+  const timeoutMs = options.pipelineStepTimeoutMs ?? DEFAULT_STEP_TIMEOUT_MS;
+
+  const modules = await loadGovernanceModules();
+  modules.__resetPipelineState();
+
+  const population = generatePopulation(rng, clock, options.populationConfig);
+  await seedCorpus(db, population);
+
+  const corpusPostInfo: FeedPostInfo[] = population.posts.map((post: PostSeed) => ({
+    uri: post.uri,
+    authorDid: post.authorDid,
+    topicVector: post.topicVector,
+  }));
+
+  const regimes: Partial<Record<RegimeName, RegimeResult>> = {};
+
+  // Regime 1: no-governance — the engine's own bootstrap default.
+  {
+    const weights = createDefaultGovernanceWeightRecord() as GovernanceWeights;
+    const epochId = await insertFixedWeightEpoch(db, weights, 'A5 baseline: no-governance (bootstrap default)');
+    await withTimeout(modules.runScoringPipeline(), timeoutMs, 'runScoringPipeline[no-governance]');
+    const persistedWeights = await fetchEpochWeights(db, epochId);
+    const { feed, scoreByUri } = await readRegimeResults(db, epochId, topK);
+    regimes['no-governance'] = { regime: 'no-governance', epochId, weights: persistedWeights, feed, scoreByUri };
+  }
+
+  // Regime 2: engagement-only — all weight on engagement, run through the
+  // real normalizeWeights so it reflects exactly what the real vote path
+  // would ever persist for this report.
+  {
+    const rawWeights: GovernanceWeights = {
+      recency: 0,
+      engagement: 1,
+      bridging: 0,
+      sourceDiversity: 0,
+      relevance: 0,
+    };
+    const weights = normalizeWeights(rawWeights);
+    const epochId = await insertFixedWeightEpoch(db, weights, 'A5 baseline: engagement-only');
+    await withTimeout(modules.runScoringPipeline(), timeoutMs, 'runScoringPipeline[engagement-only]');
+    const persistedWeights = await fetchEpochWeights(db, epochId);
+    const { feed, scoreByUri } = await readRegimeResults(db, epochId, topK);
+    regimes['engagement-only'] = { regime: 'engagement-only', epochId, weights: persistedWeights, feed, scoreByUri };
+  }
+
+  // Regime 3: community-governed — the REAL aggregated outcome from A2
+  // persona votes, via the REAL aggregateVotes -> forceEpochTransition path.
+  {
+    const votingEpochId = await insertVotingEpoch(db, 'A5 baseline: community-governed (pre-aggregation)');
+    await seedGovernedVotes(db, modules, population, votingEpochId);
+
+    const aggregated = await withTimeout(
+      modules.aggregateVotes(votingEpochId),
+      timeoutMs,
+      'aggregateVotes[community-governed]'
+    );
+    if (!aggregated) {
+      throw new Error(
+        'runBaselineComparison: aggregateVotes returned null for the community-governed regime — no eligible ' +
+          'weight votes were seeded. Increase population.subscriberCount / voteParticipationRate / castsWeightVoteRate.'
+      );
+    }
+
+    const epochId = await withTimeout(
+      modules.forceEpochTransition(),
+      timeoutMs,
+      'forceEpochTransition[community-governed]'
+    );
+    await withTimeout(modules.runScoringPipeline(), timeoutMs, 'runScoringPipeline[community-governed]');
+    const persistedWeights = await fetchEpochWeights(db, epochId);
+    const { feed, scoreByUri } = await readRegimeResults(db, epochId, topK);
+    regimes['community-governed'] = {
+      regime: 'community-governed',
+      epochId,
+      weights: persistedWeights,
+      feed,
+      scoreByUri,
+    };
+  }
+
+  const corpusTopicSupport: Record<string, number> = {};
+  for (const post of corpusPostInfo) {
+    const entries = Object.entries(post.topicVector);
+    if (entries.length === 0) continue;
+    entries.sort(([slugA, weightA], [slugB, weightB]) =>
+      weightB !== weightA ? weightB - weightA : slugA < slugB ? -1 : slugA > slugB ? 1 : 0
+    );
+    const topSlug = entries[0][0];
+    corpusTopicSupport[topSlug] = (corpusTopicSupport[topSlug] ?? 0) + 1;
+  }
+
+  return {
+    population,
+    corpusTopicSupport,
+    corpusPostInfo,
+    regimes: regimes as Record<RegimeName, RegimeResult>,
+  };
+}
+
+// ============================================================================
+// CSV artifact writer — mirrors metrics.ts's `writeArtifacts` /
+// strategyproofness.ts's `writeStrategyproofnessArtifacts` convention: a
+// `<baseDir>/baseline-comparison/` subdirectory, one `mkdir(recursive)` +
+// one `writeFile`, plain CSV.
+// ============================================================================
+
+export interface BaselineComparisonCsvRow {
+  regimeA: RegimeName;
+  regimeB: RegimeName;
+  rankDisplacement: number;
+  kendallTau: number;
+  sharedCount: number;
+}
+
+export interface RegimeSummaryCsvRow {
+  regime: RegimeName;
+  epochId: number;
+  weights: GovernanceWeights;
+  authorHHI: number;
+  authorGini: number;
+  minorityTopicExposure: number;
+}
+
+function csvNumber(value: number, digits = 6): string {
+  return value.toFixed(digits);
+}
+
+const PAIRWISE_CSV_HEADER = ['regimeA', 'regimeB', 'rankDisplacement', 'kendallTau', 'sharedCount'] as const;
+const SUMMARY_CSV_HEADER = [
+  'regime',
+  'epochId',
+  'recency',
+  'engagement',
+  'bridging',
+  'sourceDiversity',
+  'relevance',
+  'authorHHI',
+  'authorGini',
+  'minorityTopicExposure',
+] as const;
+
+function toPairwiseCsv(rows: readonly BaselineComparisonCsvRow[]): string {
+  const lines = rows.map((row) =>
+    [row.regimeA, row.regimeB, csvNumber(row.rankDisplacement), csvNumber(row.kendallTau), row.sharedCount].join(',')
+  );
+  return `${PAIRWISE_CSV_HEADER.join(',')}\n${lines.join('\n')}\n`;
+}
+
+function toSummaryCsv(rows: readonly RegimeSummaryCsvRow[]): string {
+  const lines = rows.map((row) =>
+    [
+      row.regime,
+      row.epochId,
+      csvNumber(row.weights.recency),
+      csvNumber(row.weights.engagement),
+      csvNumber(row.weights.bridging),
+      csvNumber(row.weights.sourceDiversity),
+      csvNumber(row.weights.relevance),
+      csvNumber(row.authorHHI),
+      csvNumber(row.authorGini),
+      csvNumber(row.minorityTopicExposure),
+    ].join(',')
+  );
+  return `${SUMMARY_CSV_HEADER.join(',')}\n${lines.join('\n')}\n`;
+}
+
+export interface WrittenBaselineComparisonPaths {
+  summaryCsvPath: string;
+  pairwiseCsvPath: string;
+}
+
+/**
+ * Persist the three-regime comparison to `<baseDir>/baseline-comparison/`:
+ * `regime-summary.csv` (one row per regime: weights + feed-quality metrics)
+ * and `pairwise-churn.csv` (one row per regime pair: rank-churn metrics).
+ */
+export async function writeBaselineComparisonArtifacts(
+  baseDir: string,
+  summaryRows: readonly RegimeSummaryCsvRow[],
+  pairwiseRows: readonly BaselineComparisonCsvRow[]
+): Promise<WrittenBaselineComparisonPaths> {
+  const dir = path.join(baseDir, 'baseline-comparison');
+  await mkdir(dir, { recursive: true });
+
+  const summaryCsvPath = path.join(dir, 'regime-summary.csv');
+  const pairwiseCsvPath = path.join(dir, 'pairwise-churn.csv');
+
+  await writeFile(summaryCsvPath, toSummaryCsv(summaryRows), 'utf8');
+  await writeFile(pairwiseCsvPath, toPairwiseCsv(pairwiseRows), 'utf8');
+
+  return { summaryCsvPath, pairwiseCsvPath };
+}

--- a/src/harness/baseline-comparison.ts
+++ b/src/harness/baseline-comparison.ts
@@ -341,29 +341,38 @@ async function insertVotingEpoch(db: QueryableDb, description: string): Promise<
  * whenever `GOVERNANCE_LONGTABLE_READ_ENABLED` is on (the production
  * default).
  */
+/**
+ * Fail loud, before any vote is seeded, when the long-table read/write flags
+ * disagree: with READ on but DUALWRITE off, `aggregateVotes`
+ * (src/governance/aggregation.ts) reads `governance_vote_weights` — a table the
+ * governed regime never wrote into under that config — and sees 0 eligible
+ * weight votes no matter how many are seeded. Left unchecked, that surfaces as
+ * the generic "aggregateVotes returned null … no eligible weight votes" error,
+ * mispointing an operator at participation-rate config instead of the real
+ * cause (these two flags disagreeing). Exported as a pure function so the
+ * precondition is unit-testable without a live config.
+ */
+export function assertLongtableWriteConfig(config: {
+  GOVERNANCE_LONGTABLE_READ_ENABLED: boolean;
+  GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED: boolean;
+}): void {
+  if (config.GOVERNANCE_LONGTABLE_READ_ENABLED && !config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED) {
+    throw new Error(
+      'GOVERNANCE_LONGTABLE_READ_ENABLED is on but GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED is off — ' +
+        'aggregateVotes will read the (empty) governance_vote_weights long table and see 0 eligible weight votes ' +
+        'regardless of how many votes are seeded. Enable GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED (or disable ' +
+        'GOVERNANCE_LONGTABLE_READ_ENABLED) so seeded votes are visible to the real aggregation path.'
+    );
+  }
+}
+
 async function seedGovernedVotes(
   db: QueryableDb,
   modules: Pick<GovernanceModules, 'writeVoteWeights' | 'config'>,
   population: Population,
   epochId: number
 ): Promise<void> {
-  // Config-precondition guard: if reads are long-table-sourced but dual-write
-  // is off, `aggregateVotes` (src/governance/aggregation.ts) reads
-  // `governance_vote_weights` — a table this function never wrote a row into
-  // — and sees 0 eligible weight votes no matter how many votes are seeded
-  // below. Left unchecked, that surfaces downstream as
-  // `runBaselineComparison`'s generic "aggregateVotes returned null ... no
-  // eligible weight votes" error, which points an operator at
-  // participation-rate config instead of the real cause: these two flags
-  // disagreeing. Fail here, before any vote is seeded, naming both flags.
-  if (modules.config.GOVERNANCE_LONGTABLE_READ_ENABLED && !modules.config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED) {
-    throw new Error(
-      'seedGovernedVotes: GOVERNANCE_LONGTABLE_READ_ENABLED is on but GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED is ' +
-        'off — aggregateVotes will read the (empty) governance_vote_weights long table and see 0 eligible weight ' +
-        'votes regardless of how many votes are seeded here. Enable GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED (or ' +
-        'disable GOVERNANCE_LONGTABLE_READ_ENABLED) so seeded votes are visible to the real aggregation path.'
-    );
-  }
+  assertLongtableWriteConfig(modules.config);
 
   if (population.votes.length === 0) {
     throw new Error(

--- a/src/harness/baseline-comparison.ts
+++ b/src/harness/baseline-comparison.ts
@@ -28,7 +28,7 @@
  *
  * For all three, the SAME fixed corpus (subscribers/posts/engagement/topics)
  * is seeded exactly once, and each regime's weights are scored by the REAL,
- * unmodified `runScoringPipeline` (src/scoring/pipeline.js) into its own
+ * unmodified `runScoringPipeline` (src/scoring/pipeline.ts) into its own
  * epoch's `post_scores` rows — never a harness-side re-implementation of
  * scoring. Regimes 1/2 set their epoch's weight columns directly (no vote
  * aggregation involved — there is no "vote" for a fixed baseline weight
@@ -46,6 +46,21 @@
  * `FEED_MAX_POSTS`, which are presentation-layer concerns orthogonal to "how
  * did this weight vector rank the corpus"; reading `post_scores` directly
  * keeps the three regimes comparable on ranking alone.
+ *
+ * LOAD-BEARING INVARIANT — the three regimes run strictly SEQUENTIALLY,
+ * never concurrently: `getActiveEpoch()` (src/db/queries/epochs.ts) and
+ * `forceEpochTransition()` (epoch-manager.ts) both pick the single most
+ * recent epoch by id (`status = 'active'`/`'voting'` ORDER BY id DESC LIMIT
+ * 1) — there is no per-regime scoping. Prior regimes' epochs are never
+ * closed by the fixed-weight path either (`insertFixedWeightEpoch` always
+ * inserts `status = 'active'`). So regime isolation depends entirely on each
+ * regime fully completing (scored + read back) before the next regime
+ * inserts its epoch; running two regimes concurrently would race on which
+ * epoch `getActiveEpoch()`/`forceEpochTransition()` sees. As defense in
+ * depth, each regime's epoch is marked `status = 'closed'` immediately after
+ * that regime's feed is read back (see the regime loop below), so a bug that
+ * violates sequencing fails loudly (no active epoch / wrong epoch picked up)
+ * instead of silently blending two regimes' data.
  *
  * Results (measured against one fixed corpus — 60 subscribers, 200 posts, a
  * 4-persona-equal-mix electorate, seed 90210 — real `runScoringPipeline`,
@@ -495,6 +510,19 @@ async function readRegimeResults(
   return { feed, scoreByUri };
 }
 
+/**
+ * Defense-in-depth for the sequential-execution invariant documented in this
+ * file's header: mark a regime's epoch `status = 'closed'` once that
+ * regime's feed has been fully read back from `post_scores`, so a later
+ * `getActiveEpoch()`/`forceEpochTransition()` call (from a subsequent
+ * regime) can never accidentally pick up a stale regime's epoch. Safe to
+ * call after read-back — nothing downstream re-reads this epoch's `status`
+ * or re-scores it.
+ */
+async function closeRegimeEpoch(db: QueryableDb, epochId: number): Promise<void> {
+  await db.query(`UPDATE governance_epochs SET status = 'closed', closed_at = NOW() WHERE id = $1`, [epochId]);
+}
+
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
@@ -548,14 +576,27 @@ export async function runBaselineComparison(
 
   const regimes: Partial<Record<RegimeName, RegimeResult>> = {};
 
+  // These three regimes MUST run strictly sequentially (never concurrently)
+  // — see this file's header "LOAD-BEARING INVARIANT" note:
+  // getActiveEpoch()/forceEpochTransition() both pick the single most-recent
+  // epoch by id, with no per-regime scoping. Each regime's epoch is closed
+  // (defense-in-depth, see `closeRegimeEpoch`) immediately after that
+  // regime's feed is read back, below.
+
   // Regime 1: no-governance — the engine's own bootstrap default.
   {
     const weights = createDefaultGovernanceWeightRecord() as GovernanceWeights;
     const epochId = await insertFixedWeightEpoch(db, weights, 'A5 baseline: no-governance (bootstrap default)');
+    // Fixed-weight regimes never depend on the pipeline's incremental
+    // epoch-tracking state left over from a prior regime — reset it so this
+    // regime always does a genuine full rescore of the corpus against its
+    // own weights, regardless of what regime (if any) ran before it.
+    modules.__resetPipelineState();
     await withTimeout(modules.runScoringPipeline(), timeoutMs, 'runScoringPipeline[no-governance]');
     const persistedWeights = await fetchEpochWeights(db, epochId);
     const { feed, scoreByUri } = await readRegimeResults(db, epochId, topK);
     regimes['no-governance'] = { regime: 'no-governance', epochId, weights: persistedWeights, feed, scoreByUri };
+    await closeRegimeEpoch(db, epochId);
   }
 
   // Regime 2: engagement-only — all weight on engagement, run through the
@@ -571,10 +612,14 @@ export async function runBaselineComparison(
     };
     const weights = normalizeWeights(rawWeights);
     const epochId = await insertFixedWeightEpoch(db, weights, 'A5 baseline: engagement-only');
+    // See regime 1 above: reset before scoring so this regime's full rescore
+    // never depends on the previous regime's incremental-tracking state.
+    modules.__resetPipelineState();
     await withTimeout(modules.runScoringPipeline(), timeoutMs, 'runScoringPipeline[engagement-only]');
     const persistedWeights = await fetchEpochWeights(db, epochId);
     const { feed, scoreByUri } = await readRegimeResults(db, epochId, topK);
     regimes['engagement-only'] = { regime: 'engagement-only', epochId, weights: persistedWeights, feed, scoreByUri };
+    await closeRegimeEpoch(db, epochId);
   }
 
   // Regime 3: community-governed — the REAL aggregated outcome from A2
@@ -600,7 +645,12 @@ export async function runBaselineComparison(
       timeoutMs,
       'forceEpochTransition[community-governed]'
     );
-    await withTimeout(modules.runScoringPipeline(), timeoutMs, 'runScoringPipeline[community-governed]');
+    // forceEpochTransition() scores the new epoch internally
+    // (logTransitionImpact -> runScoringPipeline); no second scoring pass is
+    // needed here. An explicit extra call here previously only "worked" by
+    // landing in the pipeline's incremental "no changed posts" mode, purely
+    // because this epoch's id happened to already equal lastScoredEpochId —
+    // fragile, not a real invariant.
     const persistedWeights = await fetchEpochWeights(db, epochId);
     const { feed, scoreByUri } = await readRegimeResults(db, epochId, topK);
     regimes['community-governed'] = {
@@ -610,6 +660,7 @@ export async function runBaselineComparison(
       feed,
       scoreByUri,
     };
+    await closeRegimeEpoch(db, epochId);
   }
 
   const corpusTopicSupport: Record<string, number> = {};

--- a/src/harness/feed-metrics.ts
+++ b/src/harness/feed-metrics.ts
@@ -1,0 +1,407 @@
+/**
+ * Feed-Space Metrics (A5 / PROJ-1486)
+ *
+ * `convergence.ts` measures governance in WEIGHT space (how far did the
+ * 5-component vector move). This module measures governance in FEED space —
+ * what a subscriber actually sees once a weight vector has been scored into a
+ * ranked list of posts. Every function here is pure: given a ranked feed (and,
+ * for the topic/author metrics, the `posts` rows those URIs join to), it
+ * returns a number or a small summary object. No I/O, no Postgres/Redis, no
+ * `Rng`/`Clock` — `baseline-comparison.ts` is the "drive" half that produces
+ * the feeds these functions measure, mirroring the harness's existing
+ * drive/measure split (simulation.ts vs metrics.ts / convergence.ts).
+ *
+ * Four metrics, all defined over a feed's top-K post URIs plus the
+ * `topic_vector/author_did` each URI joins to on `posts`:
+ *
+ *   - **rank churn**: how different are two regimes' rankings of the SAME
+ *     post set? `normalizedRankDisplacement` (average absolute rank-position
+ *     change, over the shared/intersected post set, normalized to [0, 1]) and
+ *     `kendallTauDistance` (fraction of pairwise orderings that disagree) are
+ *     both provided — the former is easy to read ("how far did posts move on
+ *     average"), the latter is the standard rank-correlation distance.
+ *
+ *   - **minority-topic exposure**: `minorityTopicExposure` — the share of a
+ *     feed whose DOMINANT topic (the highest-weight entry in its
+ *     `topic_vector`, ties broken by topic slug for determinism) is a
+ *     low-support ("tail") topic, where "low-support" is defined relative to
+ *     a caller-supplied corpus-wide topic distribution (not the feed itself —
+ *     see the function doc for why).
+ *
+ *   - **author concentration**: `authorHHI` (Herfindahl-Hirschman Index) and
+ *     `authorGini` (Gini coefficient) over the feed's `author_did` shares —
+ *     two standard, complementary concentration measures over the same
+ *     distribution (HHI is sum-of-squared-shares, sensitive to a single
+ *     dominant author; Gini is a full-distribution inequality measure).
+ *
+ *   - **distortion ratio**: `distortionRatio` — see that function's doc for
+ *     the exact definition and what it is bounded to claim.
+ *
+ * Every metric here is a bounded, corpus-relative measurement: a number
+ * computed against ONE fixed synthetic corpus and a specific pair/set of
+ * regimes, not a universal claim about governance vs. engagement optimization
+ * in general. See `baseline-comparison.ts`'s file header for the actual
+ * three-regime results measured with these functions.
+ */
+
+/** Minimal shape this module needs from a ranked feed entry — matches
+ *  `TopScoredPost` (simulation.ts) structurally without importing it, so this
+ *  module stays free of any Postgres/Redis-touching import chain. */
+export interface FeedEntry {
+  uri: string;
+  rank: number;
+}
+
+/** Minimal shape this module needs from a `posts` row for the topic/author
+ *  metrics — a subset of `PostSeed` (population.ts), read back from Postgres
+ *  by `baseline-comparison.ts` rather than reused from the generator, since
+ *  the metrics here operate on whatever is actually in the `posts` table. */
+export interface FeedPostInfo {
+  uri: string;
+  authorDid: string;
+  /** Topic slug -> weight, exactly as stored in `posts.topic_vector` (JSONB).
+   *  Empty object = no topic classified for this post. */
+  topicVector: Record<string, number>;
+}
+
+function assertNonEmpty(feed: readonly FeedEntry[], fnName: string): void {
+  if (feed.length === 0) {
+    throw new Error(`${fnName}: feed must be non-empty`);
+  }
+}
+
+// ============================================================================
+// Rank churn
+// ============================================================================
+
+/**
+ * Average absolute rank-position displacement of posts appearing in BOTH
+ * `feedA` and `feedB`, normalized to [0, 1] by the shared set's size (so a
+ * post that moved from rank 1 to the very last shared rank contributes
+ * displacement 1, not a raw integer that depends on K).
+ *
+ * Only the INTERSECTION of the two feeds' post sets is scored — a post
+ * present in one regime's top-K but absent from the other's has no rank in
+ * the other feed to compare against, so it is excluded from the displacement
+ * average rather than assigned an arbitrary penalty. `sharedCount` is
+ * returned alongside the score so a caller can see how much of the feed the
+ * average was actually computed over (two feeds that barely overlap will
+ * have a small `sharedCount` and a less meaningful churn score — this is
+ * reported, not hidden).
+ *
+ * Throws if either feed is empty, or if the two feeds share no posts at all
+ * (displacement over an empty intersection has no meaningful value).
+ */
+export function normalizedRankDisplacement(
+  feedA: readonly FeedEntry[],
+  feedB: readonly FeedEntry[]
+): { displacement: number; sharedCount: number } {
+  assertNonEmpty(feedA, 'normalizedRankDisplacement');
+  assertNonEmpty(feedB, 'normalizedRankDisplacement');
+
+  const rankB = new Map(feedB.map((entry) => [entry.uri, entry.rank]));
+  const shared: Array<{ rankA: number; rankB: number }> = [];
+  for (const entry of feedA) {
+    const b = rankB.get(entry.uri);
+    if (b !== undefined) {
+      shared.push({ rankA: entry.rank, rankB: b });
+    }
+  }
+
+  if (shared.length === 0) {
+    throw new Error(
+      'normalizedRankDisplacement: feedA and feedB share no posts — displacement is undefined over an empty intersection'
+    );
+  }
+
+  // Normalize each pair's displacement by the larger feed's max rank, so the
+  // per-pair contribution is always in [0, 1] regardless of K.
+  const maxRank = Math.max(...feedA.map((e) => e.rank), ...feedB.map((e) => e.rank));
+  const totalDisplacement = shared.reduce(
+    (sum, { rankA, rankB: rb }) => sum + Math.abs(rankA - rb) / maxRank,
+    0
+  );
+
+  return {
+    displacement: totalDisplacement / shared.length,
+    sharedCount: shared.length,
+  };
+}
+
+/**
+ * Normalized Kendall-tau distance between two rankings, restricted to their
+ * shared post set: the fraction of pairs (among the shared posts) that
+ * `feedA` and `feedB` order differently, in [0, 1]. 0 = identical relative
+ * order over the shared set; 1 = completely reversed order.
+ *
+ * This is the standard rank-correlation distance (bubble-sort-swap-count /
+ * total pairs) and is a genuinely different signal from
+ * `normalizedRankDisplacement`: two feeds can have small average
+ * displacement but many local pairwise swaps (e.g. an adjacent-pair
+ * shuffle throughout), or large displacement concentrated in a few posts
+ * that moved a long way while everything else's relative order held. Both
+ * numbers are reported so a reader isn't left with only one lens.
+ *
+ * O(n^2) over the shared set — fine at this harness's K (<= a few hundred);
+ * not intended for web-scale rankings.
+ */
+export function kendallTauDistance(feedA: readonly FeedEntry[], feedB: readonly FeedEntry[]): number {
+  assertNonEmpty(feedA, 'kendallTauDistance');
+  assertNonEmpty(feedB, 'kendallTauDistance');
+
+  const rankBByUri = new Map(feedB.map((entry) => [entry.uri, entry.rank]));
+  const shared = feedA
+    .filter((entry) => rankBByUri.has(entry.uri))
+    .map((entry) => ({ uri: entry.uri, rankA: entry.rank, rankB: rankBByUri.get(entry.uri)! }));
+
+  if (shared.length < 2) {
+    throw new Error(
+      `kendallTauDistance: needs at least 2 shared posts to compare pairwise order, got ${shared.length}`
+    );
+  }
+
+  let discordant = 0;
+  let totalPairs = 0;
+  for (let i = 0; i < shared.length; i++) {
+    for (let j = i + 1; j < shared.length; j++) {
+      totalPairs++;
+      const signA = Math.sign(shared[i].rankA - shared[j].rankA);
+      const signB = Math.sign(shared[i].rankB - shared[j].rankB);
+      // signA/signB are never 0: two distinct feed entries never share a rank
+      // (rank is a 1..K position, unique per feed) — a same-sign comparison is
+      // "concordant" (both feeds agree on relative order), opposite-sign is
+      // "discordant".
+      if (signA !== signB) {
+        discordant++;
+      }
+    }
+  }
+
+  return discordant / totalPairs;
+}
+
+// ============================================================================
+// Minority-topic exposure
+// ============================================================================
+
+/**
+ * The dominant topic slug of a post's `topic_vector` — the entry with the
+ * highest weight, ties broken by ascending slug name for determinism (two
+ * topics can legitimately tie at the same jittered/rounded weight — see
+ * population.ts's topic generation — so an arbitrary `Object.entries` order
+ * must not decide the winner). Returns `null` for a post with an empty
+ * `topic_vector` (no topic classified).
+ */
+export function dominantTopic(topicVector: Record<string, number>): string | null {
+  const entries = Object.entries(topicVector);
+  if (entries.length === 0) {
+    return null;
+  }
+  entries.sort(([slugA, weightA], [slugB, weightB]) => {
+    if (weightB !== weightA) {
+      return weightB - weightA;
+    }
+    return slugA < slugB ? -1 : slugA > slugB ? 1 : 0;
+  });
+  return entries[0][0];
+}
+
+/**
+ * Share of `feed`'s posts whose dominant topic is a "tail" (low-support)
+ * topic, per `corpusTopicSupport` — a slug -> post-count (or share) map
+ * describing how common each topic is ACROSS THE WHOLE CORPUS the feed was
+ * ranked from, not just within the feed itself.
+ *
+ * Corpus-relative (not feed-relative) support is deliberate: "minority topic"
+ * describes a topic that is rare in the community's content overall — a topic
+ * that happens to be rare in one particular feed but common in the corpus
+ * would not be a meaningful minority-exposure signal, and computing support
+ * from the feed alone would make the metric circular (a feed that already
+ * excludes a topic entirely would trivially show 0% exposure to it, which is
+ * the opposite of what "exposure" should mean here).
+ *
+ * `tailThreshold` (share of corpus posts, e.g. 0.1) marks a topic as "tail"
+ * when its corpus-wide share is strictly below the threshold. Posts with no
+ * dominant topic (`dominantTopic` returns null) are excluded from both the
+ * numerator and denominator — an unclassified post has no topic to be a
+ * minority or majority member of.
+ */
+export function minorityTopicExposure(
+  feed: readonly FeedPostInfo[],
+  corpusTopicSupport: Readonly<Record<string, number>>,
+  tailThreshold: number
+): { exposure: number; classifiedCount: number; totalCount: number } {
+  if (tailThreshold < 0 || tailThreshold > 1) {
+    throw new Error(`minorityTopicExposure: tailThreshold must be in [0, 1], got ${tailThreshold}`);
+  }
+
+  const totalCorpusPosts = Object.values(corpusTopicSupport).reduce((sum, count) => sum + count, 0);
+  const tailSlugs = new Set(
+    Object.entries(corpusTopicSupport)
+      .filter(([, count]) => (totalCorpusPosts === 0 ? false : count / totalCorpusPosts < tailThreshold))
+      .map(([slug]) => slug)
+  );
+
+  let classifiedCount = 0;
+  let minorityCount = 0;
+  for (const post of feed) {
+    const topic = dominantTopic(post.topicVector);
+    if (topic === null) {
+      continue;
+    }
+    classifiedCount++;
+    if (tailSlugs.has(topic)) {
+      minorityCount++;
+    }
+  }
+
+  return {
+    exposure: classifiedCount === 0 ? 0 : minorityCount / classifiedCount,
+    classifiedCount,
+    totalCount: feed.length,
+  };
+}
+
+/**
+ * Build a corpus-wide topic-support map (slug -> post count, by dominant
+ * topic) from the full corpus's posts — the input `minorityTopicExposure`
+ * expects for its `corpusTopicSupport` parameter. Separate from that function
+ * so a caller with a pre-computed support map (e.g. from a DB aggregate
+ * query) can skip this and pass their own.
+ */
+export function buildCorpusTopicSupport(corpusPosts: readonly FeedPostInfo[]): Record<string, number> {
+  const support: Record<string, number> = {};
+  for (const post of corpusPosts) {
+    const topic = dominantTopic(post.topicVector);
+    if (topic === null) {
+      continue;
+    }
+    support[topic] = (support[topic] ?? 0) + 1;
+  }
+  return support;
+}
+
+// ============================================================================
+// Author concentration
+// ============================================================================
+
+/** Author -> share of `feed` (post count / feed length), for `feed`'s
+ *  non-empty post set. Shared by `authorHHI`/`authorGini` so both operate
+ *  over the identical distribution. */
+function authorShares(feed: readonly FeedPostInfo[]): number[] {
+  const counts = new Map<string, number>();
+  for (const post of feed) {
+    counts.set(post.authorDid, (counts.get(post.authorDid) ?? 0) + 1);
+  }
+  return [...counts.values()].map((count) => count / feed.length);
+}
+
+/**
+ * Herfindahl-Hirschman Index over a feed's `author_did` distribution: the sum
+ * of squared per-author shares, in (0, 1]. Standard concentration measure
+ * (same definition used for market-share concentration) — higher means fewer
+ * authors dominate the feed. A feed of N posts by N distinct authors has HHI
+ * `1/N` (minimum possible concentration for that N); a feed entirely from one
+ * author has HHI 1 (maximum).
+ */
+export function authorHHI(feed: readonly FeedPostInfo[]): number {
+  if (feed.length === 0) {
+    throw new Error('authorHHI: feed must be non-empty');
+  }
+  return authorShares(feed).reduce((sum, share) => sum + share * share, 0);
+}
+
+/**
+ * Gini coefficient over a feed's `author_did` distribution (post counts per
+ * author), in [0, 1). 0 = every author in the feed has an identical post
+ * count (perfect equality); approaches 1 as the feed concentrates on fewer
+ * and fewer authors. Computed via the standard mean-absolute-difference form
+ * (mean pairwise absolute difference between shares, divided by twice the
+ * mean share) rather than a sorted-cumulative-share approximation, so it is
+ * exact (not a discretization) for a finite author list.
+ *
+ * A feed with only one distinct author is a degenerate case (no inequality
+ * to measure between authors — there's only one) and returns 0 rather than
+ * dividing by a zero mean-absolute-difference denominator ambiguously; this
+ * is called out explicitly rather than silently producing `NaN`.
+ */
+export function authorGini(feed: readonly FeedPostInfo[]): number {
+  if (feed.length === 0) {
+    throw new Error('authorGini: feed must be non-empty');
+  }
+  const shares = authorShares(feed);
+  if (shares.length === 1) {
+    return 0;
+  }
+
+  let sumAbsDiff = 0;
+  for (let i = 0; i < shares.length; i++) {
+    for (let j = 0; j < shares.length; j++) {
+      sumAbsDiff += Math.abs(shares[i] - shares[j]);
+    }
+  }
+  const n = shares.length;
+  const mean = shares.reduce((sum, s) => sum + s, 0) / n;
+  const meanAbsDiff = sumAbsDiff / (n * n);
+  return meanAbsDiff / (2 * mean);
+}
+
+// ============================================================================
+// Distortion ratio
+// ============================================================================
+
+/**
+ * Distortion ratio of a `treatment` feed relative to a `reference` feed, over
+ * a shared quality proxy: the reference feed's OWN total_score for each post
+ * (i.e. "how good does the reference regime think these posts are"), summed
+ * over the treatment feed's top-K post set and normalized by the reference
+ * feed's own top-K total.
+ *
+ * Concretely: `sum(referenceScoreByUri[uri] for uri in treatmentFeed top-K) /
+ * sum(referenceScoreByUri[uri] for uri in referenceFeed top-K)`.
+ *
+ * This answers "if we score the TREATMENT regime's chosen posts using the
+ * REFERENCE regime's own quality function, how much of the reference
+ * regime's own best-case score do we still capture?" A ratio of 1.0 means the
+ * treatment feed's posts are, by the reference's own yardstick, exactly as
+ * good as what the reference itself would have chosen (even if the actual
+ * post SET differs) — 0.7 means it captures 70% of that reference-defined
+ * "quality mass". A post the treatment feed included that the reference feed
+ * never scored at all (not in `referenceScoreByUri`) contributes 0 to the
+ * numerator, not an error — that post simply has no reference-defined
+ * quality contribution.
+ *
+ * Bounded framing (see baseline-comparison.ts's header for the actual
+ * numbers): this is ONE way to operationalize "welfare cost", and it is only
+ * as meaningful as the reference regime's own scoring function is a good
+ * quality proxy — it is not an independent ground-truth utility measure. When
+ * `reference` is the engagement-only regime, this ratio is read as "how much
+ * of the engagement-maximizer's own best-case engagement-quality does the
+ * governed feed still capture" — the "at what cost" half of the A5 question.
+ * A ratio near 1 says "governance cost little engagement-quality by the
+ * engagement regime's own yardstick"; a ratio well below 1 says the two
+ * regimes are optimizing for substantially different post sets.
+ */
+export function distortionRatio(
+  treatment: readonly FeedEntry[],
+  reference: readonly FeedEntry[],
+  referenceScoreByUri: ReadonlyMap<string, number>
+): number {
+  assertNonEmpty(treatment, 'distortionRatio');
+  assertNonEmpty(reference, 'distortionRatio');
+
+  const referenceTotal = reference.reduce((sum, entry) => sum + (referenceScoreByUri.get(entry.uri) ?? 0), 0);
+  if (referenceTotal === 0) {
+    throw new Error(
+      'distortionRatio: reference feed\'s own total quality mass is 0 — ratio is undefined (division by zero). ' +
+        'This means every reference-feed post scored 0 or is missing from referenceScoreByUri.'
+    );
+  }
+
+  const treatmentTotal = treatment.reduce(
+    (sum, entry) => sum + (referenceScoreByUri.get(entry.uri) ?? 0),
+    0
+  );
+
+  return treatmentTotal / referenceTotal;
+}

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -58,6 +58,30 @@ export type {
 export { createRng, SeededClock } from './rng.js';
 export type { Rng, Clock } from './rng.js';
 
+export { runBaselineComparison, writeBaselineComparisonArtifacts, REGIME_NAMES } from './baseline-comparison.js';
+export type {
+  RegimeName,
+  BaselineComparisonDeps,
+  RegimeResult,
+  BaselineComparisonResult,
+  RunBaselineComparisonOptions,
+  BaselineComparisonCsvRow,
+  RegimeSummaryCsvRow,
+  WrittenBaselineComparisonPaths,
+} from './baseline-comparison.js';
+
+export {
+  normalizedRankDisplacement,
+  kendallTauDistance,
+  dominantTopic,
+  minorityTopicExposure,
+  buildCorpusTopicSupport,
+  authorHHI,
+  authorGini,
+  distortionRatio,
+} from './feed-metrics.js';
+export type { FeedEntry, FeedPostInfo } from './feed-metrics.js';
+
 export { generatePopulation, TOPIC_SLUGS } from './population.js';
 export type { Population, SubscriberSeed, PostSeed, VoteSeed } from './population.js';
 

--- a/tests/harness/baseline-comparison.sim.ts
+++ b/tests/harness/baseline-comparison.sim.ts
@@ -1,0 +1,276 @@
+/**
+ * Integration test: A5 three-way baseline comparison (PROJ-1486), driven
+ * against the real Testcontainers-backed Postgres + Redis stack.
+ *
+ * Same "drive the real engine, read back what it persisted" pattern as
+ * multi-epoch-cycle.sim.ts / strategyproofness.sim.ts: `runBaselineComparison`
+ * (src/harness/baseline-comparison.ts) seeds ONE fixed corpus, scores it under
+ * all three regimes via the REAL `runScoringPipeline`
+ * (no-governance/engagement-only via direct weight injection,
+ * community-governed via the REAL `aggregateVotes` -> `forceEpochTransition`),
+ * and this file asserts:
+ *
+ *   1. The three regimes produce measurably distinct rankings — non-trivial
+ *      rank churn between engagement-only and community-governed.
+ *   2. A feed-quality-vs-engagement direction: the governed feed's author
+ *      concentration is no higher than the engagement-only feed's (governance
+ *      is not making concentration WORSE on this corpus) — asserted with the
+ *      real numbers this corpus/seed actually produces, not assumed. A
+ *      companion distortion-ratio assertion checks the "at what cost" half:
+ *      the governed feed still captures a majority (but not all) of the
+ *      engagement-only regime's own best-case quality mass.
+ *   3. Determinism: the same seed reproduces identical feed-metric output
+ *      across two independent runs against a freshly reset database.
+ *
+ * Feed-metrics math itself (rank churn on known permutations, HHI/Gini on
+ * known distributions, minority exposure on a known feed) is unit-tested in
+ * feed-metrics.test.ts against hand-computed fixtures, not re-verified here —
+ * this file only checks that the REAL pipeline run produces distinct,
+ * reproducible input for those already-verified functions.
+ *
+ * `vi.useFakeTimers({ toFake: ['Date'] })` + a fixed `HARNESS_FIXED_CLOCK_MS`
+ * (same pattern as golden-snapshot.sim.ts): the real scoring pipeline's
+ * `recency` component and its scoring-window cutoff (`getPostsForScoring`,
+ * pipeline.ts) read the real wall clock, not an injected `Clock` — freezing
+ * `Date` itself is what makes seeded post timestamps land inside the scoring
+ * window deterministically, independent of the real calendar date the suite
+ * runs on.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { db } from '../../src/db/client.js';
+import { createRng, SeededClock } from '../../src/harness/rng.js';
+import {
+  runBaselineComparison,
+  writeBaselineComparisonArtifacts,
+  REGIME_NAMES,
+  type RegimeName,
+  type RegimeSummaryCsvRow,
+  type BaselineComparisonCsvRow,
+} from '../../src/harness/baseline-comparison.js';
+import {
+  normalizedRankDisplacement,
+  kendallTauDistance,
+  minorityTopicExposure,
+  authorHHI,
+  authorGini,
+  distortionRatio,
+} from '../../src/harness/feed-metrics.js';
+import { resetHarnessData, HARNESS_FIXED_CLOCK_MS } from './helpers.js';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const SEED = 90210;
+
+const POPULATION_CONFIG = {
+  subscriberCount: 60,
+  postCount: 200,
+  voteParticipationRate: 1,
+  contentVoteRate: 0,
+  castsWeightVoteRate: 1,
+  castsTopicVoteRate: 0,
+  personaMix: {
+    'engagement-maximizer': 1,
+    'chronological-purist': 1,
+    'bridge-builder': 1,
+    balanced: 1,
+  },
+};
+
+describe('baseline comparison (PROJ-1486 / A5): three regimes on one fixed corpus', () => {
+  beforeAll(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(HARNESS_FIXED_CLOCK_MS));
+  });
+
+  afterEach(async () => {
+    await resetHarnessData();
+  });
+
+  afterAll(async () => {
+    await resetHarnessData();
+    vi.useRealTimers();
+  });
+
+  it('every regime produces a non-empty, distinctly-weighted top-K feed', async () => {
+    const deps = { db, rng: createRng(SEED), clock: new SeededClock(HARNESS_FIXED_CLOCK_MS) };
+    const result = await runBaselineComparison(deps, { populationConfig: POPULATION_CONFIG, topK: 50 });
+
+    for (const name of REGIME_NAMES) {
+      const regime = result.regimes[name];
+      expect(regime.feed.length).toBeGreaterThan(0);
+      const weightSum = Object.values(regime.weights).reduce((sum, v) => sum + v, 0);
+      expect(weightSum).toBeCloseTo(1, 6);
+    }
+
+    // no-governance is the bootstrap default: equal 0.2 across all 5 components.
+    expect(result.regimes['no-governance'].weights.engagement).toBeCloseTo(0.2, 6);
+    expect(result.regimes['no-governance'].weights.recency).toBeCloseTo(0.2, 6);
+
+    // engagement-only puts (after real normalization) all weight on engagement.
+    expect(result.regimes['engagement-only'].weights.engagement).toBeCloseTo(1, 6);
+    expect(result.regimes['engagement-only'].weights.recency).toBeCloseTo(0, 6);
+
+    // community-governed is a REAL aggregated outcome from a 4-persona mix —
+    // it must not collapse onto either hand-specified baseline vector.
+    const governed = result.regimes['community-governed'].weights;
+    expect(governed.engagement).toBeLessThan(0.9);
+    expect(governed.engagement).toBeGreaterThan(0);
+  });
+
+  it('engagement-only and community-governed produce measurably distinct rankings (non-trivial rank churn)', async () => {
+    const deps = { db, rng: createRng(SEED), clock: new SeededClock(HARNESS_FIXED_CLOCK_MS) };
+    const result = await runBaselineComparison(deps, { populationConfig: POPULATION_CONFIG, topK: 50 });
+
+    const engagementFeed = result.regimes['engagement-only'].feed;
+    const governedFeed = result.regimes['community-governed'].feed;
+
+    const { displacement, sharedCount } = normalizedRankDisplacement(engagementFeed, governedFeed);
+    const tau = kendallTauDistance(engagementFeed, governedFeed);
+
+    // Not a trivial/degenerate comparison — the two feeds share enough posts
+    // for the churn numbers to mean something.
+    expect(sharedCount).toBeGreaterThan(5);
+    // The two regimes' weight vectors are far apart (all-engagement vs. a
+    // blended 4-persona outcome), so their rankings over the same corpus must
+    // show real churn, not a coincidental near-identical order.
+    expect(displacement).toBeGreaterThan(0.02);
+    expect(tau).toBeGreaterThan(0.02);
+  });
+
+  it('feed-quality-vs-engagement direction: governed feed is no more author-concentrated than the engagement-only feed', async () => {
+    const deps = { db, rng: createRng(SEED), clock: new SeededClock(HARNESS_FIXED_CLOCK_MS) };
+    const result = await runBaselineComparison(deps, { populationConfig: POPULATION_CONFIG, topK: 50 });
+
+    const postInfoByUri = new Map(result.corpusPostInfo.map((post) => [post.uri, post]));
+    const feedPostInfo = (regime: RegimeName) =>
+      result.regimes[regime].feed.map((entry) => postInfoByUri.get(entry.uri)!);
+
+    const engagementHHI = authorHHI(feedPostInfo('engagement-only'));
+    const governedHHI = authorHHI(feedPostInfo('community-governed'));
+    const engagementGini = authorGini(feedPostInfo('engagement-only'));
+    const governedGini = authorGini(feedPostInfo('community-governed'));
+
+    // sourceDiversity has non-trivial weight in the real aggregated outcome
+    // (see the previous test), so the governed feed's author concentration
+    // should be at or below the pure-engagement feed's — asserting the exact
+    // direction this experiment's write-up claims, not just "some number".
+    expect(governedHHI).toBeLessThanOrEqual(engagementHHI);
+    expect(governedGini).toBeLessThanOrEqual(engagementGini);
+  });
+
+  it('distortion ratio: the governed feed still captures most of the engagement regime\'s own best-case quality mass', async () => {
+    const deps = { db, rng: createRng(SEED), clock: new SeededClock(HARNESS_FIXED_CLOCK_MS) };
+    const result = await runBaselineComparison(deps, { populationConfig: POPULATION_CONFIG, topK: 50 });
+
+    const engagementOnly = result.regimes['engagement-only'];
+    const governed = result.regimes['community-governed'];
+
+    const ratio = distortionRatio(governed.feed, engagementOnly.feed, engagementOnly.scoreByUri);
+
+    // Bounded to THIS corpus/seed: measured at ~0.88 — governance gives up
+    // roughly a tenth of the engagement regime's own best-case quality mass
+    // in exchange for the lower author concentration asserted above. Neither
+    // 1.0 (no cost at all) nor near-0 (governance and engagement optimizing
+    // for almost disjoint post sets) — a real, partial tradeoff.
+    expect(ratio).toBeGreaterThan(0.5);
+    expect(ratio).toBeLessThan(1);
+  });
+
+  it('minority-topic exposure is computable per regime against the corpus-wide topic distribution', async () => {
+    const deps = { db, rng: createRng(SEED), clock: new SeededClock(HARNESS_FIXED_CLOCK_MS) };
+    const result = await runBaselineComparison(deps, { populationConfig: POPULATION_CONFIG, topK: 50 });
+
+    const postInfoByUri = new Map(result.corpusPostInfo.map((post) => [post.uri, post]));
+    for (const name of REGIME_NAMES) {
+      const feedPosts = result.regimes[name].feed.map((entry) => postInfoByUri.get(entry.uri)!);
+      const { exposure, classifiedCount, totalCount } = minorityTopicExposure(
+        feedPosts,
+        result.corpusTopicSupport,
+        0.15
+      );
+      expect(exposure).toBeGreaterThanOrEqual(0);
+      expect(exposure).toBeLessThanOrEqual(1);
+      expect(classifiedCount).toBeLessThanOrEqual(totalCount);
+    }
+  });
+
+  it('determinism: the same seed reproduces identical feed-metric output across two independent runs', async () => {
+    const depsA = { db, rng: createRng(SEED), clock: new SeededClock(HARNESS_FIXED_CLOCK_MS) };
+    const resultA = await runBaselineComparison(depsA, { populationConfig: POPULATION_CONFIG, topK: 50 });
+
+    const summarize = (r: typeof resultA) => ({
+      weights: REGIME_NAMES.map((name) => r.regimes[name].weights),
+      feeds: REGIME_NAMES.map((name) => r.regimes[name].feed.map((e) => e.uri)),
+    });
+    const snapshotA = summarize(resultA);
+
+    await resetHarnessData();
+
+    const depsB = { db, rng: createRng(SEED), clock: new SeededClock(HARNESS_FIXED_CLOCK_MS) };
+    const resultB = await runBaselineComparison(depsB, { populationConfig: POPULATION_CONFIG, topK: 50 });
+    const snapshotB = summarize(resultB);
+
+    expect(snapshotB).toEqual(snapshotA);
+  });
+
+  it('writes a deterministic CSV artifact comparing the three regimes', async () => {
+    const artifactsDir = await mkdtemp(path.join(tmpdir(), 'corgi-sim-baseline-comparison-'));
+    try {
+      const deps = { db, rng: createRng(SEED), clock: new SeededClock(HARNESS_FIXED_CLOCK_MS) };
+      const result = await runBaselineComparison(deps, { populationConfig: POPULATION_CONFIG, topK: 50 });
+
+      const postInfoByUri = new Map(result.corpusPostInfo.map((post) => [post.uri, post]));
+      const summaryRows: RegimeSummaryCsvRow[] = REGIME_NAMES.map((name) => {
+        const regime = result.regimes[name];
+        const feedPosts = regime.feed.map((entry) => postInfoByUri.get(entry.uri)!);
+        const { exposure } = minorityTopicExposure(feedPosts, result.corpusTopicSupport, 0.15);
+        return {
+          regime: name,
+          epochId: regime.epochId,
+          weights: regime.weights,
+          authorHHI: authorHHI(feedPosts),
+          authorGini: authorGini(feedPosts),
+          minorityTopicExposure: exposure,
+        };
+      });
+
+      const pairwiseRows: BaselineComparisonCsvRow[] = [];
+      for (let i = 0; i < REGIME_NAMES.length; i++) {
+        for (let j = i + 1; j < REGIME_NAMES.length; j++) {
+          const a = result.regimes[REGIME_NAMES[i]].feed;
+          const b = result.regimes[REGIME_NAMES[j]].feed;
+          const { displacement, sharedCount } = normalizedRankDisplacement(a, b);
+          pairwiseRows.push({
+            regimeA: REGIME_NAMES[i],
+            regimeB: REGIME_NAMES[j],
+            rankDisplacement: displacement,
+            kendallTau: kendallTauDistance(a, b),
+            sharedCount,
+          });
+        }
+      }
+
+      const { summaryCsvPath, pairwiseCsvPath } = await writeBaselineComparisonArtifacts(
+        artifactsDir,
+        summaryRows,
+        pairwiseRows
+      );
+
+      const summaryCsv = await readFile(summaryCsvPath, 'utf8');
+      const summaryLines = summaryCsv.trim().split('\n');
+      expect(summaryLines).toHaveLength(REGIME_NAMES.length + 1);
+      expect(summaryLines[0]).toBe(
+        'regime,epochId,recency,engagement,bridging,sourceDiversity,relevance,authorHHI,authorGini,minorityTopicExposure'
+      );
+
+      const pairwiseCsv = await readFile(pairwiseCsvPath, 'utf8');
+      const pairwiseLines = pairwiseCsv.trim().split('\n');
+      expect(pairwiseLines).toHaveLength(4); // header + 3 pairs (C(3,2))
+      expect(pairwiseLines[0]).toBe('regimeA,regimeB,rankDisplacement,kendallTau,sharedCount');
+    } finally {
+      await rm(artifactsDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/harness/baseline-comparison.sim.ts
+++ b/tests/harness/baseline-comparison.sim.ts
@@ -55,6 +55,7 @@ import {
   authorHHI,
   authorGini,
   distortionRatio,
+  type FeedPostInfo,
 } from '../../src/harness/feed-metrics.js';
 import { resetHarnessData, HARNESS_FIXED_CLOCK_MS } from './helpers.js';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
@@ -62,6 +63,24 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 const SEED = 90210;
+
+/**
+ * Look up a feed entry's corpus post info, failing loudly with the offending
+ * uri if it's missing — a non-null `!` assertion here would silently become
+ * `undefined`, surfacing later (inside a metric function) as a confusing
+ * "Cannot read properties of undefined" with no indication of which uri or
+ * which feed/regime was responsible. Every feed uri is expected to join back
+ * to `corpusPostInfo` (the same corpus every regime is scored against), so a
+ * miss here means the seeded corpus and a regime's scored feed have
+ * diverged — a bug worth surfacing at the join, not deep in a metric.
+ */
+function requirePostInfo(postInfoByUri: ReadonlyMap<string, FeedPostInfo>, uri: string): FeedPostInfo {
+  const info = postInfoByUri.get(uri);
+  if (!info) {
+    throw new Error(`requirePostInfo: uri "${uri}" is missing from corpusPostInfo — seeded corpus and scored feed have diverged`);
+  }
+  return info;
+}
 
 const POPULATION_CONFIG = {
   subscriberCount: 60,
@@ -145,7 +164,7 @@ describe('baseline comparison (PROJ-1486 / A5): three regimes on one fixed corpu
 
     const postInfoByUri = new Map(result.corpusPostInfo.map((post) => [post.uri, post]));
     const feedPostInfo = (regime: RegimeName) =>
-      result.regimes[regime].feed.map((entry) => postInfoByUri.get(entry.uri)!);
+      result.regimes[regime].feed.map((entry) => requirePostInfo(postInfoByUri, entry.uri));
 
     const engagementHHI = authorHHI(feedPostInfo('engagement-only'));
     const governedHHI = authorHHI(feedPostInfo('community-governed'));
@@ -184,7 +203,7 @@ describe('baseline comparison (PROJ-1486 / A5): three regimes on one fixed corpu
 
     const postInfoByUri = new Map(result.corpusPostInfo.map((post) => [post.uri, post]));
     for (const name of REGIME_NAMES) {
-      const feedPosts = result.regimes[name].feed.map((entry) => postInfoByUri.get(entry.uri)!);
+      const feedPosts = result.regimes[name].feed.map((entry) => requirePostInfo(postInfoByUri, entry.uri));
       const { exposure, classifiedCount, totalCount } = minorityTopicExposure(
         feedPosts,
         result.corpusTopicSupport,
@@ -194,6 +213,22 @@ describe('baseline comparison (PROJ-1486 / A5): three regimes on one fixed corpu
       expect(exposure).toBeLessThanOrEqual(1);
       expect(classifiedCount).toBeLessThanOrEqual(totalCount);
     }
+  });
+
+  it('throws the descriptive "no eligible weight votes" error when the electorate casts no weight votes', async () => {
+    // castsWeightVoteRate: 0 -> every seeded vote has weights: null (see
+    // population.ts's generateVotes), so seedGovernedVotes's own
+    // population.votes.length guard doesn't trip (voteParticipationRate is
+    // still 1, so votes ARE cast — just none carry a weight opinion), but the
+    // real aggregateVotes sees 0 weight-bearing votes for the epoch and
+    // returns null, which runBaselineComparison surfaces as this descriptive
+    // error rather than a generic downstream failure.
+    const noWeightVotesConfig = { ...POPULATION_CONFIG, castsWeightVoteRate: 0 };
+    const deps = { db, rng: createRng(SEED), clock: new SeededClock(HARNESS_FIXED_CLOCK_MS) };
+
+    await expect(runBaselineComparison(deps, { populationConfig: noWeightVotesConfig, topK: 50 })).rejects.toThrow(
+      /no eligible weight votes/
+    );
   });
 
   it('determinism: the same seed reproduces identical feed-metric output across two independent runs', async () => {
@@ -224,7 +259,7 @@ describe('baseline comparison (PROJ-1486 / A5): three regimes on one fixed corpu
       const postInfoByUri = new Map(result.corpusPostInfo.map((post) => [post.uri, post]));
       const summaryRows: RegimeSummaryCsvRow[] = REGIME_NAMES.map((name) => {
         const regime = result.regimes[name];
-        const feedPosts = regime.feed.map((entry) => postInfoByUri.get(entry.uri)!);
+        const feedPosts = regime.feed.map((entry) => requirePostInfo(postInfoByUri, entry.uri));
         const { exposure } = minorityTopicExposure(feedPosts, result.corpusTopicSupport, 0.15);
         return {
           regime: name,

--- a/tests/harness/baseline-comparison.test.ts
+++ b/tests/harness/baseline-comparison.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Baseline-Comparison Unit Tests (PROJ-1486 / A5)
+ *
+ * Pure — no Postgres/Redis/Testcontainers dependency. Covers the
+ * `assertLongtableWriteConfig` precondition guard directly, so the READ-on /
+ * DUALWRITE-off misconfiguration (which would otherwise make the governed
+ * regime's `aggregateVotes` silently read an empty long table) is pinned
+ * without standing up the whole pipeline.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { assertLongtableWriteConfig } from '../../src/harness/baseline-comparison.js';
+
+describe('assertLongtableWriteConfig', () => {
+  it('throws, naming DUALWRITE, when READ is on but DUALWRITE is off', () => {
+    expect(() =>
+      assertLongtableWriteConfig({
+        GOVERNANCE_LONGTABLE_READ_ENABLED: true,
+        GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED: false,
+      })
+    ).toThrow(/GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED/);
+  });
+
+  it('does not throw when both are on (the production default)', () => {
+    expect(() =>
+      assertLongtableWriteConfig({
+        GOVERNANCE_LONGTABLE_READ_ENABLED: true,
+        GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED: true,
+      })
+    ).not.toThrow();
+  });
+
+  it('does not throw when READ is off (the long table is not the read source)', () => {
+    expect(() =>
+      assertLongtableWriteConfig({
+        GOVERNANCE_LONGTABLE_READ_ENABLED: false,
+        GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED: false,
+      })
+    ).not.toThrow();
+  });
+});

--- a/tests/harness/feed-metrics.test.ts
+++ b/tests/harness/feed-metrics.test.ts
@@ -104,6 +104,11 @@ describe('kendallTauDistance', () => {
   it('throws with fewer than 2 shared posts', () => {
     expect(() => kendallTauDistance(feed(['p1']), feed(['p1']))).toThrow(/at least 2 shared/);
   });
+
+  it('throws on an empty feed', () => {
+    expect(() => kendallTauDistance([], feed(['p1']))).toThrow(/non-empty/);
+    expect(() => kendallTauDistance(feed(['p1']), [])).toThrow(/non-empty/);
+  });
 });
 
 describe('dominantTopic', () => {
@@ -173,6 +178,26 @@ describe('buildCorpusTopicSupport', () => {
       { uri: 'p4', authorDid: 'a', topicVector: { music: 1 } },
     ];
     expect(buildCorpusTopicSupport(posts)).toEqual({ sports: 2, music: 1 });
+  });
+
+  // Regression coverage for the dominant-topic tie-break this function
+  // delegates to `dominantTopic` — previously reimplemented inline in
+  // baseline-comparison.ts's corpus-topic-support loop (now replaced by a
+  // direct call to this function), so an empty topicVector and an
+  // equal-weight tie must resolve identically here to what that inline loop
+  // used to compute.
+  it('excludes a post with an empty topicVector entirely (not counted under any slug)', () => {
+    const posts: FeedPostInfo[] = [{ uri: 'p1', authorDid: 'a', topicVector: {} }];
+    expect(buildCorpusTopicSupport(posts)).toEqual({});
+  });
+
+  it('breaks an equal-weight tie by ascending slug name, same as dominantTopic', () => {
+    const posts: FeedPostInfo[] = [
+      { uri: 'p1', authorDid: 'a', topicVector: { zzz: 0.5, aaa: 0.5 } },
+      { uri: 'p2', authorDid: 'a', topicVector: { sports: 0.5, music: 0.5 } },
+    ];
+    // p1 ties zzz/aaa -> aaa wins; p2 ties sports/music -> music wins.
+    expect(buildCorpusTopicSupport(posts)).toEqual({ aaa: 1, music: 1 });
   });
 });
 
@@ -278,6 +303,12 @@ describe('distortionRatio', () => {
     const treatment = feed(['p1']);
     const scoreByUri = new Map([['p1', 0]]);
     expect(() => distortionRatio(treatment, reference, scoreByUri)).toThrow(/division by zero/);
+  });
+
+  it('throws on an empty treatment or reference feed', () => {
+    const scoreByUri = new Map([['p1', 10]]);
+    expect(() => distortionRatio([], feed(['p1']), scoreByUri)).toThrow(/non-empty/);
+    expect(() => distortionRatio(feed(['p1']), [], scoreByUri)).toThrow(/non-empty/);
   });
 });
 

--- a/tests/harness/feed-metrics.test.ts
+++ b/tests/harness/feed-metrics.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Feed-Space Metrics Unit Tests (PROJ-1486 / A5)
+ *
+ * Pure — no Postgres/Redis/Testcontainers dependency, same pattern as
+ * convergence.test.ts. Every metric in feed-metrics.ts is exercised against
+ * hand-computable fixtures (known permutations, known distributions) so the
+ * math itself is pinned independent of any real scoring-pipeline run.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  normalizedRankDisplacement,
+  kendallTauDistance,
+  dominantTopic,
+  minorityTopicExposure,
+  buildCorpusTopicSupport,
+  authorHHI,
+  authorGini,
+  distortionRatio,
+  type FeedEntry,
+  type FeedPostInfo,
+} from '../../src/harness/feed-metrics.js';
+
+function feed(uris: readonly string[]): FeedEntry[] {
+  return uris.map((uri, index) => ({ uri, rank: index + 1 }));
+}
+
+describe('normalizedRankDisplacement', () => {
+  it('is 0 for two identical rankings', () => {
+    const a = feed(['p1', 'p2', 'p3', 'p4']);
+    const b = feed(['p1', 'p2', 'p3', 'p4']);
+    const result = normalizedRankDisplacement(a, b);
+    expect(result.displacement).toBe(0);
+    expect(result.sharedCount).toBe(4);
+  });
+
+  it('matches a hand-computed displacement on a full reversal', () => {
+    // ranks: p1 1->4, p2 2->3, p3 3->2, p4 4->1. |diff| = 3,1,1,3, maxRank=4.
+    // mean = (3+1+1+3)/4 / 4 = 8/4/4 = 0.5
+    const a = feed(['p1', 'p2', 'p3', 'p4']);
+    const b = feed(['p4', 'p3', 'p2', 'p1']);
+    const result = normalizedRankDisplacement(a, b);
+    expect(result.displacement).toBeCloseTo(0.5, 12);
+    expect(result.sharedCount).toBe(4);
+  });
+
+  it('matches a hand-computed displacement on a single adjacent swap', () => {
+    // p1<->p2 swapped, p3/p4 fixed. |diff| = 1,1,0,0, maxRank=4.
+    // mean = (1+1+0+0)/4/4 = 2/16 = 0.125
+    const a = feed(['p1', 'p2', 'p3', 'p4']);
+    const b = feed(['p2', 'p1', 'p3', 'p4']);
+    const result = normalizedRankDisplacement(a, b);
+    expect(result.displacement).toBeCloseTo(0.125, 12);
+  });
+
+  it('only scores the shared post set, reporting sharedCount', () => {
+    // p5 only in a, p6 only in b — excluded from the pairwise comparison.
+    const a = feed(['p1', 'p2', 'p5']);
+    const b = feed(['p1', 'p2', 'p6']);
+    const result = normalizedRankDisplacement(a, b);
+    expect(result.sharedCount).toBe(2);
+    // p1: rank 1 vs 1 (diff 0), p2: rank 2 vs 2 (diff 0) -> displacement 0
+    expect(result.displacement).toBe(0);
+  });
+
+  it('throws when feeds share no posts', () => {
+    expect(() => normalizedRankDisplacement(feed(['p1']), feed(['p2']))).toThrow(/share no posts/);
+  });
+
+  it('throws on an empty feed', () => {
+    expect(() => normalizedRankDisplacement([], feed(['p1']))).toThrow(/non-empty/);
+  });
+});
+
+describe('kendallTauDistance', () => {
+  it('is 0 for two identical rankings', () => {
+    const a = feed(['p1', 'p2', 'p3']);
+    const b = feed(['p1', 'p2', 'p3']);
+    expect(kendallTauDistance(a, b)).toBe(0);
+  });
+
+  it('is 1 for a full reversal (every pair disagrees)', () => {
+    const a = feed(['p1', 'p2', 'p3']);
+    const b = feed(['p3', 'p2', 'p1']);
+    expect(kendallTauDistance(a, b)).toBe(1);
+  });
+
+  it('matches a hand-computed distance on a single adjacent swap', () => {
+    // Order a: p1,p2,p3,p4 (6 pairs total). Order b: p2,p1,p3,p4 (only the
+    // p1/p2 pair is discordant) -> 1/6.
+    const a = feed(['p1', 'p2', 'p3', 'p4']);
+    const b = feed(['p2', 'p1', 'p3', 'p4']);
+    expect(kendallTauDistance(a, b)).toBeCloseTo(1 / 6, 12);
+  });
+
+  it('restricts to the shared post set', () => {
+    const a = feed(['p1', 'p2', 'p3', 'px']);
+    const b = feed(['p1', 'p3', 'p2', 'py']);
+    // shared: p1, p2, p3. a-order: p1,p2,p3. b-order among shared: p1,p3,p2.
+    // pairs: (p1,p2) concordant, (p1,p3) concordant, (p2,p3) discordant -> 1/3
+    expect(kendallTauDistance(a, b)).toBeCloseTo(1 / 3, 12);
+  });
+
+  it('throws with fewer than 2 shared posts', () => {
+    expect(() => kendallTauDistance(feed(['p1']), feed(['p1']))).toThrow(/at least 2 shared/);
+  });
+});
+
+describe('dominantTopic', () => {
+  it('returns the highest-weight topic', () => {
+    expect(dominantTopic({ sports: 0.2, music: 0.8 })).toBe('music');
+  });
+
+  it('breaks ties by ascending slug name for determinism', () => {
+    expect(dominantTopic({ sports: 0.5, music: 0.5 })).toBe('music');
+    expect(dominantTopic({ zzz: 0.5, aaa: 0.5 })).toBe('aaa');
+  });
+
+  it('returns null for an empty topic vector', () => {
+    expect(dominantTopic({})).toBeNull();
+  });
+});
+
+describe('minorityTopicExposure', () => {
+  function post(uri: string, topicVector: Record<string, number>): FeedPostInfo {
+    return { uri, authorDid: `author-${uri}`, topicVector };
+  }
+
+  it('matches a hand-computed exposure on a known feed and corpus support', () => {
+    // Corpus: sports 90%, music 10% -> music is tail at threshold 0.15.
+    const corpusSupport = { sports: 90, music: 10 };
+    const feedPosts: FeedPostInfo[] = [
+      post('p1', { sports: 1 }),
+      post('p2', { sports: 1 }),
+      post('p3', { music: 1 }),
+      post('p4', { sports: 1 }),
+    ];
+    const result = minorityTopicExposure(feedPosts, corpusSupport, 0.15);
+    expect(result.classifiedCount).toBe(4);
+    expect(result.exposure).toBeCloseTo(0.25, 12); // 1 of 4 posts is music (tail)
+  });
+
+  it('excludes unclassified posts from both numerator and denominator', () => {
+    const corpusSupport = { sports: 90, music: 10 };
+    const feedPosts: FeedPostInfo[] = [
+      post('p1', { music: 1 }),
+      post('p2', {}), // unclassified
+      post('p3', { sports: 1 }),
+    ];
+    const result = minorityTopicExposure(feedPosts, corpusSupport, 0.15);
+    expect(result.classifiedCount).toBe(2);
+    expect(result.totalCount).toBe(3);
+    expect(result.exposure).toBeCloseTo(0.5, 12); // 1 of 2 classified posts is music
+  });
+
+  it('a threshold of 0 marks no topic as tail (exposure 0)', () => {
+    const corpusSupport = { sports: 99, music: 1 };
+    const feedPosts: FeedPostInfo[] = [post('p1', { music: 1 })];
+    expect(minorityTopicExposure(feedPosts, corpusSupport, 0).exposure).toBe(0);
+  });
+
+  it('throws for an out-of-range threshold', () => {
+    expect(() => minorityTopicExposure([], {}, 1.5)).toThrow(/tailThreshold/);
+  });
+});
+
+describe('buildCorpusTopicSupport', () => {
+  it('counts posts by dominant topic, ignoring unclassified posts', () => {
+    const posts: FeedPostInfo[] = [
+      { uri: 'p1', authorDid: 'a', topicVector: { sports: 1 } },
+      { uri: 'p2', authorDid: 'a', topicVector: { sports: 0.6, music: 0.4 } },
+      { uri: 'p3', authorDid: 'a', topicVector: {} },
+      { uri: 'p4', authorDid: 'a', topicVector: { music: 1 } },
+    ];
+    expect(buildCorpusTopicSupport(posts)).toEqual({ sports: 2, music: 1 });
+  });
+});
+
+describe('authorHHI', () => {
+  function feedOf(authorDids: readonly string[]): FeedPostInfo[] {
+    return authorDids.map((authorDid, i) => ({ uri: `p${i}`, authorDid, topicVector: {} }));
+  }
+
+  it('matches a hand-computed HHI on a known distribution', () => {
+    // 4 posts: author A has 2 (share 0.5), B has 1 (0.25), C has 1 (0.25).
+    // HHI = 0.5^2 + 0.25^2 + 0.25^2 = 0.25 + 0.0625 + 0.0625 = 0.375
+    const feedPosts = feedOf(['A', 'A', 'B', 'C']);
+    expect(authorHHI(feedPosts)).toBeCloseTo(0.375, 12);
+  });
+
+  it('is 1 when a single author dominates the entire feed', () => {
+    expect(authorHHI(feedOf(['A', 'A', 'A']))).toBe(1);
+  });
+
+  it('is 1/N for N distinct authors with one post each (minimum concentration)', () => {
+    const feedPosts = feedOf(['A', 'B', 'C', 'D']);
+    expect(authorHHI(feedPosts)).toBeCloseTo(0.25, 12);
+  });
+
+  it('throws on an empty feed', () => {
+    expect(() => authorHHI([])).toThrow(/non-empty/);
+  });
+});
+
+describe('authorGini', () => {
+  function feedOf(authorDids: readonly string[]): FeedPostInfo[] {
+    return authorDids.map((authorDid, i) => ({ uri: `p${i}`, authorDid, topicVector: {} }));
+  }
+
+  it('is 0 when every author has an identical post count (perfect equality)', () => {
+    const feedPosts = feedOf(['A', 'A', 'B', 'B', 'C', 'C']);
+    expect(authorGini(feedPosts)).toBeCloseTo(0, 12);
+  });
+
+  it('is 0 for a single distinct author (degenerate case, not NaN)', () => {
+    const feedPosts = feedOf(['A', 'A', 'A']);
+    expect(authorGini(feedPosts)).toBe(0);
+  });
+
+  it('matches a hand-computed Gini on a known 2-author distribution', () => {
+    // A has 3 posts (share 0.75), B has 1 (0.25).
+    // shares = [0.75, 0.25]; mean = 0.5
+    // sumAbsDiff over all i,j pairs (n=2): |0.75-0.75|+|0.75-0.25|+|0.25-0.75|+|0.25-0.25| = 0+0.5+0.5+0 = 1.0
+    // meanAbsDiff = 1.0 / 4 = 0.25; gini = 0.25 / (2*0.5) = 0.25
+    const feedPosts = feedOf(['A', 'A', 'A', 'B']);
+    expect(authorGini(feedPosts)).toBeCloseTo(0.25, 12);
+  });
+
+  it('increases as concentration increases', () => {
+    const equal = feedOf(['A', 'B', 'C', 'D']);
+    const concentrated = feedOf(['A', 'A', 'A', 'B']);
+    expect(authorGini(concentrated)).toBeGreaterThan(authorGini(equal));
+  });
+
+  it('throws on an empty feed', () => {
+    expect(() => authorGini([])).toThrow(/non-empty/);
+  });
+});
+
+describe('distortionRatio', () => {
+  it('is 1.0 when treatment and reference are the same feed', () => {
+    const reference = feed(['p1', 'p2', 'p3']);
+    const scoreByUri = new Map([
+      ['p1', 10],
+      ['p2', 5],
+      ['p3', 2],
+    ]);
+    expect(distortionRatio(reference, reference, scoreByUri)).toBe(1);
+  });
+
+  it('matches a hand-computed ratio when treatment picks a different, lower-scoring post set', () => {
+    // reference feed: p1(10) + p2(5) = 15 (its own top-K quality mass)
+    // treatment feed swaps in p4 (score 3 by the reference's own yardstick) for p2
+    const reference = feed(['p1', 'p2']);
+    const treatment = feed(['p1', 'p4']);
+    const scoreByUri = new Map([
+      ['p1', 10],
+      ['p2', 5],
+      ['p4', 3],
+    ]);
+    // treatment mass by reference yardstick = 10 + 3 = 13; ratio = 13/15
+    expect(distortionRatio(treatment, reference, scoreByUri)).toBeCloseTo(13 / 15, 12);
+  });
+
+  it('treats a post missing from referenceScoreByUri as contributing 0, not an error', () => {
+    const reference = feed(['p1', 'p2']);
+    const treatment = feed(['p1', 'unknown']);
+    const scoreByUri = new Map([
+      ['p1', 10],
+      ['p2', 5],
+    ]);
+    // treatment mass = 10 (p1) + 0 (unknown, missing) = 10; ratio = 10/15
+    expect(distortionRatio(treatment, reference, scoreByUri)).toBeCloseTo(10 / 15, 12);
+  });
+
+  it('throws when the reference feed carries zero quality mass', () => {
+    const reference = feed(['p1']);
+    const treatment = feed(['p1']);
+    const scoreByUri = new Map([['p1', 0]]);
+    expect(() => distortionRatio(treatment, reference, scoreByUri)).toThrow(/division by zero/);
+  });
+});
+
+describe('determinism', () => {
+  it('every metric is a pure function: same inputs always produce the same outputs', () => {
+    const a = feed(['p1', 'p2', 'p3', 'p4']);
+    const b = feed(['p2', 'p4', 'p1', 'p3']);
+    const posts: FeedPostInfo[] = [
+      { uri: 'p1', authorDid: 'A', topicVector: { sports: 0.9 } },
+      { uri: 'p2', authorDid: 'A', topicVector: { music: 0.8 } },
+      { uri: 'p3', authorDid: 'B', topicVector: { sports: 0.5 } },
+      { uri: 'p4', authorDid: 'C', topicVector: { music: 0.3 } },
+    ];
+    const corpusSupport = buildCorpusTopicSupport(posts);
+
+    const run = () => ({
+      displacement: normalizedRankDisplacement(a, b),
+      tau: kendallTauDistance(a, b),
+      exposure: minorityTopicExposure(posts, corpusSupport, 0.4),
+      hhi: authorHHI(posts),
+      gini: authorGini(posts),
+    });
+
+    expect(run()).toEqual(run());
+  });
+});


### PR DESCRIPTION
## Summary

Implements A5 (PROJ-1486) — the governance stress-test's **three-way baseline**: on ONE fixed synthetic corpus, ranks the feed under three regimes and compares them in **feed-space** (what users actually see), answering "is a governed feed better than an engagement-maximizer, and at what cost?"

- **no-governance** — fixed default weights.
- **engagement-only** — `{engagement: 1, …}` through the real `normalizeWeights`.
- **community-governed** — the REAL aggregated weights (`aggregateVotes` → `forceEpochTransition` on A2 persona votes).

All three drive the REAL, unmodified `runScoringPipeline` (which reads weights via `getActiveEpoch()`), and the ranked feed is read from `post_scores ORDER BY total_score DESC, post_uri ASC` — the same table/tie-break `Simulation.fetchTopScoredPosts` uses. (Deliberately not Redis `feed:current`, whose write path applies presentation-layer filters orthogonal to "how did this weight vector rank the corpus" — documented in the module header.) **Harness-only:** no edits under `src/governance/` or `src/scoring/`.

## Result (honest, bounded to this corpus/seed)

60 subscribers, 200 posts, equal-persona electorate, seed 90210, top-K=50:

| regime | engagement wt | author HHI | author Gini |
|---|---|---|---|
| no-governance | 0.200 | 0.0216 | 0.038 |
| engagement-only | 1.000 | 0.0352 | 0.201 |
| community-governed | 0.120 | 0.0248 | 0.104 |

- **engagement-only vs governed** is the largest divergence (rank displacement 0.367 / Kendall-τ 0.389; only 9/50 shared posts).
- The **governed feed is measurably less author-concentrated** than engagement-only (HHI 0.0248 vs 0.0352, Gini 0.104 vs 0.201) while still capturing **~88%** of the engagement regime's own best-case quality mass (`distortionRatio(governed, engagement-only) = 0.882`) — a real but partial tradeoff, not a wash and not a collapse.
- `minorityTopicExposure` was 0 across all regimes because this corpus has no topic below the 0.15 tail threshold — an honest reading of this corpus (the metric is verified non-degenerate on separate fixtures in `feed-metrics.test.ts`).

## Scope

- `src/harness/feed-metrics.ts` (new) — pure metrics: rank churn (`normalizedRankDisplacement`/`kendallTauDistance`), `minorityTopicExposure`, `authorHHI`/`authorGini`, `distortionRatio` (definition documented in-code).
- `src/harness/baseline-comparison.ts` (new) — `runBaselineComparison` drives the three regimes; CSV writer (`regime-summary.csv` + `pairwise-churn.csv`).
- `src/harness/index.ts` — re-exports.
- `tests/harness/feed-metrics.test.ts` (new, pure, 33 tests) + `tests/harness/baseline-comparison.sim.ts` (new, Testcontainers, 7 tests).

## Verification

- `npm run build` (tsc): 0 errors.
- `npm run sim:core`: **152 tests pass** (14 files).
- Harness-only; deterministic; no attribution.

## Related

Epic PROJ-1480. Completes the A-series (A2–A5) — the governance stress-test evidence chain.


## CodeRabbit Audit

- Head SHA: 79a2c91328de5b79baeea3b9f46eadbc4efb1506
- Review history: 10 review rounds on this PR. CHANGES_REQUESTED on eebaec6 was addressed; CodeRabbit **APPROVED** the current head 79a2c91 at 2026-07-03T21:49:06Z. Review threads: 7 total, 0 unresolved (verified via GraphQL 2026-07-03).
- Gate failure cause: the `CodeRabbit` commit status on this head reads "Usage spending cap reached" (state: failure) — a billing/quota artifact. Review substance on this exact head is complete and positive; a fresh review request cannot clear a spend-cap status (pr-review-readiness: "CodeRabbit already reviewed the current head; no new review request is needed").
- All other required checks are green; coderabbit-freshness is the only red required context.
- Exemption basis: sanctioned label bypass named by the coderabbit-freshness workflow itself, applied under the standing founder pre-authorization (2026-05-31) for the audited CodeRabbit freshness exemption, with all honesty preconditions verified as above.
