### PR TITLE
[PROJ-1432] Fix post explanation run scoping

### DIFF
--- a/src/transparency/routes/counterfactual.ts
+++ b/src/transparency/routes/counterfactual.ts
@@ -31,33 +31,6 @@ const CounterfactualQuerySchema = z.object({
 /** JSON Schema for OpenAPI documentation. */
 const CounterfactualQueryJsonSchema = zodToJsonSchema(CounterfactualQuerySchema, { target: 'jsonSchema7' });
 
-interface CurrentScoringRunValue {
-  run_id?: unknown;
-  epoch_id?: unknown;
-}
-
-async function getCurrentScoringRunScope(): Promise<{ runId: string; epochId: number } | null> {
-  const result = await db.query<{ value: CurrentScoringRunValue }>(
-    `SELECT value
-     FROM system_status
-     WHERE key = 'current_scoring_run'`
-  );
-
-  const value = result.rows[0]?.value;
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
-
-  if (typeof value.run_id !== 'string' || typeof value.epoch_id !== 'number') {
-    return null;
-  }
-
-  return {
-    runId: value.run_id,
-    epochId: value.epoch_id,
-  };
-}
-
 export function registerCounterfactualRoute(app: FastifyInstance): void {
   app.get(
     '/api/transparency/counterfactual',
@@ -165,9 +138,6 @@ export function registerCounterfactualRoute(app: FastifyInstance): void {
 
         const epoch = epochResult.rows[0];
         const epochId = epoch.id;
-        const runScope = await getCurrentScoringRunScope();
-        const runIdFilter =
-          runScope && runScope.epochId === epochId ? runScope.runId : undefined;
 
         // Fetch top posts with per-component raw scores from current epoch via
         // the storage-agnostic batch reader. Fetch more than limit so rank
@@ -176,7 +146,6 @@ export function registerCounterfactualRoute(app: FastifyInstance): void {
         const batchRows = await readPostScoresForEpoch({
           epochId,
           limit: fetchLimit,
-          runId: runIdFilter,
         });
 
         const currentWeights = {

--- a/src/transparency/routes/post-explain.ts
+++ b/src/transparency/routes/post-explain.ts
@@ -19,33 +19,6 @@ import {
 } from '../../scoring/score-reader.js';
 import type { PostExplanation, TopicBreakdownEntry } from '../transparency.types.js';
 
-interface CurrentScoringRunValue {
-  run_id?: unknown;
-  epoch_id?: unknown;
-}
-
-async function getCurrentScoringRunScope(): Promise<{ runId: string; epochId: number } | null> {
-  const result = await db.query<{ value: CurrentScoringRunValue }>(
-    `SELECT value
-     FROM system_status
-     WHERE key = 'current_scoring_run'`
-  );
-
-  const value = result.rows[0]?.value;
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
-
-  if (typeof value.run_id !== 'string' || typeof value.epoch_id !== 'number') {
-    return null;
-  }
-
-  return {
-    runId: value.run_id,
-    epochId: value.epoch_id,
-  };
-}
-
 export function registerPostExplainRoute(app: FastifyInstance): void {
   app.get(
     '/api/transparency/post/:uri',
@@ -151,8 +124,6 @@ export function registerPostExplainRoute(app: FastifyInstance): void {
 
         const epochId = epochResult.rows[0].id;
         const epochDescription = epochResult.rows[0].description;
-        const runScope = await getCurrentScoringRunScope();
-        const runIdFilter = runScope?.epochId === epochId ? runScope.runId : undefined;
 
         // Decomposed score via the storage-agnostic reader. Behind
         // SCORE_LONGTABLE_READ_ENABLED it reads from post_score_components;
@@ -160,7 +131,6 @@ export function registerPostExplainRoute(app: FastifyInstance): void {
         const record = await readPostScore({
           postUri: decodedUri,
           epochId,
-          runId: runIdFilter,
         });
 
         if (!record) {

--- a/tests/post-explain-uri-validation.test.ts
+++ b/tests/post-explain-uri-validation.test.ts
@@ -38,7 +38,6 @@ describe('post explain URI validation', () => {
   it('continues normal flow for valid URI encoding', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [{ id: 5 }] })
-      .mockResolvedValueOnce({ rows: [{ value: null }] })
       .mockResolvedValueOnce({ rows: [] });
 
     const app = Fastify();

--- a/tests/transparency-run-scope.test.ts
+++ b/tests/transparency-run-scope.test.ts
@@ -48,24 +48,37 @@ describe('transparency routes current-run scoping', () => {
     await app.close();
   });
 
-  it('scopes counterfactual ranking query to current run', async () => {
+  it('does not scope counterfactual rankings to the latest incremental run', async () => {
     dbQueryMock
       .mockResolvedValueOnce({
         rows: [{ id: 2, recency_weight: 0.2, engagement_weight: 0.2, bridging_weight: 0.2, source_diversity_weight: 0.2, relevance_weight: 0.2 }],
       })
       .mockResolvedValueOnce({
-        rows: [{ value: { run_id: 'run-2', epoch_id: 2 } }],
-      })
-      .mockResolvedValueOnce({
         rows: [
           {
             post_uri: 'at://did:plc:a/app.bsky.feed.post/1',
-            recency_score: 0.8,
-            engagement_score: 0.7,
-            bridging_score: 0.6,
-            source_diversity_score: 0.5,
-            relevance_score: 0.4,
-            total_score: 0.6,
+            total_score: '0.6',
+            components_raw: {
+              recency: '0.8',
+              engagement: '0.7',
+              bridging: '0.6',
+              sourceDiversity: '0.5',
+              relevance: '0.4',
+            },
+            components_weight: {
+              recency: '0.2',
+              engagement: '0.2',
+              bridging: '0.2',
+              sourceDiversity: '0.2',
+              relevance: '0.2',
+            },
+            components_weighted: {
+              recency: '0.16',
+              engagement: '0.14',
+              bridging: '0.12',
+              sourceDiversity: '0.1',
+              relevance: '0.08',
+            },
           },
         ],
       });
@@ -79,24 +92,24 @@ describe('transparency routes current-run scoping', () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(String(dbQueryMock.mock.calls[2]?.[0])).toContain("component_details->>'run_id'");
+    expect(dbQueryMock).toHaveBeenCalledTimes(2);
+    expect(String(dbQueryMock.mock.calls[1]?.[0])).not.toContain("component_details->>'run_id'");
+    expect(dbQueryMock.mock.calls.some(([query]) => String(query).includes('system_status'))).toBe(false);
 
     await app.close();
   });
 
-  it('scopes post explanation rank calculations to current run', async () => {
+  it('resolves post explanations for scores from older incremental runs', async () => {
     // Post-PROJ-817 with read flag flipped to true:
     //   0: epoch lookup
-    //   1: current-scoring-run scope
-    //   2: readPostScore long-path #1 — post_scores header
-    //   3: readPostScore long-path #2 — post_score_components SELECT
-    //   4: rank query (total_score)  ← assertion target
-    //   5: countPostsWithComponentAbove long-path JOIN  ← assertion target
-    //   6: topic_vector (try-block, non-fatal)
-    //   7: topic_weights (try-block, non-fatal)
+    //   1: readPostScore long-path #1 — post_scores header
+    //   2: readPostScore long-path #2 — post_score_components SELECT
+    //   3: rank query (total_score)  ← assertion target
+    //   4: countPostsWithComponentAbove long-path JOIN  ← assertion target
+    //   5: topic_vector (try-block, non-fatal)
+    //   6: topic_weights (try-block, non-fatal)
     dbQueryMock
       .mockResolvedValueOnce({ rows: [{ id: 3, description: 'epoch' }] })
-      .mockResolvedValueOnce({ rows: [{ value: { run_id: 'run-3', epoch_id: 3 } }] })
       .mockResolvedValueOnce({
         rows: [
           {
@@ -105,7 +118,7 @@ describe('transparency routes current-run scoping', () => {
             total_score: 0.7,
             scored_at: '2026-02-09T00:00:00.000Z',
             classification_method: 'keyword',
-            component_details: { run_id: 'run-3' },
+            component_details: { run_id: 'older-run' },
           },
         ],
       })
@@ -140,11 +153,16 @@ describe('transparency routes current-run scoping', () => {
       communityWeight: 0.5,
       contribution: 0.4,
     });
-    // Rank-by-total query (call 4) and counterfactual long-path JOIN (call 5)
-    // both filter on component_details->>'run_id' when a scoped run exists.
+    // The initial score lookup is epoch-scoped so older incremental-run rows
+    // can resolve. Rank-by-total query (call 3) and counterfactual long-path
+    // JOIN (call 4) still filter on the resolved score row's run_id.
+    expect(String(dbQueryMock.mock.calls[1]?.[0])).not.toContain("component_details->>'run_id'");
+    expect(String(dbQueryMock.mock.calls[3]?.[0])).toContain("component_details->>'run_id'");
     expect(String(dbQueryMock.mock.calls[4]?.[0])).toContain("component_details->>'run_id'");
-    expect(String(dbQueryMock.mock.calls[5]?.[0])).toContain("component_details->>'run_id'");
-    expect(dbQueryMock).toHaveBeenCalledTimes(8);
+    expect(dbQueryMock.mock.calls[3]?.[1]).toEqual([3, 0.7, 'older-run']);
+    expect(dbQueryMock.mock.calls[4]?.[1]).toEqual([3, 'engagement', 0.6, 'older-run']);
+    expect(dbQueryMock.mock.calls.some(([query]) => String(query).includes('system_status'))).toBe(false);
+    expect(dbQueryMock).toHaveBeenCalledTimes(7);
 
     await app.close();
   });
@@ -152,7 +170,6 @@ describe('transparency routes current-run scoping', () => {
   it('does not scope post explanation rank calculations when the score row has no run id', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [{ id: 3, description: 'epoch' }] })
-      .mockResolvedValueOnce({ rows: [{ value: { run_id: 'run-3', epoch_id: 3 } }] })
       .mockResolvedValueOnce({
         rows: [
           {
@@ -188,9 +205,10 @@ describe('transparency routes current-run scoping', () => {
     });
 
     expect(response.statusCode).toBe(200);
+    expect(String(dbQueryMock.mock.calls[3]?.[0])).not.toContain("component_details->>'run_id'");
     expect(String(dbQueryMock.mock.calls[4]?.[0])).not.toContain("component_details->>'run_id'");
-    expect(String(dbQueryMock.mock.calls[5]?.[0])).not.toContain("component_details->>'run_id'");
-    expect(dbQueryMock).toHaveBeenCalledTimes(8);
+    expect(dbQueryMock.mock.calls.some(([query]) => String(query).includes('system_status'))).toBe(false);
+    expect(dbQueryMock).toHaveBeenCalledTimes(7);
 
     await app.close();
   });
@@ -198,7 +216,6 @@ describe('transparency routes current-run scoping', () => {
   it('returns a controlled error for invalid score timestamps', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [{ id: 3, description: 'epoch' }] })
-      .mockResolvedValueOnce({ rows: [{ value: { run_id: 'run-3', epoch_id: 3 } }] })
       .mockResolvedValueOnce({
         rows: [
           {


### PR DESCRIPTION
## Summary
- remove the global current-scoring-run pin from post explanation score lookup so active-epoch rows from older incremental runs resolve
- stop counterfactual rankings from limiting the active epoch to the latest incremental run
- update transparency regression coverage for older-run rows and URI validation mock flow

## Verification
- npm run build
- ./node_modules/.bin/vitest run tests/transparency-run-scope.test.ts tests/post-explain-uri-validation.test.ts
- git --no-pager diff --check
- python3 ../../.github/ops/flow.py validate-agent-lease --issue PROJ-1432 --staged --json

## Notes
- The deploy workflow migration step from PROJ-1432 is intentionally not included in this PR; that remains a separate control-plane-gated slice.
- Full local npm test was attempted in a fresh worktree but is not a useful local gate here because the ignored test env is absent and sandboxed local Redis/listen calls fail. CI should be treated as the full-suite authority for this PR.