### PR TITLE
[PROJ-1465] Ship legal docs in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,13 @@ COPY --from=builder /app/dist ./dist
 # Copy database migrations (needed at runtime)
 COPY src/db/migrations ./src/db/migrations
 
+# Copy legal documents (needed by /api/legal/* at runtime)
+COPY legal/TERMS_OF_SERVICE.md legal/PRIVACY_POLICY.md ./legal/
+RUN test -f /app/legal/TERMS_OF_SERVICE.md || { echo 'Missing /app/legal/TERMS_OF_SERVICE.md' >&2; exit 1; }; \
+    test -f /app/legal/PRIVACY_POLICY.md || { echo 'Missing /app/legal/PRIVACY_POLICY.md' >&2; exit 1; }; \
+    unexpected_file="$(find /app/legal -maxdepth 1 -type f ! -name TERMS_OF_SERVICE.md ! -name PRIVACY_POLICY.md -print -quit)"; \
+    test -z "${unexpected_file}" || { echo "Unexpected file in /app/legal: ${unexpected_file}" >&2; exit 1; }
+
 # Create non-root user for security
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
@@ -64,4 +71,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:3000/health/ready || exit 1
 
 # Start the application
-CMD ["node", "dist/index.js"]
+CMD ["sh", "-c", "test -f /app/legal/TERMS_OF_SERVICE.md || { echo 'Missing /app/legal/TERMS_OF_SERVICE.md' >&2; exit 1; }; test -f /app/legal/PRIVACY_POLICY.md || { echo 'Missing /app/legal/PRIVACY_POLICY.md' >&2; exit 1; }; exec node dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,11 +47,9 @@ COPY --from=builder /app/dist ./dist
 COPY src/db/migrations ./src/db/migrations
 
 # Copy legal documents (needed by /api/legal/* at runtime)
+COPY scripts/check-legal-docs.sh ./scripts/check-legal-docs.sh
 COPY legal/TERMS_OF_SERVICE.md legal/PRIVACY_POLICY.md ./legal/
-RUN test -f /app/legal/TERMS_OF_SERVICE.md || { echo 'Missing /app/legal/TERMS_OF_SERVICE.md' >&2; exit 1; }; \
-    test -f /app/legal/PRIVACY_POLICY.md || { echo 'Missing /app/legal/PRIVACY_POLICY.md' >&2; exit 1; }; \
-    unexpected_file="$(find /app/legal -maxdepth 1 -type f ! -name TERMS_OF_SERVICE.md ! -name PRIVACY_POLICY.md -print -quit)"; \
-    test -z "${unexpected_file}" || { echo "Unexpected file in /app/legal: ${unexpected_file}" >&2; exit 1; }
+RUN sh /app/scripts/check-legal-docs.sh /app/legal
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S appgroup && \
@@ -71,4 +69,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:3000/health/ready || exit 1
 
 # Start the application
-CMD ["sh", "-c", "test -f /app/legal/TERMS_OF_SERVICE.md || { echo 'Missing /app/legal/TERMS_OF_SERVICE.md' >&2; exit 1; }; test -f /app/legal/PRIVACY_POLICY.md || { echo 'Missing /app/legal/PRIVACY_POLICY.md' >&2; exit 1; }; exec node dist/index.js"]
+CMD ["sh", "-c", "sh /app/scripts/check-legal-docs.sh /app/legal && exec node dist/index.js"]

--- a/scripts/check-legal-docs.sh
+++ b/scripts/check-legal-docs.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: check-legal-docs.sh <legal-dir>" >&2
+  exit 2
+fi
+
+legal_dir="$1"
+tos_file="${legal_dir}/TERMS_OF_SERVICE.md"
+privacy_file="${legal_dir}/PRIVACY_POLICY.md"
+
+if [ ! -d "$legal_dir" ]; then
+  echo "Missing legal directory: $legal_dir" >&2
+  exit 1
+fi
+
+if [ ! -f "$tos_file" ] || [ -L "$tos_file" ] || [ ! -s "$tos_file" ]; then
+  echo "Missing or empty $tos_file" >&2
+  exit 1
+fi
+
+if [ ! -f "$privacy_file" ] || [ -L "$privacy_file" ] || [ ! -s "$privacy_file" ]; then
+  echo "Missing or empty $privacy_file" >&2
+  exit 1
+fi
+
+unexpected_file="$(find "$legal_dir" -mindepth 1 -maxdepth 1 ! -name TERMS_OF_SERVICE.md ! -name PRIVACY_POLICY.md -print -quit)"
+if [ -n "$unexpected_file" ]; then
+  echo "Unexpected file in $legal_dir: $unexpected_file" >&2
+  exit 1
+fi

--- a/tests/check-legal-docs-script.test.ts
+++ b/tests/check-legal-docs-script.test.ts
@@ -1,0 +1,286 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'scripts',
+  'check-legal-docs.sh',
+);
+
+function assertSpawnCompleted(result: SpawnSyncReturns<string>): void {
+  expect(result.error).toBeUndefined();
+  expect(result.status).not.toBeNull();
+  expect(result.signal).toBeNull();
+}
+
+function runCheck(legalDir: string): SpawnSyncReturns<string> {
+  return spawnSync('sh', [SCRIPT, legalDir], {
+    encoding: 'utf8',
+    timeout: 15_000,
+  });
+}
+
+function runRaw(args: string[]): SpawnSyncReturns<string> {
+  return spawnSync('sh', [SCRIPT, ...args], {
+    encoding: 'utf8',
+    timeout: 15_000,
+  });
+}
+
+function createTempRoot(): string {
+  return mkdtempSync(path.join(tmpdir(), 'corgi-legal-docs-'));
+}
+
+function writeTermsOfService(legalDir: string): void {
+  writeFileSync(path.join(legalDir, 'TERMS_OF_SERVICE.md'), '# Terms\n');
+}
+
+function writePrivacyPolicy(legalDir: string): void {
+  writeFileSync(path.join(legalDir, 'PRIVACY_POLICY.md'), '# Privacy\n');
+}
+
+function createLegalDir(): string {
+  const legalDir = createTempRoot();
+  writeTermsOfService(legalDir);
+  writePrivacyPolicy(legalDir);
+  return legalDir;
+}
+
+describe('check-legal-docs.sh', () => {
+  it('accepts exactly the two runtime legal documents', () => {
+    const legalDir = createLegalDir();
+
+    try {
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a missing terms-of-service document', () => {
+    const legalDir = createTempRoot();
+
+    try {
+      writePrivacyPolicy(legalDir);
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Missing or empty ${path.join(legalDir, 'TERMS_OF_SERVICE.md')}`,
+      );
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an empty terms-of-service document', () => {
+    const legalDir = createLegalDir();
+
+    try {
+      writeFileSync(path.join(legalDir, 'TERMS_OF_SERVICE.md'), '');
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Missing or empty ${path.join(legalDir, 'TERMS_OF_SERVICE.md')}`,
+      );
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a terms-of-service path that is a directory', () => {
+    const legalDir = createTempRoot();
+
+    try {
+      mkdirSync(path.join(legalDir, 'TERMS_OF_SERVICE.md'));
+      writePrivacyPolicy(legalDir);
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Missing or empty ${path.join(legalDir, 'TERMS_OF_SERVICE.md')}`,
+      );
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a terms-of-service path that is a symlink', () => {
+    const legalDir = createTempRoot();
+
+    try {
+      const linkedTermsPath = path.join(legalDir, 'TERMS_SOURCE.md');
+      writeFileSync(linkedTermsPath, '# Terms\n');
+      symlinkSync(linkedTermsPath, path.join(legalDir, 'TERMS_OF_SERVICE.md'));
+      writePrivacyPolicy(legalDir);
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Missing or empty ${path.join(legalDir, 'TERMS_OF_SERVICE.md')}`,
+      );
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a missing privacy policy document', () => {
+    const legalDir = createTempRoot();
+
+    try {
+      writeTermsOfService(legalDir);
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Missing or empty ${path.join(legalDir, 'PRIVACY_POLICY.md')}`,
+      );
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an empty privacy policy document', () => {
+    const legalDir = createLegalDir();
+
+    try {
+      writeFileSync(path.join(legalDir, 'PRIVACY_POLICY.md'), '');
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Missing or empty ${path.join(legalDir, 'PRIVACY_POLICY.md')}`,
+      );
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an unexpected top-level file', () => {
+    const legalDir = createLegalDir();
+
+    try {
+      const unexpectedPath = path.join(legalDir, 'README.md');
+      writeFileSync(unexpectedPath, '# README\n');
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`Unexpected file in ${legalDir}: ${unexpectedPath}`);
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an unexpected top-level hidden file', () => {
+    const legalDir = createLegalDir();
+
+    try {
+      const unexpectedPath = path.join(legalDir, '.DS_Store');
+      writeFileSync(unexpectedPath, 'finder metadata\n');
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`Unexpected file in ${legalDir}: ${unexpectedPath}`);
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an unexpected top-level directory', () => {
+    const legalDir = createLegalDir();
+
+    try {
+      const unexpectedPath = path.join(legalDir, 'archive');
+      mkdirSync(unexpectedPath);
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`Unexpected file in ${legalDir}: ${unexpectedPath}`);
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an unexpected top-level symlink', () => {
+    const legalDir = createLegalDir();
+
+    try {
+      const termsPath = path.join(legalDir, 'TERMS_OF_SERVICE.md');
+      const unexpectedPath = path.join(legalDir, 'TERMS_LINK.md');
+      symlinkSync(termsPath, unexpectedPath);
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`Unexpected file in ${legalDir}: ${unexpectedPath}`);
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an unexpected dangling top-level symlink', () => {
+    const legalDir = createLegalDir();
+
+    try {
+      const unexpectedPath = path.join(legalDir, 'MISSING_LINK.md');
+      symlinkSync(path.join(legalDir, 'missing-target.md'), unexpectedPath);
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`Unexpected file in ${legalDir}: ${unexpectedPath}`);
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects invalid argument counts', () => {
+    const result = runRaw([]);
+
+    assertSpawnCompleted(result);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Usage: check-legal-docs.sh <legal-dir>');
+  });
+
+  it('rejects too many arguments', () => {
+    const result = runRaw(['/tmp/one', '/tmp/two']);
+
+    assertSpawnCompleted(result);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Usage: check-legal-docs.sh <legal-dir>');
+  });
+
+  it('rejects a non-existent legal directory', () => {
+    const rootDir = createTempRoot();
+    const missingDir = path.join(rootDir, 'missing');
+
+    try {
+      const result = runCheck(missingDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`Missing legal directory: ${missingDir}`);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/check-legal-docs-script.test.ts
+++ b/tests/check-legal-docs-script.test.ts
@@ -66,6 +66,22 @@ describe('check-legal-docs.sh', () => {
     }
   });
 
+  it('rejects a completely empty legal directory', () => {
+    const legalDir = createTempRoot();
+
+    try {
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Missing or empty ${path.join(legalDir, 'TERMS_OF_SERVICE.md')}`,
+      );
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects a missing terms-of-service document', () => {
     const legalDir = createTempRoot();
 
@@ -160,6 +176,44 @@ describe('check-legal-docs.sh', () => {
 
     try {
       writeFileSync(path.join(legalDir, 'PRIVACY_POLICY.md'), '');
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Missing or empty ${path.join(legalDir, 'PRIVACY_POLICY.md')}`,
+      );
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a privacy-policy path that is a directory', () => {
+    const legalDir = createTempRoot();
+
+    try {
+      writeTermsOfService(legalDir);
+      mkdirSync(path.join(legalDir, 'PRIVACY_POLICY.md'));
+      const result = runCheck(legalDir);
+
+      assertSpawnCompleted(result);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `Missing or empty ${path.join(legalDir, 'PRIVACY_POLICY.md')}`,
+      );
+    } finally {
+      rmSync(legalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a privacy-policy path that is a symlink', () => {
+    const legalDir = createTempRoot();
+
+    try {
+      writeTermsOfService(legalDir);
+      const linkedPrivacyPath = path.join(legalDir, 'PRIVACY_SOURCE.md');
+      writeFileSync(linkedPrivacyPath, '# Privacy\n');
+      symlinkSync(linkedPrivacyPath, path.join(legalDir, 'PRIVACY_POLICY.md'));
       const result = runCheck(legalDir);
 
       assertSpawnCompleted(result);


### PR DESCRIPTION
## Summary
- Copy the runtime Terms of Service and Privacy Policy markdown files into the production image.
- Use a shared runtime legal-doc checker during image build and container startup.
- Fail closed when the legal directory is missing, required docs are missing or empty, required docs are symlinks, or unexpected top-level entries are present.

## Validation
- `npx vitest run tests/check-legal-docs-script.test.ts` passed: 1 test file, 18 tests.
- `docker build -t corgi-proj1465-legal-runtime .` passed; production validation layer ran `sh /app/scripts/check-legal-docs.sh /app/legal`; final image manifest `sha256:0f95298ae1c06a741783dafaddd2906668444326956d7d4cb65dc2cd8ca1f954`.
- Runtime positive check passed with exactly 2 files in `/app/legal`: `TERMS_OF_SERVICE.md` and `PRIVACY_POLICY.md`.
- Runtime document hashes: ToS `7438c52bf6e1e7cb27459bc6bd21e9221fb30dbd2c58831191bb67d94bd6bba5`; Privacy `d815d6c8ac6dc374ce9e2366e52e8e73b929e44ca7ca8dc8008fc7316842b242`.
- Runtime negative check with an empty mounted `/app/legal` exited 1 with `Missing or empty /app/legal/TERMS_OF_SERVICE.md`.
- `npm run verify` passed: 86 test files, 681 tests, backend build, CLI build, SDK builds, web lint/build, and web-next build.
- `npm run docs:verify` passed: 14 tracked docs, 26 markdown files scanned.
- `npm audit --omit=dev` passed with 0 vulnerabilities.
- `git diff --check` passed.

Closes PROJ-1465
