### PR TITLE
[PROJ-1433] Refresh live recsys metrics packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A production Bluesky custom feed where subscribers democratically vote on rankin
 
 ![Governance dashboard screenshot](docs/screenshots/dashboard.png)
 
+**Live production snapshot:** on 2026-07-07 at 03:00 UTC, `GET /api/transparency/stats` reported epoch 2 active with 3,348 scored posts, 3,007 unique authors, and 0 votes in the current epoch. See [the dated metrics packet](docs/lab/2026-07-07-recsys-live-metrics-packet.md) for commands, caveats, and counterfactual receipts.
+
 ---
 
 ## Try It

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1358,3 +1358,46 @@ The previous timeout tests proved the response path stayed non-blocking, but the
 - Kept the feed response non-blocking, but made abandoned backend work visible and gated instead of treating abort as cancellation.
 - Did not rerun the full 5-run memory gate in this entry; prior memory receipts remain valid for their recorded protocol, while future memory gates now include abandoned-backend-operation assertions.
 - Kept staging/systemd, production traffic, credentials, DNS, deploys, and shared databases untouched.
+
+## 2026-07-07 #01 — PROJ-1433 live metrics packet and paper/site refresh
+
+**Branch:** `anordstrom/proj-1433-recsys-live-metrics-and-figures-packet-is-refreshed-from`
+**Commits:** see branch history for this PROJ-1433 refresh commit
+**Files changed:** `docs/lab/2026-07-07-recsys-live-metrics-packet.md`, `README.md`, `web-next/lib/live-metrics-snapshot.ts`, `web-next/components/hero-section.tsx`, `web-next/components/dashboard-preview.tsx`, `web-next/app/demo/page.tsx`, `web-next/components/animated-section.tsx`, `web-next/components/ui/score-radar.tsx`, `tests/web-next-demo-fixtures.test.ts`, `docs/dev-journal.md`, external workspace paper draft `corgi-recsys2026-paper-draft.md`.
+
+### What changed
+
+- Added a dated PROJ-1433 metrics packet with public production endpoint commands, exact timestamps, raw metric values, counterfactual summaries, and caveats.
+- Updated README and Corgi `web-next` homepage/demo copy from fake or stale figures to the 2026-07-07 live-production snapshot.
+- Replaced the demo walkthrough's fake epoch 47 / 312-vote fixture with epoch 2, 3,348 scored posts, 3,007 unique authors, 0 current-epoch votes, and a public rank-1 post explanation receipt.
+- Fixed two pre-existing `web-next` TypeScript validation blockers in animation and radar tooltip components so the branch can pass direct `npx tsc --noEmit`, not only the configured Next build that skips type validation.
+- Addressed CodeRabbit's valid major privacy finding by anonymizing public UI receipt fixtures, moving shared snapshot values into `web-next/lib/live-metrics-snapshot.ts`, and adding a regression guard that rejects live Bluesky handles, DIDs, AT-URIs, and known receipt text in the public demo fixtures.
+- Refreshed the external demo-paper draft with the same live numbers and downgraded the old Sybil-resistance paragraph to bounded simulation/mechanism evidence.
+
+### Why
+
+PROJ-1433 requires every metric used in the paper or site to have a receipt and to be classified as live production, demo-seeded, or simulation-derived. The prior paper draft still carried a 2026-06-27 snapshot and an obsolete Sybil-resistance claim pointing at a test file that no longer exists.
+
+### Measurements
+
+- `curl -sS https://feed.corgi.network/health`: pass, `{"status":"ok"}`.
+- `curl -sS https://feed.corgi.network/api/transparency/stats`: pass; epoch 2 active, 3,348 scored posts, 3,007 unique authors, 0 current-epoch votes, median total score 0.5312066730135393.
+- `curl -sS https://feed.corgi.network/api/governance/weights`: pass; recency 0.25, engagement 0.20, bridging 0.10, source diversity 0.10, relevance 0.35; epoch description says forced transition from epoch 1 with 2 votes.
+- `curl -sS ...getFeedSkeleton...limit=100`: pass; returned 100 post URIs plus a cursor, proving a served page rather than total feed size.
+- `curl -sS ...counterfactual?recency=0.2&engagement=0.5&bridging=0.1&source_diversity=0.1&relevance=0.1&limit=10`: pass; 4 posts moved up, 6 moved down, max rank change 13, average absolute rank change 4.1.
+- `curl -sS .../api/transparency/post/<rank-1-uri>`: pass; total score 0.8486208006784361, community rank 1, pure-engagement rank 4, component rows recorded in the metrics packet.
+- `git diff --check`: pass.
+- `npx tsc --noEmit` from `web-next`: pass after the narrow type-only fixes.
+- `npx vitest tests/web-next-demo-fixtures.test.ts --run` with dummy non-production env: pass, 1 file / 1 test.
+- `npm run docs:verify`: pass, 14 tracked docs / 29 markdown files scanned.
+- Full `npm run verify` with dummy non-production env and local loopback/IPC permission: pass, including root build, 98 files / 879 Vitest tests, CLI build, MCP-local skip, SDK build, SDK fixture, web lint/build, and web-next build.
+- CodeRabbit CLI `coderabbit review --agent -t committed -c .coderabbit.yaml`: returned 2 issues before this fix pass, 1 valid major privacy issue and 1 trivial drift issue; both were addressed in the public UI fixture update.
+- Fresh strategyproofness simulation rerun did not produce a result in this worktree: Vitest/Testcontainers failed before tests with `Could not find a working container runtime strategy`, even though `docker info` showed Docker Desktop server 29.4.3 running.
+
+### Decisions & alternatives
+
+- Used only public endpoints for production receipts; no admin export, database query, cookie, bearer token, or host mutation was used.
+- Treated the feed skeleton `limit=100` result as a served-page receipt, not total corpus volume.
+- Removed hard Sybil-resistance wording from refreshed paper/site claims. Current safe wording is simulation/mechanism evidence only, and the metrics packet preserves the PROJ-1551 warning that synthetic voter populations do not prove real electorate behavior, Sybil resistance, personhood, or abuse resistance.
+- Kept the `web-next` type fixes scoped to validation blockers discovered during PROJ-1433; no visual behavior was intentionally changed in those two helper components.
+- Kept real handles, post text, DIDs, and source URIs in the internal metrics packet only; public site and paper copy now use anonymized receipt labels while preserving the numeric proof.

--- a/docs/lab/2026-07-07-recsys-live-metrics-packet.md
+++ b/docs/lab/2026-07-07-recsys-live-metrics-packet.md
@@ -1,0 +1,164 @@
+# 2026-07-07 RecSys Live Metrics Packet
+
+Status: PROJ-1433 production refresh
+Collected: 2026-07-07T03:00:57Z
+Environment: live production, `https://feed.corgi.network`
+Repo base: `origin/main` at `da2450fd28a014f2e94d2c46721f6e42413c0ad2`
+Admin scope: public endpoints only; no admin cookies, bearer tokens, database credentials, or export secrets used
+
+## Receipt Commands
+
+```bash
+curl -sS https://feed.corgi.network/health
+curl -sS https://feed.corgi.network/xrpc/app.bsky.feed.describeFeedGenerator
+curl -sS https://feed.corgi.network/api/governance/weights
+curl -sS https://feed.corgi.network/api/transparency/stats
+curl -sS 'https://feed.corgi.network/xrpc/app.bsky.feed.getFeedSkeleton?feed=at%3A%2F%2Fdid%3Aplc%3Aamzyknmm4auxijvykyfgznw2%2Fapp.bsky.feed.generator%2Fcommunity-gov&limit=100'
+curl -sS 'https://feed.corgi.network/api/transparency/counterfactual?recency=0.2&engagement=0.5&bridging=0.1&source_diversity=0.1&relevance=0.1&limit=10'
+curl -sS 'https://feed.corgi.network/api/transparency/post/at%3A%2F%2Fdid%3Aplc%3Adv4t4hwp2bzm2ruyim2hpssa%2Fapp.bsky.feed.post%2F3mpaxvobadc2e'
+curl -sS 'https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=at%3A%2F%2Fdid%3Aplc%3Adv4t4hwp2bzm2ruyim2hpssa%2Fapp.bsky.feed.post%2F3mpaxvobadc2e&depth=0'
+```
+
+## Live Production Claims
+
+| Metric | Value | Receipt |
+|---|---:|---|
+| Health | `{"status":"ok"}` | `/health` |
+| Feed generator DID | `did:plc:amzyknmm4auxijvykyfgznw2` | `describeFeedGenerator` |
+| Feed URI | `at://did:plc:amzyknmm4auxijvykyfgznw2/app.bsky.feed.generator/community-gov` | `describeFeedGenerator` |
+| Active epoch | `2` | `/api/transparency/stats`, `/api/governance/weights` |
+| Epoch status | `active` | `/api/transparency/stats` |
+| Epoch created | `2026-02-07T21:38:06.153Z` | `/api/transparency/stats` |
+| Current epoch votes | `0` | `/api/transparency/stats`, `/api/governance/weights` |
+| Scored posts | `3,348` | `/api/transparency/stats` |
+| Unique authors | `3,007` | `/api/transparency/stats` |
+| Average bridging score | `0.7276394256303051` | `/api/transparency/stats` |
+| Average engagement score | `0.3226783153401943` | `/api/transparency/stats` |
+| Median bridging score | `0.9186194653299917` | `/api/transparency/stats` |
+| Median total score | `0.5312066730135393` | `/api/transparency/stats` |
+| Served feed page | `100` posts returned with a cursor for `limit=100` | `getFeedSkeleton` |
+
+Current weights from both public governance and transparency endpoints:
+
+```json
+{
+  "recency": 0.25,
+  "engagement": 0.2,
+  "bridging": 0.1,
+  "source_diversity": 0.1,
+  "relevance": 0.35
+}
+```
+
+The governance weights endpoint reports the epoch description as `FORCED transition from epoch 1 with 2 votes.` The current epoch itself has `0` votes, so public copy should not imply current live voter participation beyond that historical transition note.
+
+## Post Explanation Example
+
+Production post:
+
+```text
+at://did:plc:dv4t4hwp2bzm2ruyim2hpssa/app.bsky.feed.post/3mpaxvobadc2e
+```
+
+Public Bluesky appview context:
+
+- Author handle: `elainesque.bsky.social`
+- Post text: `Also, this is just funny.`
+- Created: `2026-06-27T07:49:32.745Z`
+- Indexed: `2026-06-27T07:49:34.782Z`
+- Engagement at appview fetch time: 10 likes, 6 reposts, 0 replies, 0 quotes
+
+Corgi explanation receipt:
+
+| Field | Value |
+|---|---:|
+| Epoch | `2` |
+| Rank | `1` |
+| Total score | `0.8486208006784361` |
+| Scored at | `2026-06-27T08:33:59.649Z` |
+| Classification method | `keyword` |
+| Pure-engagement rank | `4` |
+| Community-governed rank | `1` |
+| Governance difference | `+3` positions |
+
+Component breakdown:
+
+| Component | Raw | Weight | Weighted |
+|---|---:|---:|---:|
+| Recency | `0.971876150243864` | `0.25` | `0.242969037560966` |
+| Engagement | `0.45384361090898817` | `0.2` | `0.09076872218179764` |
+| Bridging | `0.9988304093567251` | `0.1` | `0.09988304093567252` |
+| Source diversity | `1` | `0.1` | `0.1` |
+| Relevance | `0.9` | `0.35` | `0.315` |
+
+Topic breakdown for relevance:
+
+```json
+{
+  "decentralized-social": {
+    "postScore": 1,
+    "communityWeight": 0.9,
+    "contribution": 0.9
+  }
+}
+```
+
+## Counterfactual Example
+
+Engagement-heavy alternate weights:
+
+```json
+{
+  "recency": 0.2,
+  "engagement": 0.5,
+  "bridging": 0.1,
+  "source_diversity": 0.1,
+  "relevance": 0.1
+}
+```
+
+Receipt summary for the top 10 current posts:
+
+| Metric | Value |
+|---|---:|
+| Posts compared | `10` |
+| Posts moved up | `4` |
+| Posts moved down | `6` |
+| Posts unchanged | `0` |
+| Max absolute rank change | `13` |
+| Average absolute rank change | `4.1` |
+
+Largest observed movement in this receipt: the current rank-1 post above moves to rank 14 under the engagement-heavy counterfactual (`rank_delta = -13`).
+
+## Simulation-Derived And Local Claims
+
+These are not live production metrics:
+
+- PROJ-1551 local validation reported a recorded Jetstream replay fixture of 1,200 events at 3,105.67 events/sec with 0 drops, 0 handler errors, 0 state mismatches, 0 outcome mismatches, handler p95 0.76 ms, 569 durable state mutations, and cursor lag 793 microseconds.
+- PROJ-1551 local validation reported a real-route voting load of 8,000 POSTs across 500 synthetic users with 8,000/8,000 `200` responses, p95 48.18 ms, exact database/audit reconciliation, exact aggregate rows after the 429 phase, cleanup failures 0, and correct per-DID 429 behavior.
+- PROJ-1551 local validation reported a compiled prod-parity memory gate of 5 runs per mode at 10,000 requests and 100 connections with normal/no-op median after-GC RSS deltas 36.43 MB / 30.14 MB.
+
+Do not turn those into production-scale claims. The PROJ-1551 lab note explicitly says synthetic voter populations are useful for mechanism evidence but do not prove real electorate behavior, Sybil resistance, personhood, or abuse resistance.
+
+Current strategyproofness evidence is also simulation-derived. The source fixture in `tests/harness/strategyproofness.sim.ts` pins a bounded result for the real `aggregateVotes` implementation: at `n=10`, sincere L1 is approximately `0.302`, strategic L1 approximately `0.236`, and the manipulation direction is positive for that documented population. This is evidence about manipulability of one synthetic population, not a Sybil-resistance proof.
+
+Fresh local rerun attempt for `tests/harness/strategyproofness.sim.ts` on this branch did not produce a simulation result. `./node_modules/.bin/vitest run --config vitest.harness.config.ts tests/harness/strategyproofness.sim.ts` failed before tests with `Could not find a working container runtime strategy` from Testcontainers, even though `docker info` reported Docker Desktop server `29.4.3` running. The paper/site should therefore avoid fresh-run claims for this simulation until the harness is rerun successfully.
+
+## Branch Verification
+
+Final branch verification used dummy non-production environment values and local loopback/IPC permission. `npm run verify` passed on 2026-07-07 at 03:27 UTC, including root TypeScript build, 98 Vitest files / 879 tests, CLI build, MCP-local skip check, SDK build, SDK fixture, Vite lint/build, and Next static build. A direct `web-next` TypeScript guard also passed with `npx tsc --noEmit` after the branch fixed two pre-existing component type errors that Next's configured build does not enforce. The extra Vitest file guards the public `web-next` demo fixtures against accidentally committing live Bluesky handles, DIDs, AT-URIs, or known receipt text.
+
+## Copy Guidance
+
+Safe live-production wording:
+
+- "As of 2026-07-07 03:00 UTC, Corgi's public transparency endpoint reported epoch 2 active with 3,348 scored posts, 3,007 unique authors, and 0 votes in the current epoch."
+- "A public post explanation shows a rank-1 production post with total score 0.8486, all five component contributions, and a pure-engagement counterfactual rank of 4."
+- "An engagement-heavy counterfactual over the top 10 current posts moved 4 posts up and 6 down, with max rank change 13 and average absolute change 4.1."
+
+Unsafe wording:
+
+- "Corgi has proven live Sybil resistance."
+- "The 8,000-request vote-load receipt proves production voting capacity."
+- "The feed contains only 100 posts." The public skeleton receipt proves a 100-item served page with cursor, not total feed size.
+- "Current epoch weights were produced by current live voters." The active epoch has 0 current-epoch votes; the epoch description references a forced transition from epoch 1 with 2 votes.

--- a/tests/web-next-demo-fixtures.test.ts
+++ b/tests/web-next-demo-fixtures.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const UI_FIXTURE_FILES = [
+  path.join(REPO_ROOT, 'web-next', 'app', 'demo', 'page.tsx'),
+  path.join(REPO_ROOT, 'web-next', 'components', 'dashboard-preview.tsx'),
+  path.join(REPO_ROOT, 'web-next', 'lib', 'live-metrics-snapshot.ts'),
+];
+
+const FORBIDDEN_LIVE_RECEIPT_PATTERNS = [
+  { name: 'AT Protocol post URI', pattern: /at:\/\/did:/i },
+  { name: 'PLC DID', pattern: /did:plc:/i },
+  { name: 'Bluesky handle', pattern: /[a-z0-9._-]+\.bsky\.social/i },
+  { name: 'known receipt handle', pattern: /\b(elainesque|waveforest|kdinjenzenvo|sonicstadium)\b/i },
+  { name: 'known receipt text', pattern: /Also, this is just funny\./i },
+];
+
+describe('web-next demo receipt fixtures', () => {
+  it('keeps public UI fixtures anonymized while preserving numeric receipts', () => {
+    for (const fixtureFile of UI_FIXTURE_FILES) {
+      const content = readFileSync(fixtureFile, 'utf8');
+
+      for (const forbiddenPattern of FORBIDDEN_LIVE_RECEIPT_PATTERNS) {
+        expect(
+          content,
+          `${path.relative(REPO_ROOT, fixtureFile)} contains ${forbiddenPattern.name}`,
+        ).not.toMatch(forbiddenPattern.pattern);
+      }
+    }
+  });
+});

--- a/web-next/app/demo/page.tsx
+++ b/web-next/app/demo/page.tsx
@@ -3,73 +3,53 @@
 import { useState } from "react"
 import Link from "next/link"
 import { AppShell } from "@/components/app-shell"
-import { ScoreBreakdown, type ScoreComponent } from "@/components/ui/score-breakdown"
+import { ScoreBreakdown } from "@/components/ui/score-breakdown"
 import { ScoreRadar } from "@/components/ui/score-radar"
 import { WeightBar } from "@/components/ui/weight-bar"
 import { StatusChip } from "@/components/ui/status-chip"
+import { LIVE_FEED_POSTS, LIVE_METRICS_SNAPSHOT, LIVE_RANK_ONE_EXPLANATION } from "@/lib/live-metrics-snapshot"
 
 // ── Mock data (seam-exact field names) ───────────────────────────────────────
 
 const MOCK_STATS = {
-  epoch: { id: 47, phase: "voting" as const },
+  epoch: { id: LIVE_METRICS_SNAPSHOT.epochId, phase: "live" as const },
   feed_stats: {
-    total_posts_scored: 1240,
-    unique_authors: 318,
-    avg_bridging: 0.41,
-    avg_total: 0.57,
+    total_posts_scored: LIVE_METRICS_SNAPSHOT.scoredPosts,
+    unique_authors: LIVE_METRICS_SNAPSHOT.uniqueAuthors,
+    avg_bridging: LIVE_METRICS_SNAPSHOT.avgBridging,
+    avg_engagement: LIVE_METRICS_SNAPSHOT.avgEngagement,
+    median_bridging: LIVE_METRICS_SNAPSHOT.medianBridging,
+    median_total: LIVE_METRICS_SNAPSHOT.medianTotal,
   },
-  governance: { votes_this_epoch: 312 },
-  metrics: {
-    author_gini: 0.34,
-    vs_chronological_overlap: 0.61,
-    vs_engagement_overlap: 0.44,
-  },
+  governance: { votes_this_epoch: LIVE_METRICS_SNAPSHOT.votesThisEpoch },
 }
 
-const MOCK_WEIGHTS = {
-  recency: 0.35,
-  engagement: 0.25,
-  bridging: 0.20,
-  source_diversity: 0.15,
-  relevance: 0.05,
-}
+const MOCK_WEIGHTS = LIVE_METRICS_SNAPSHOT.weights
 
-const MOCK_TOPICS = [
-  { slug: "machine-learning", name: "Machine learning", currentWeight: 0.62, communityAvg: 0.55 },
-  { slug: "open-source", name: "Open source", currentWeight: 0.71, communityAvg: 0.60 },
-  { slug: "science", name: "Science", currentWeight: 0.50, communityAvg: 0.50 },
-  { slug: "politics", name: "Politics", currentWeight: 0.32, communityAvg: 0.41 },
-  { slug: "sports", name: "Sports", currentWeight: 0.28, communityAvg: 0.35 },
-]
+const MOCK_TOPICS = LIVE_METRICS_SNAPSHOT.topics
 
 const MOCK_EXPLANATION = {
-  post_uri: "at://did:plc:abc123/app.bsky.feed.post/xyz789",
-  author: "maya.bsky.social",
-  text: "New benchmark results show open-source models closing the gap with proprietary ones on reasoning tasks.",
-  epoch_id: 47,
-  total_score: 0.57,
-  rank: 3,
-  components: [
-    { key: "recency",          label: "Recency",          raw_score: 0.82, weight: 0.35, weighted: 0.287 },
-    { key: "engagement",       label: "Engagement",       raw_score: 0.61, weight: 0.25, weighted: 0.153 },
-    { key: "bridging",         label: "Bridging",         raw_score: 0.44, weight: 0.20, weighted: 0.088 },
-    { key: "source_diversity", label: "Source diversity", raw_score: 0.29, weight: 0.15, weighted: 0.044 },
-    { key: "relevance",        label: "Relevance",        raw_score: 0.40, weight: 0.05, weighted: 0.020 },
-  ] satisfies ScoreComponent[],
+  post_uri: LIVE_RANK_ONE_EXPLANATION.receiptId,
+  author: LIVE_RANK_ONE_EXPLANATION.authorLabel,
+  text: LIVE_RANK_ONE_EXPLANATION.text,
+  epoch_id: LIVE_RANK_ONE_EXPLANATION.epochId,
+  total_score: LIVE_RANK_ONE_EXPLANATION.totalScore,
+  rank: LIVE_RANK_ONE_EXPLANATION.rank,
+  components: LIVE_RANK_ONE_EXPLANATION.components,
   governance_weights: MOCK_WEIGHTS,
   counterfactual: {
-    pure_engagement_rank: 9,
-    community_governed_rank: 3,
-    difference: 6,
+    pure_engagement_rank: LIVE_RANK_ONE_EXPLANATION.counterfactual.pureEngagementRank,
+    community_governed_rank: LIVE_RANK_ONE_EXPLANATION.counterfactual.communityGovernedRank,
+    difference: LIVE_RANK_ONE_EXPLANATION.counterfactual.difference,
   },
 }
 
 // ── Step definitions ──────────────────────────────────────────────────────────
 
 const STEPS = [
-  { id: 1, label: "Feed stats",    title: "How the feed performed" },
+  { id: 1, label: "Feed stats",    title: "Live production snapshot" },
   { id: 2, label: "Live feed",     title: "Posts ranked by your community" },
-  { id: 3, label: "Topic weights", title: "What your community amplifies" },
+  { id: 3, label: "Topic signal",  title: "What this post matched" },
   { id: 4, label: "Explain a post", title: "See exactly why this post ranked" },
   { id: 5, label: "Counterfactual", title: "What would have happened instead" },
 ]
@@ -77,17 +57,17 @@ const STEPS = [
 // ── Step content components ───────────────────────────────────────────────────
 
 function StepStats() {
-  const { feed_stats, epoch, governance, metrics } = MOCK_STATS
+  const { feed_stats, epoch, governance } = MOCK_STATS
   const stats = [
     { label: "Posts scored",    value: feed_stats.total_posts_scored.toLocaleString() },
     { label: "Authors",         value: feed_stats.unique_authors.toLocaleString() },
     { label: "Votes this round", value: governance.votes_this_epoch.toLocaleString() },
-    { label: "Avg score",       value: feed_stats.avg_total.toFixed(2) },
+    { label: "Median score",    value: feed_stats.median_total.toFixed(2) },
   ]
   const health = [
-    { label: "vs Chronological", value: `${Math.round(metrics.vs_chronological_overlap * 100)}%`, hint: "posts in common with time-sorted" },
-    { label: "vs Engagement-only", value: `${Math.round(metrics.vs_engagement_overlap * 100)}%`, hint: "posts in common with likes-sorted" },
-    { label: "Author diversity", value: metrics.author_gini.toFixed(2), hint: "Gini coefficient — lower is more diverse" },
+    { label: "Average bridging", value: feed_stats.avg_bridging.toFixed(2), hint: "mean raw bridging score" },
+    { label: "Average engagement", value: feed_stats.avg_engagement.toFixed(2), hint: "mean raw engagement score" },
+    { label: "Median bridging", value: feed_stats.median_bridging.toFixed(2), hint: "middle raw bridging score" },
   ]
   return (
     <div className="flex flex-col gap-8">
@@ -115,19 +95,13 @@ function StepStats() {
       </div>
       <div className="flex items-center gap-2 p-4 rounded-xl bg-biscuit/60 text-sm text-foreground/60 leading-relaxed">
         <StatusChip phase={epoch.phase} />
-        <span>Round #{epoch.id} is currently open for voting. Results update once the round closes.</span>
+        <span>Round #{epoch.id} is active. Snapshot refreshed from public endpoints on {LIVE_METRICS_SNAPSHOT.collectedAtLabel}.</span>
       </div>
     </div>
   )
 }
 
-const MOCK_FEED_POSTS = [
-  { rank: 1, author: "alice.bsky.social",  score: 0.74, text: "Open-source models are catching up fast — new reasoning benchmark shows parity with GPT-4." },
-  { rank: 2, author: "bob.bsky.social",    score: 0.68, text: "Science funding in the EU set to double over the next decade. Good news for open research." },
-  { rank: 3, author: "maya.bsky.social",   score: 0.57, text: "New benchmark results show open-source models closing the gap with proprietary ones." },
-  { rank: 4, author: "carlos.bsky.social", score: 0.51, text: "Some really thoughtful work coming out of independent ML labs this week." },
-  { rank: 5, author: "dana.bsky.social",   score: 0.44, text: "Bridging score matters more than you'd think — posts that connect different clusters bubble up." },
-]
+const MOCK_FEED_POSTS = LIVE_FEED_POSTS
 
 function StepFeed() {
   return (
@@ -149,7 +123,7 @@ function StepFeed() {
         </div>
       ))}
       <p className="text-xs text-foreground/40 text-center pt-2">
-        Ranked by community-voted weights, not engagement alone.
+        Top scored posts from the anonymized {LIVE_METRICS_SNAPSHOT.collectedAtLabel} production transparency receipt.
       </p>
     </div>
   )
@@ -159,7 +133,7 @@ function StepTopics() {
   return (
     <div className="flex flex-col gap-6">
       <p className="text-sm text-foreground/55 leading-relaxed">
-        Your community votes to boost or suppress topics. The bar shows the community&apos;s current applied weight — right of centre boosts, left reduces.
+        The explained post carried a stored relevance topic breakdown. This is public explanation data for that post, not a claim about all current feed topics.
       </p>
       <div className="flex flex-col">
         {MOCK_TOPICS.map((t) => {
@@ -219,7 +193,7 @@ function StepExplain() {
           <ScoreBreakdown
             components={components}
             total_score={total_score}
-            epochLabel="Round #47 · community weighted"
+            epochLabel="Round #2 · community weighted"
           />
         </div>
         <div className="lg:w-72 rounded-xl border border-border bg-card px-4 py-4 flex flex-col gap-3">
@@ -261,7 +235,7 @@ function StepCounterfactual() {
   return (
     <div className="flex flex-col gap-8">
       <p className="text-sm text-foreground/55 leading-relaxed max-w-xl">
-        This post scored <span className="font-mono font-semibold text-foreground">{total_score.toFixed(2)}</span> and ranked <span className="font-mono font-semibold text-foreground">#{rank}</span>. Without community governance, a pure engagement sort would have placed it much lower.
+        This post scored <span className="font-mono font-semibold text-foreground">{total_score.toFixed(2)}</span> and ranked <span className="font-mono font-semibold text-foreground">#{rank}</span>. A pure engagement sort would have placed it at rank #{counterfactual.pure_engagement_rank}.
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         {boxes.map((box) => (
@@ -275,13 +249,13 @@ function StepCounterfactual() {
       <div className="rounded-xl bg-biscuit/60 border border-border px-5 py-4 flex flex-col gap-2">
         <p className="text-sm font-semibold text-foreground">This is what community governance means.</p>
         <p className="text-sm text-foreground/55 leading-relaxed">
-          The feed ranked this post higher not because it got the most likes, but because your community voted for bridging and source diversity — and this post delivered on both.
+          The feed ranked this post higher because the active epoch weights relevance and recency alongside engagement, and the stored explanation exposes each contribution.
         </p>
         <Link
           href="/vote"
           className="mt-1 inline-flex items-center gap-1.5 text-sm font-semibold text-primary hover:text-primary-dark transition-colors"
         >
-          Cast your vote in Round #47
+          Cast your vote in Round #2
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
@@ -318,7 +292,7 @@ export default function DemoPage() {
           <span className="text-[10px] font-mono uppercase tracking-widest text-foreground/35">Guided walkthrough</span>
           <h1 className="font-display text-2xl font-bold text-foreground tracking-normal">How Corgi works</h1>
           <p className="text-sm text-foreground/50 leading-relaxed max-w-lg">
-            A 5-step tour of the transparency loop — from community votes to ranked posts. Read-only; your feed is unchanged.
+            A 5-step tour using a dated live-production receipt. Read-only; your feed is unchanged.
           </p>
         </div>
 
@@ -425,7 +399,7 @@ export default function DemoPage() {
 
         {/* ── Footer note ──────────────────────────────────────────── */}
         <p className="text-center text-xs text-foreground/35 leading-relaxed">
-          This walkthrough uses sample data. Your actual feed data is live at{" "}
+          This walkthrough uses the 2026-07-07 live-production metrics packet. Current feed data is live at{" "}
           <Link href="/dashboard" className="text-primary hover:underline">Overview</Link>.
         </p>
       </div>

--- a/web-next/components/animated-section.tsx
+++ b/web-next/components/animated-section.tsx
@@ -1,20 +1,23 @@
 "use client"
 
 import { motion } from "framer-motion"
-import type { HTMLAttributes, ReactNode } from "react"
+import type { HTMLMotionProps } from "framer-motion"
+import type { ReactNode } from "react"
 
-interface AnimatedSectionProps extends HTMLAttributes<HTMLDivElement> {
+interface AnimatedSectionProps extends Omit<HTMLMotionProps<"div">, "children"> {
   children: ReactNode
   delay?: number
 }
 
-export function AnimatedSection({ children, className, delay = 0, ...props }: AnimatedSectionProps) {
+export function AnimatedSection({ children, className, delay, ...props }: AnimatedSectionProps) {
+  const transitionDelay = delay ?? 0
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20, scale: 0.98 }}
       whileInView={{ opacity: 1, y: 0, scale: 1 }}
       viewport={{ once: true }}
-      transition={{ duration: 0.8, ease: [0.33, 1, 0.68, 1], delay }}
+      transition={{ duration: 0.8, ease: [0.33, 1, 0.68, 1], delay: transitionDelay }}
       className={className}
       {...props}
     >

--- a/web-next/components/dashboard-preview.tsx
+++ b/web-next/components/dashboard-preview.tsx
@@ -1,12 +1,14 @@
 // Score breakdown card — the "killer feature" UI shown below the hero
+import { LIVE_METRICS_SNAPSHOT, LIVE_RANK_ONE_EXPLANATION } from "@/lib/live-metrics-snapshot"
+
 export function DashboardPreview() {
-  const signals = [
-    { label: "Recency", weight: 0.35, value: "+0.82", bar: 82, positive: true },
-    { label: "Reply depth", weight: 0.25, value: "+0.61", bar: 61, positive: true },
-    { label: "Follows author", weight: 0.20, value: "+0.44", bar: 44, positive: true },
-    { label: "Quality score", weight: 0.15, value: "+0.29", bar: 29, positive: true },
-    { label: "Spam risk", weight: 0.05, value: "-0.04", bar: 8, positive: false },
-  ]
+  const signals = LIVE_RANK_ONE_EXPLANATION.components.map((component) => ({
+    label: component.label,
+    weight: component.weight,
+    value: `+${component.raw_score.toFixed(2)}`,
+    bar: Math.round(component.raw_score * 100),
+    positive: component.weighted >= 0,
+  }))
 
   return (
     <div className="w-full max-w-[900px]">
@@ -22,14 +24,14 @@ export function DashboardPreview() {
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1 flex-wrap">
-              <span className="text-foreground font-semibold text-sm">alicia.bsky.social</span>
-              <span className="text-foreground/40 text-xs">· 2h</span>
+              <span className="text-foreground font-semibold text-sm">{LIVE_RANK_ONE_EXPLANATION.authorLabel}</span>
+              <span className="text-foreground/40 text-xs">· anonymized live receipt</span>
               <span className="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-semibold font-mono">
-                score: 0.57
+                score: {LIVE_RANK_ONE_EXPLANATION.totalScore.toFixed(2)}
               </span>
             </div>
             <p className="text-foreground/80 text-sm leading-relaxed">
-              The governance model here is genuinely novel. Watching my community vote in real time and see the feed update is unlike anything else on Bluesky.
+              {LIVE_RANK_ONE_EXPLANATION.text}
             </p>
           </div>
         </div>
@@ -67,10 +69,10 @@ export function DashboardPreview() {
           {/* Total — anchors the right side and ties the math together */}
           <div className="mt-4 pt-3 border-t border-border flex items-center justify-between">
             <span className="text-foreground text-sm font-semibold">Total score</span>
-            <span className="text-primary text-lg font-bold font-mono">+0.57</span>
+            <span className="text-primary text-lg font-bold font-mono">+{LIVE_RANK_ONE_EXPLANATION.totalScore.toFixed(2)}</span>
           </div>
           <div className="mt-3 flex items-center justify-between">
-            <span className="text-foreground/40 text-xs">Epoch #47 · voted by 312 members</span>
+            <span className="text-foreground/40 text-xs">Epoch #{LIVE_METRICS_SNAPSHOT.epochId} · refreshed {LIVE_METRICS_SNAPSHOT.collectedAtLabel}</span>
             <button className="text-primary text-xs font-medium hover:underline">
               View epoch history &rarr;
             </button>

--- a/web-next/components/hero-section.tsx
+++ b/web-next/components/hero-section.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
+import { LIVE_METRICS_SNAPSHOT } from "@/lib/live-metrics-snapshot"
 
 export function HeroSection() {
   return (
@@ -166,6 +167,9 @@ export function HeroSection() {
       {/* Trust line */}
       <p className="relative z-10 mt-3 text-xs text-foreground/40 font-medium">
         Free &middot; App-password secure &middot; Leave anytime
+      </p>
+      <p className="relative z-10 mt-2 text-xs text-foreground/40 font-medium">
+        Live snapshot, {LIVE_METRICS_SNAPSHOT.collectedAtLabel}: {LIVE_METRICS_SNAPSHOT.scoredPosts.toLocaleString()} scored posts &middot; {LIVE_METRICS_SNAPSHOT.uniqueAuthors.toLocaleString()} authors &middot; epoch {LIVE_METRICS_SNAPSHOT.epochId} active
       </p>
     </section>
   )

--- a/web-next/components/ui/score-radar.tsx
+++ b/web-next/components/ui/score-radar.tsx
@@ -43,10 +43,10 @@ function GingerDot(props: {
 /* Custom tooltip */
 function RadarTooltip({ active, payload }: {
   active?: boolean
-  payload?: Array<{ name: string; value: number; dataKey: string }>
+  payload?: Array<{ name: string; value: number; dataKey: string; payload?: { label?: string } }>
 }) {
   if (!active || !payload?.length) return null
-  const label = payload[0]?.payload?.label as string | undefined
+  const label = payload[0]?.payload?.label
   return (
     <div className="rounded-lg border border-border bg-card shadow-md px-3 py-2 text-xs">
       <p className="font-semibold text-foreground mb-1.5">{label}</p>

--- a/web-next/lib/live-metrics-snapshot.ts
+++ b/web-next/lib/live-metrics-snapshot.ts
@@ -1,0 +1,86 @@
+export interface LiveScoreComponent {
+  key: string
+  label: string
+  raw_score: number
+  weight: number
+  weighted: number
+}
+
+export interface LiveFeedPostPreview {
+  rank: number
+  author: string
+  score: number
+  text: string
+}
+
+export const LIVE_METRICS_SNAPSHOT = {
+  collectedAtLabel: "2026-07-07 03:00 UTC",
+  epochId: 2,
+  scoredPosts: 3348,
+  uniqueAuthors: 3007,
+  votesThisEpoch: 0,
+  avgBridging: 0.7276394256303051,
+  avgEngagement: 0.3226783153401943,
+  medianBridging: 0.9186194653299917,
+  medianTotal: 0.5312066730135393,
+  weights: {
+    recency: 0.25,
+    engagement: 0.20,
+    bridging: 0.10,
+    source_diversity: 0.10,
+    relevance: 0.35,
+  },
+  topics: [
+    { slug: "decentralized-social", name: "Decentralized social", currentWeight: 0.90, communityAvg: 0.90 },
+  ],
+}
+
+export const LIVE_RANK_ONE_COMPONENTS: LiveScoreComponent[] = [
+  { key: "recency", label: "Recency", raw_score: 0.971876150243864, weight: 0.25, weighted: 0.242969037560966 },
+  { key: "engagement", label: "Engagement", raw_score: 0.45384361090898817, weight: 0.20, weighted: 0.09076872218179764 },
+  { key: "bridging", label: "Bridging", raw_score: 0.9988304093567251, weight: 0.10, weighted: 0.09988304093567252 },
+  { key: "source_diversity", label: "Source diversity", raw_score: 1, weight: 0.10, weighted: 0.1 },
+  { key: "relevance", label: "Relevance", raw_score: 0.9, weight: 0.35, weighted: 0.315 },
+]
+
+export const LIVE_RANK_ONE_EXPLANATION = {
+  receiptId: "production-receipt-rank-1",
+  authorLabel: "Production receipt 001",
+  text: "Public post text redacted; score structure preserved from the production receipt.",
+  epochId: LIVE_METRICS_SNAPSHOT.epochId,
+  totalScore: 0.8486208006784361,
+  rank: 1,
+  components: LIVE_RANK_ONE_COMPONENTS,
+  counterfactual: {
+    pureEngagementRank: 4,
+    communityGovernedRank: 1,
+    difference: 3,
+  },
+}
+
+export const LIVE_FEED_POSTS: LiveFeedPostPreview[] = [
+  {
+    rank: 1,
+    author: "Production receipt 001",
+    score: 0.8486208006784361,
+    text: "Public post text redacted; score structure preserved from the production receipt.",
+  },
+  {
+    rank: 2,
+    author: "Production receipt 002",
+    score: 0.8447181456756023,
+    text: "Public post text redacted; receipt categorized around AI terminology and LLMs.",
+  },
+  {
+    rank: 3,
+    author: "Production receipt 003",
+    score: 0.8447074117364842,
+    text: "Public post text redacted; receipt categorized around generative AI adoption.",
+  },
+  {
+    rank: 4,
+    author: "Production receipt 004",
+    score: 0.8442263537240301,
+    text: "Public post text redacted; receipt categorized around generative AI in games.",
+  },
+]


### PR DESCRIPTION
## Summary

- Add a dated PROJ-1433 live metrics packet sourced from public production endpoints.
- Refresh README and Corgi `web-next` demo/homepage figures from fake or stale values to the 2026-07-07 03:00 UTC production snapshot.
- Replace the demo's fake epoch 47 / 312-vote fixture with epoch 2, 3,348 scored posts, 3,007 unique authors, 0 current-epoch votes, and an anonymized rank-1 production receipt.
- Centralize the shared live snapshot values for `web-next` and add a regression guard that prevents live handles, DIDs, AT-URIs, or known receipt text from being committed into public UI fixtures.
- Fix two pre-existing `web-next` TypeScript validation blockers found while checking the final branch.

## Receipts

- `GET /api/transparency/stats`: epoch 2 active, 3,348 scored posts, 3,007 unique authors, 0 current-epoch votes, median total score 0.5312066730135393.
- `GET /api/governance/weights`: recency 0.25, engagement 0.20, bridging 0.10, source diversity 0.10, relevance 0.35.
- `getFeedSkeleton` with `limit=100`: returned 100 post URIs plus a cursor, recorded only as a served-page receipt.
- Engagement-heavy counterfactual top-10 receipt: 4 posts moved up, 6 moved down, max rank change 13, average absolute rank change 4.1.

## Validation

- `git diff --check`
- `npm run docs:verify`
- `npx tsc --noEmit` from `web-next`
- `npx vitest tests/web-next-demo-fixtures.test.ts --run` with dummy non-production env: 1 file / 1 test.
- `npm run verify` with dummy non-production env and loopback/IPC permission: root build, 98 Vitest files / 879 tests, CLI build, MCP-local skip, SDK build, SDK fixture, web lint/build, and web-next build.
- CodeRabbit CLI returned 2 issues on the first committed review; the valid major privacy issue and trivial drift issue are addressed in this update.

## Notes

- Production receipts used public endpoints only: no admin export, database query, cookie, bearer token, or host mutation.
- Sybil-resistance wording is intentionally caveated as simulation/mechanism evidence, not a live production proof.
- Real source handles/URIs remain in the internal lab packet only; public site/demo copy uses anonymized receipt labels while preserving numeric proof.
- The external workspace paper draft `corgi-recsys2026-paper-draft.md` was refreshed locally with the same numbers, but it is outside this repository and not part of this PR.

Linear: PROJ-1433
