### PR TITLE
[PROJ-1433] Refresh live recsys metrics packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A production Bluesky custom feed where subscribers democratically vote on rankin
 
 ![Governance dashboard screenshot](docs/screenshots/dashboard.png)
 
+**Live production snapshot:** on 2026-07-07 at 03:00 UTC, `GET /api/transparency/stats` reported epoch 2 active with 3,348 scored posts, 3,007 unique authors, and 0 votes in the current epoch. See [the dated metrics packet](docs/lab/2026-07-07-recsys-live-metrics-packet.md) for commands, caveats, and counterfactual receipts.
+
 ---
 
 ## Try It

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A production Bluesky custom feed where subscribers democratically vote on rankin
 
 ![Governance dashboard screenshot](docs/screenshots/dashboard.png)
 
-**Live production snapshot:** on 2026-07-07 at 03:00 UTC, `GET /api/transparency/stats` reported epoch 2 active with 3,348 scored posts, 3,007 unique authors, and 0 votes in the current epoch. See [the dated metrics packet](docs/lab/2026-07-07-recsys-live-metrics-packet.md) for commands, caveats, and counterfactual receipts.
+**Live production snapshot:** on 2026-07-07 at 03:00 UTC, `GET /api/transparency/stats` reported epoch 2 active with 3,348 scored posts, 3,007 unique authors, and 0 votes in the current epoch. See [the dated anonymized metrics packet](docs/lab/2026-07-07-recsys-live-metrics-packet.md) for commands, caveats, and counterfactual receipts.
 
 ---
 

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1400,4 +1400,4 @@ PROJ-1433 requires every metric used in the paper or site to have a receipt and 
 - Treated the feed skeleton `limit=100` result as a served-page receipt, not total corpus volume.
 - Removed hard Sybil-resistance wording from refreshed paper/site claims. Current safe wording is simulation/mechanism evidence only, and the metrics packet preserves the PROJ-1551 warning that synthetic voter populations do not prove real electorate behavior, Sybil resistance, personhood, or abuse resistance.
 - Kept the `web-next` type fixes scoped to validation blockers discovered during PROJ-1433; no visual behavior was intentionally changed in those two helper components.
-- Kept real handles, post text, DIDs, and source URIs in the internal metrics packet only; public site and paper copy now use anonymized receipt labels while preserving the numeric proof.
+- Redacted the example production post's raw handle, post text, DID, and source URI from the public metrics packet and UI fixtures; public site and paper copy now use anonymized receipt labels while preserving the numeric proof.

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1358,3 +1358,46 @@ The previous timeout tests proved the response path stayed non-blocking, but the
 - Kept the feed response non-blocking, but made abandoned backend work visible and gated instead of treating abort as cancellation.
 - Did not rerun the full 5-run memory gate in this entry; prior memory receipts remain valid for their recorded protocol, while future memory gates now include abandoned-backend-operation assertions.
 - Kept staging/systemd, production traffic, credentials, DNS, deploys, and shared databases untouched.
+
+## 2026-07-07 #01 — PROJ-1433 live metrics packet and paper/site refresh
+
+**Branch:** `dev/PROJ-1433-recsys-live-metrics-packet`
+**Commits:** see branch history for this PROJ-1433 refresh commit
+**Files changed:** `docs/lab/2026-07-07-recsys-live-metrics-packet.md`, `README.md`, `web-next/lib/live-metrics-snapshot.ts`, `web-next/components/hero-section.tsx`, `web-next/components/dashboard-preview.tsx`, `web-next/app/demo/page.tsx`, `web-next/components/animated-section.tsx`, `web-next/components/ui/score-radar.tsx`, `tests/web-next-demo-fixtures.test.ts`, `docs/dev-journal.md`, external workspace paper draft `corgi-recsys2026-paper-draft.md`.
+
+### What changed
+
+- Added a dated PROJ-1433 metrics packet with public production endpoint commands, exact timestamps, raw metric values, counterfactual summaries, and caveats.
+- Updated README and Corgi `web-next` homepage/demo copy from fake or stale figures to the 2026-07-07 live-production snapshot.
+- Replaced the demo walkthrough's fake epoch 47 / 312-vote fixture with epoch 2, 3,348 scored posts, 3,007 unique authors, 0 current-epoch votes, and a public rank-1 post explanation receipt.
+- Fixed two pre-existing `web-next` TypeScript validation blockers in animation and radar tooltip components so the branch can pass direct `npx tsc --noEmit`, not only the configured Next build that skips type validation.
+- Addressed CodeRabbit's valid major privacy finding by anonymizing public UI receipt fixtures, moving shared snapshot values into `web-next/lib/live-metrics-snapshot.ts`, and adding a regression guard that rejects live Bluesky handles, DIDs, AT-URIs, and known receipt text in the public demo fixtures.
+- Refreshed the external demo-paper draft with the same live numbers and downgraded the old Sybil-resistance paragraph to bounded simulation/mechanism evidence.
+
+### Why
+
+PROJ-1433 requires every metric used in the paper or site to have a receipt and to be classified as live production, demo-seeded, or simulation-derived. The prior paper draft still carried a 2026-06-27 snapshot and an obsolete Sybil-resistance claim pointing at a test file that no longer exists.
+
+### Measurements
+
+- `curl -sS https://feed.corgi.network/health`: pass, `{"status":"ok"}`.
+- `curl -sS https://feed.corgi.network/api/transparency/stats`: pass; epoch 2 active, 3,348 scored posts, 3,007 unique authors, 0 current-epoch votes, median total score 0.5312066730135393.
+- `curl -sS https://feed.corgi.network/api/governance/weights`: pass; recency 0.25, engagement 0.20, bridging 0.10, source diversity 0.10, relevance 0.35; epoch description says forced transition from epoch 1 with 2 votes.
+- `curl -sS ...getFeedSkeleton...limit=100`: pass; returned 100 post URIs plus a cursor, proving a served page rather than total feed size.
+- `curl -sS ...counterfactual?recency=0.2&engagement=0.5&bridging=0.1&source_diversity=0.1&relevance=0.1&limit=10`: pass; 4 posts moved up, 6 moved down, max rank change 13, average absolute rank change 4.1.
+- `curl -sS .../api/transparency/post/<rank-1-uri>`: pass; total score 0.8486208006784361, community rank 1, pure-engagement rank 4, component rows recorded in the metrics packet.
+- `git diff --check`: pass.
+- `npx tsc --noEmit` from `web-next`: pass after the narrow type-only fixes.
+- `npx vitest tests/web-next-demo-fixtures.test.ts --run`: pass, 1 file / 7 tests.
+- `npm run docs:verify`: pass, 14 tracked docs / 29 markdown files scanned.
+- Full `npm run verify` with dummy non-production env and local loopback/IPC permission: pass, including root build, 98 files / 885 Vitest tests, CLI build, MCP-local skip, SDK build, SDK fixture, web lint/build, and web-next build.
+- CodeRabbit CLI `coderabbit review --agent -t committed -c .coderabbit.yaml`: returned 2 issues before this fix pass, 1 valid major privacy issue and 1 trivial drift issue; both were addressed in the public UI fixture update.
+- Fresh strategyproofness simulation rerun did not produce a result in this worktree: Vitest/Testcontainers failed before tests with `Could not find a working container runtime strategy`, even though `docker info` showed Docker Desktop server 29.4.3 running.
+
+### Decisions & alternatives
+
+- Used only public endpoints for production receipts; no admin export, database query, cookie, bearer token, or host mutation was used.
+- Treated the feed skeleton `limit=100` result as a served-page receipt, not total corpus volume.
+- Removed hard Sybil-resistance wording from refreshed paper/site claims. Current safe wording is simulation/mechanism evidence only, and the metrics packet preserves the PROJ-1551 warning that synthetic voter populations do not prove real electorate behavior, Sybil resistance, personhood, or abuse resistance.
+- Kept the `web-next` type fixes scoped to validation blockers discovered during PROJ-1433; no visual behavior was intentionally changed in those two helper components.
+- Kept real handles, post text, DIDs, and source URIs in the internal metrics packet only; public site and paper copy now use anonymized receipt labels while preserving the numeric proof.

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1388,9 +1388,9 @@ PROJ-1433 requires every metric used in the paper or site to have a receipt and 
 - `curl -sS .../api/transparency/post/<rank-1-uri>`: pass; total score 0.8486208006784361, community rank 1, pure-engagement rank 4, component rows recorded in the metrics packet.
 - `git diff --check`: pass.
 - `npx tsc --noEmit` from `web-next`: pass after the narrow type-only fixes.
-- `npx vitest tests/web-next-demo-fixtures.test.ts --run`: pass, 1 file / 7 tests.
+- `npx vitest tests/web-next-demo-fixtures.test.ts --run`: pass, 1 file / 11 tests.
 - `npm run docs:verify`: pass, 14 tracked docs / 29 markdown files scanned.
-- Full `npm run verify` with dummy non-production env and local loopback/IPC permission: pass, including root build, 98 files / 885 Vitest tests, CLI build, MCP-local skip, SDK build, SDK fixture, web lint/build, and web-next build.
+- Full `npm run verify` with dummy non-production env and local loopback/IPC permission: pass, including root build, 98 files / 889 Vitest tests, CLI build, MCP-local skip, SDK build, SDK fixture, web lint/build, and web-next build.
 - CodeRabbit CLI `coderabbit review --agent -t committed -c .coderabbit.yaml`: returned 2 issues before this fix pass, 1 valid major privacy issue and 1 trivial drift issue; both were addressed in the public UI fixture update.
 - Fresh strategyproofness simulation rerun did not produce a result in this worktree: Vitest/Testcontainers failed before tests with `Could not find a working container runtime strategy`, even though `docker info` showed Docker Desktop server 29.4.3 running.
 

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1388,9 +1388,9 @@ PROJ-1433 requires every metric used in the paper or site to have a receipt and 
 - `curl -sS .../api/transparency/post/<rank-1-uri>`: pass; total score 0.8486208006784361, community rank 1, pure-engagement rank 4, component rows recorded in the metrics packet.
 - `git diff --check`: pass.
 - `npx tsc --noEmit` from `web-next`: pass after the narrow type-only fixes.
-- `npx vitest tests/web-next-demo-fixtures.test.ts --run`: pass, 1 file / 11 tests.
+- `npx vitest tests/web-next-demo-fixtures.test.ts --run`: pass, 1 file / 12 tests.
 - `npm run docs:verify`: pass, 14 tracked docs / 29 markdown files scanned.
-- Full `npm run verify` with dummy non-production env and local loopback/IPC permission: pass, including root build, 98 files / 889 Vitest tests, CLI build, MCP-local skip, SDK build, SDK fixture, web lint/build, and web-next build.
+- Full `npm run verify` with dummy non-production env and local loopback/IPC permission: pass, including root build, 98 files / 890 Vitest tests, CLI build, MCP-local skip, SDK build, SDK fixture, web lint/build, and web-next build.
 - CodeRabbit CLI `coderabbit review --agent -t committed -c .coderabbit.yaml`: returned 2 issues before this fix pass, 1 valid major privacy issue and 1 trivial drift issue; both were addressed in the public UI fixture update.
 - Fresh strategyproofness simulation rerun did not produce a result in this worktree: Vitest/Testcontainers failed before tests with `Could not find a working container runtime strategy`, even though `docker info` showed Docker Desktop server 29.4.3 running.
 

--- a/docs/lab/2026-07-07-recsys-live-metrics-packet.md
+++ b/docs/lab/2026-07-07-recsys-live-metrics-packet.md
@@ -146,7 +146,7 @@ Fresh local rerun attempt for `tests/harness/strategyproofness.sim.ts` on this b
 
 ## Branch Verification
 
-Final branch verification used dummy non-production environment values and local loopback/IPC permission. `npm run verify` passed on 2026-07-07 at 04:10 UTC, including root TypeScript build, 98 Vitest files / 885 tests, CLI build, MCP-local skip check, SDK build, SDK fixture, Vite lint/build, and Next static build. A direct `web-next` TypeScript guard also passed with `npx tsc --noEmit` after the branch fixed two pre-existing component type errors that Next's configured build does not enforce. The extra Vitest file guards the public `web-next` demo fixtures against accidentally committing live Bluesky handles, DIDs, AT-URIs, known receipt text, and receipt drift.
+Final branch verification used dummy non-production environment values and local loopback/IPC permission. `npm run verify` passed on 2026-07-07 at 04:10 UTC, including root TypeScript build, 98 Vitest files / 889 tests, CLI build, MCP-local skip check, SDK build, SDK fixture, Vite lint/build, and Next static build. A direct `web-next` TypeScript guard also passed with `npx tsc --noEmit` after the branch fixed two pre-existing component type errors that Next's configured build does not enforce. The extra Vitest file guards the public `web-next` demo fixtures against accidentally committing live Bluesky handles, DIDs, AT-URIs, known receipt text, and receipt drift.
 
 ## Copy Guidance
 

--- a/docs/lab/2026-07-07-recsys-live-metrics-packet.md
+++ b/docs/lab/2026-07-07-recsys-live-metrics-packet.md
@@ -146,7 +146,7 @@ Fresh local rerun attempt for `tests/harness/strategyproofness.sim.ts` on this b
 
 ## Branch Verification
 
-Final branch verification used dummy non-production environment values and local loopback/IPC permission. `npm run verify` passed on 2026-07-07 at 04:10 UTC, including root TypeScript build, 98 Vitest files / 889 tests, CLI build, MCP-local skip check, SDK build, SDK fixture, Vite lint/build, and Next static build. A direct `web-next` TypeScript guard also passed with `npx tsc --noEmit` after the branch fixed two pre-existing component type errors that Next's configured build does not enforce. The extra Vitest file guards the public `web-next` demo fixtures against accidentally committing live Bluesky handles, DIDs, AT-URIs, known receipt text, and receipt drift.
+Final branch verification used dummy non-production environment values and local loopback/IPC permission. `npm run verify` passed on 2026-07-07 at 08:36 UTC, including root TypeScript build, 98 Vitest files / 890 tests, CLI build, MCP-local skip check, SDK build, SDK fixture, Vite lint/build, and Next static build. A direct `web-next` TypeScript guard also passed with `npx tsc --noEmit` after the branch fixed two pre-existing component type errors that Next's configured build does not enforce. The extra Vitest file guards the public `web-next` demo fixtures against accidentally committing live Bluesky handles, DIDs, AT-URIs, known receipt text, and receipt drift.
 
 ## Copy Guidance
 

--- a/docs/lab/2026-07-07-recsys-live-metrics-packet.md
+++ b/docs/lab/2026-07-07-recsys-live-metrics-packet.md
@@ -5,6 +5,7 @@ Collected: 2026-07-07T03:00:57Z
 Environment: live production, `https://feed.corgi.network`
 Repo base: `origin/main` at `da2450fd28a014f2e94d2c46721f6e42413c0ad2`
 Admin scope: public endpoints only; no admin cookies, bearer tokens, database credentials, or export secrets used
+Public redaction boundary: this tracked packet preserves numeric production receipts, endpoint provenance, timestamps, ranks, and caveats, but redacts raw DIDs, AT-URIs, author handles, and post text. Unredacted identifiers belong only in operator-local/private review notes.
 
 ## Receipt Commands
 
@@ -13,10 +14,10 @@ curl -sS https://feed.corgi.network/health
 curl -sS https://feed.corgi.network/xrpc/app.bsky.feed.describeFeedGenerator
 curl -sS https://feed.corgi.network/api/governance/weights
 curl -sS https://feed.corgi.network/api/transparency/stats
-curl -sS 'https://feed.corgi.network/xrpc/app.bsky.feed.getFeedSkeleton?feed=at%3A%2F%2Fdid%3Aplc%3Aamzyknmm4auxijvykyfgznw2%2Fapp.bsky.feed.generator%2Fcommunity-gov&limit=100'
+curl -sS 'https://feed.corgi.network/xrpc/app.bsky.feed.getFeedSkeleton?feed=<redacted-public-feed-uri>&limit=100'
 curl -sS 'https://feed.corgi.network/api/transparency/counterfactual?recency=0.2&engagement=0.5&bridging=0.1&source_diversity=0.1&relevance=0.1&limit=10'
-curl -sS 'https://feed.corgi.network/api/transparency/post/at%3A%2F%2Fdid%3Aplc%3Adv4t4hwp2bzm2ruyim2hpssa%2Fapp.bsky.feed.post%2F3mpaxvobadc2e'
-curl -sS 'https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=at%3A%2F%2Fdid%3Aplc%3Adv4t4hwp2bzm2ruyim2hpssa%2Fapp.bsky.feed.post%2F3mpaxvobadc2e&depth=0'
+curl -sS 'https://feed.corgi.network/api/transparency/post/<redacted-production-receipt-uri>'
+curl -sS 'https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=<redacted-production-receipt-uri>&depth=0'
 ```
 
 ## Live Production Claims
@@ -24,8 +25,8 @@ curl -sS 'https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=at%3A
 | Metric | Value | Receipt |
 |---|---:|---|
 | Health | `{"status":"ok"}` | `/health` |
-| Feed generator DID | `did:plc:amzyknmm4auxijvykyfgznw2` | `describeFeedGenerator` |
-| Feed URI | `at://did:plc:amzyknmm4auxijvykyfgznw2/app.bsky.feed.generator/community-gov` | `describeFeedGenerator` |
+| Feed generator identity | redacted in the public tracked packet | `describeFeedGenerator` |
+| Feed URI | redacted in the public tracked packet | `describeFeedGenerator` |
 | Active epoch | `2` | `/api/transparency/stats`, `/api/governance/weights` |
 | Epoch status | `active` | `/api/transparency/stats` |
 | Epoch created | `2026-02-07T21:38:06.153Z` | `/api/transparency/stats` |
@@ -54,19 +55,18 @@ The governance weights endpoint reports the epoch description as `FORCED transit
 
 ## Post Explanation Example
 
-Production post:
+Anonymized production explanation receipt:
 
 ```text
-at://did:plc:dv4t4hwp2bzm2ruyim2hpssa/app.bsky.feed.post/3mpaxvobadc2e
+production-receipt-rank-1
 ```
 
-Public Bluesky appview context:
+Public Bluesky appview context was fetched for the raw production URI during collection, but the tracked packet intentionally does not publish the example post URI, DID, author handle, or text.
 
-- Author handle: `elainesque.bsky.social`
-- Post text: `Also, this is just funny.`
-- Created: `2026-06-27T07:49:32.745Z`
-- Indexed: `2026-06-27T07:49:34.782Z`
-- Engagement at appview fetch time: 10 likes, 6 reposts, 0 replies, 0 quotes
+- Author label: `Production receipt 001`
+- Post text: redacted from the public tracked packet
+- Raw production URI: redacted from the public tracked packet
+- Raw author DID and handle: redacted from the public tracked packet
 
 Corgi explanation receipt:
 
@@ -128,7 +128,7 @@ Receipt summary for the top 10 current posts:
 | Max absolute rank change | `13` |
 | Average absolute rank change | `4.1` |
 
-Largest observed movement in this receipt: the current rank-1 post above moves to rank 14 under the engagement-heavy counterfactual (`rank_delta = -13`).
+Largest observed movement in this receipt: anonymized `production-receipt-rank-1` moves from current rank 1 to rank 14 under the engagement-heavy counterfactual (`rank_delta = -13`).
 
 ## Simulation-Derived And Local Claims
 
@@ -153,7 +153,7 @@ Final branch verification used dummy non-production environment values and local
 Safe live-production wording:
 
 - "As of 2026-07-07 03:00 UTC, Corgi's public transparency endpoint reported epoch 2 active with 3,348 scored posts, 3,007 unique authors, and 0 votes in the current epoch."
-- "A public post explanation shows a rank-1 production post with total score 0.8486, all five component contributions, and a pure-engagement counterfactual rank of 4."
+- "An anonymized public production explanation shows a rank-1 post with total score 0.8486, all five component contributions, and a pure-engagement counterfactual rank of 4."
 - "An engagement-heavy counterfactual over the top 10 current posts moved 4 posts up and 6 down, with max rank change 13 and average absolute change 4.1."
 
 Unsafe wording:

--- a/docs/lab/2026-07-07-recsys-live-metrics-packet.md
+++ b/docs/lab/2026-07-07-recsys-live-metrics-packet.md
@@ -1,0 +1,164 @@
+# 2026-07-07 RecSys Live Metrics Packet
+
+Status: PROJ-1433 production refresh
+Collected: 2026-07-07T03:00:57Z
+Environment: live production, `https://feed.corgi.network`
+Repo base: `origin/main` at `da2450fd28a014f2e94d2c46721f6e42413c0ad2`
+Admin scope: public endpoints only; no admin cookies, bearer tokens, database credentials, or export secrets used
+
+## Receipt Commands
+
+```bash
+curl -sS https://feed.corgi.network/health
+curl -sS https://feed.corgi.network/xrpc/app.bsky.feed.describeFeedGenerator
+curl -sS https://feed.corgi.network/api/governance/weights
+curl -sS https://feed.corgi.network/api/transparency/stats
+curl -sS 'https://feed.corgi.network/xrpc/app.bsky.feed.getFeedSkeleton?feed=at%3A%2F%2Fdid%3Aplc%3Aamzyknmm4auxijvykyfgznw2%2Fapp.bsky.feed.generator%2Fcommunity-gov&limit=100'
+curl -sS 'https://feed.corgi.network/api/transparency/counterfactual?recency=0.2&engagement=0.5&bridging=0.1&source_diversity=0.1&relevance=0.1&limit=10'
+curl -sS 'https://feed.corgi.network/api/transparency/post/at%3A%2F%2Fdid%3Aplc%3Adv4t4hwp2bzm2ruyim2hpssa%2Fapp.bsky.feed.post%2F3mpaxvobadc2e'
+curl -sS 'https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=at%3A%2F%2Fdid%3Aplc%3Adv4t4hwp2bzm2ruyim2hpssa%2Fapp.bsky.feed.post%2F3mpaxvobadc2e&depth=0'
+```
+
+## Live Production Claims
+
+| Metric | Value | Receipt |
+|---|---:|---|
+| Health | `{"status":"ok"}` | `/health` |
+| Feed generator DID | `did:plc:amzyknmm4auxijvykyfgznw2` | `describeFeedGenerator` |
+| Feed URI | `at://did:plc:amzyknmm4auxijvykyfgznw2/app.bsky.feed.generator/community-gov` | `describeFeedGenerator` |
+| Active epoch | `2` | `/api/transparency/stats`, `/api/governance/weights` |
+| Epoch status | `active` | `/api/transparency/stats` |
+| Epoch created | `2026-02-07T21:38:06.153Z` | `/api/transparency/stats` |
+| Current epoch votes | `0` | `/api/transparency/stats`, `/api/governance/weights` |
+| Scored posts | `3,348` | `/api/transparency/stats` |
+| Unique authors | `3,007` | `/api/transparency/stats` |
+| Average bridging score | `0.7276394256303051` | `/api/transparency/stats` |
+| Average engagement score | `0.3226783153401943` | `/api/transparency/stats` |
+| Median bridging score | `0.9186194653299917` | `/api/transparency/stats` |
+| Median total score | `0.5312066730135393` | `/api/transparency/stats` |
+| Served feed page | `100` posts returned with a cursor for `limit=100` | `getFeedSkeleton` |
+
+Current weights from both public governance and transparency endpoints:
+
+```json
+{
+  "recency": 0.25,
+  "engagement": 0.2,
+  "bridging": 0.1,
+  "source_diversity": 0.1,
+  "relevance": 0.35
+}
+```
+
+The governance weights endpoint reports the epoch description as `FORCED transition from epoch 1 with 2 votes.` The current epoch itself has `0` votes, so public copy should not imply current live voter participation beyond that historical transition note.
+
+## Post Explanation Example
+
+Production post:
+
+```text
+at://did:plc:dv4t4hwp2bzm2ruyim2hpssa/app.bsky.feed.post/3mpaxvobadc2e
+```
+
+Public Bluesky appview context:
+
+- Author handle: `elainesque.bsky.social`
+- Post text: `Also, this is just funny.`
+- Created: `2026-06-27T07:49:32.745Z`
+- Indexed: `2026-06-27T07:49:34.782Z`
+- Engagement at appview fetch time: 10 likes, 6 reposts, 0 replies, 0 quotes
+
+Corgi explanation receipt:
+
+| Field | Value |
+|---|---:|
+| Epoch | `2` |
+| Rank | `1` |
+| Total score | `0.8486208006784361` |
+| Scored at | `2026-06-27T08:33:59.649Z` |
+| Classification method | `keyword` |
+| Pure-engagement rank | `4` |
+| Community-governed rank | `1` |
+| Governance difference | `+3` positions |
+
+Component breakdown:
+
+| Component | Raw | Weight | Weighted |
+|---|---:|---:|---:|
+| Recency | `0.971876150243864` | `0.25` | `0.242969037560966` |
+| Engagement | `0.45384361090898817` | `0.2` | `0.09076872218179764` |
+| Bridging | `0.9988304093567251` | `0.1` | `0.09988304093567252` |
+| Source diversity | `1` | `0.1` | `0.1` |
+| Relevance | `0.9` | `0.35` | `0.315` |
+
+Topic breakdown for relevance:
+
+```json
+{
+  "decentralized-social": {
+    "postScore": 1,
+    "communityWeight": 0.9,
+    "contribution": 0.9
+  }
+}
+```
+
+## Counterfactual Example
+
+Engagement-heavy alternate weights:
+
+```json
+{
+  "recency": 0.2,
+  "engagement": 0.5,
+  "bridging": 0.1,
+  "source_diversity": 0.1,
+  "relevance": 0.1
+}
+```
+
+Receipt summary for the top 10 current posts:
+
+| Metric | Value |
+|---|---:|
+| Posts compared | `10` |
+| Posts moved up | `4` |
+| Posts moved down | `6` |
+| Posts unchanged | `0` |
+| Max absolute rank change | `13` |
+| Average absolute rank change | `4.1` |
+
+Largest observed movement in this receipt: the current rank-1 post above moves to rank 14 under the engagement-heavy counterfactual (`rank_delta = -13`).
+
+## Simulation-Derived And Local Claims
+
+These are not live production metrics:
+
+- PROJ-1551 local validation reported a recorded Jetstream replay fixture of 1,200 events at 3,105.67 events/sec with 0 drops, 0 handler errors, 0 state mismatches, 0 outcome mismatches, handler p95 0.76 ms, 569 durable state mutations, and cursor lag 793 microseconds.
+- PROJ-1551 local validation reported a real-route voting load of 8,000 POSTs across 500 synthetic users with 8,000/8,000 `200` responses, p95 48.18 ms, exact database/audit reconciliation, exact aggregate rows after the 429 phase, cleanup failures 0, and correct per-DID 429 behavior.
+- PROJ-1551 local validation reported a compiled prod-parity memory gate of 5 runs per mode at 10,000 requests and 100 connections with normal/no-op median after-GC RSS deltas 36.43 MB / 30.14 MB.
+
+Do not turn those into production-scale claims. The PROJ-1551 lab note explicitly says synthetic voter populations are useful for mechanism evidence but do not prove real electorate behavior, Sybil resistance, personhood, or abuse resistance.
+
+Current strategyproofness evidence is also simulation-derived. The source fixture in `tests/harness/strategyproofness.sim.ts` pins a bounded result for the real `aggregateVotes` implementation: at `n=10`, sincere L1 is approximately `0.302`, strategic L1 approximately `0.236`, and the manipulation direction is positive for that documented population. This is evidence about manipulability of one synthetic population, not a Sybil-resistance proof.
+
+Fresh local rerun attempt for `tests/harness/strategyproofness.sim.ts` on this branch did not produce a simulation result. `./node_modules/.bin/vitest run --config vitest.harness.config.ts tests/harness/strategyproofness.sim.ts` failed before tests with `Could not find a working container runtime strategy` from Testcontainers, even though `docker info` reported Docker Desktop server `29.4.3` running. The paper/site should therefore avoid fresh-run claims for this simulation until the harness is rerun successfully.
+
+## Branch Verification
+
+Final branch verification used dummy non-production environment values and local loopback/IPC permission. `npm run verify` passed on 2026-07-07 at 04:10 UTC, including root TypeScript build, 98 Vitest files / 885 tests, CLI build, MCP-local skip check, SDK build, SDK fixture, Vite lint/build, and Next static build. A direct `web-next` TypeScript guard also passed with `npx tsc --noEmit` after the branch fixed two pre-existing component type errors that Next's configured build does not enforce. The extra Vitest file guards the public `web-next` demo fixtures against accidentally committing live Bluesky handles, DIDs, AT-URIs, known receipt text, and receipt drift.
+
+## Copy Guidance
+
+Safe live-production wording:
+
+- "As of 2026-07-07 03:00 UTC, Corgi's public transparency endpoint reported epoch 2 active with 3,348 scored posts, 3,007 unique authors, and 0 votes in the current epoch."
+- "A public post explanation shows a rank-1 production post with total score 0.8486, all five component contributions, and a pure-engagement counterfactual rank of 4."
+- "An engagement-heavy counterfactual over the top 10 current posts moved 4 posts up and 6 down, with max rank change 13 and average absolute change 4.1."
+
+Unsafe wording:
+
+- "Corgi has proven live Sybil resistance."
+- "The 8,000-request vote-load receipt proves production voting capacity."
+- "The feed contains only 100 posts." The public skeleton receipt proves a 100-item served page with cursor, not total feed size.
+- "Current epoch weights were produced by current live voters." The active epoch has 0 current-epoch votes; the epoch description references a forced transition from epoch 1 with 2 votes.

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -4,10 +4,21 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import pg from 'pg';
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 const { Client } = pg;
 const MIGRATIONS_DIR = path.resolve(process.cwd(), 'src/db/migrations');
 const MIGRATIONS_TABLE = 'schema_migrations';
 const NON_TRANSACTIONAL_MIGRATION_MARKER = '-- migrate: no-transaction';
+const NON_TRANSACTIONAL_MIGRATION_MARKER_PATTERN = new RegExp(
+  `^\\s*${escapeRegExp(NON_TRANSACTIONAL_MIGRATION_MARKER)}\\s*$`,
+  'm'
+);
+const POST_SCORES_RUN_SCOPE_INDEX_MIGRATION = '024_post_scores_run_scope_index.sql';
+const POST_SCORES_RUN_SCOPE_INDEX_NAME = 'idx_scores_epoch_run_total';
+const POST_SCORES_RUN_SCOPE_INDEX_REGCLASS = `public.${POST_SCORES_RUN_SCOPE_INDEX_NAME}`;
 const LEGACY_MIGRATION_SENTINEL_TABLES = ['posts', 'governance_epochs', 'post_scores'] as const;
 
 const LEGACY_MIGRATION_PROBES: Record<string, string> = {
@@ -123,8 +134,61 @@ async function queryBoolean(client: pg.Client, sql: string): Promise<boolean> {
   return result.rows[0]?.applied === true;
 }
 
+export class MigrationVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MigrationVerificationError';
+  }
+}
+
 export function shouldRunMigrationInTransaction(sql: string): boolean {
-  return !sql.includes(NON_TRANSACTIONAL_MIGRATION_MARKER);
+  return !NON_TRANSACTIONAL_MIGRATION_MARKER_PATTERN.test(sql);
+}
+
+export async function verifyRequiredMigrationSideEffects(
+  client: pg.Client,
+  filename: string
+): Promise<void> {
+  if (filename !== POST_SCORES_RUN_SCOPE_INDEX_MIGRATION) {
+    return;
+  }
+
+  const result = await client.query<{ index_exists: boolean; index_is_valid: boolean }>(
+    `
+      SELECT
+        to_regclass($1) IS NOT NULL AS index_exists,
+        COALESCE((
+          SELECT pg_index.indisvalid
+          FROM pg_class index_class
+          JOIN pg_index ON pg_index.indexrelid = index_class.oid
+          JOIN pg_namespace namespace ON namespace.oid = index_class.relnamespace
+          WHERE namespace.nspname = $2
+            AND index_class.relname = $3
+        ), false) AS index_is_valid
+    `,
+    [POST_SCORES_RUN_SCOPE_INDEX_REGCLASS, 'public', POST_SCORES_RUN_SCOPE_INDEX_NAME]
+  );
+  const verification = result.rows[0];
+
+  if (verification?.index_exists === true && verification.index_is_valid === true) {
+    return;
+  }
+
+  throw new MigrationVerificationError(
+    `Migration ${filename} did not leave a valid ${POST_SCORES_RUN_SCOPE_INDEX_REGCLASS} index: ` +
+      `index_exists=${String(verification?.index_exists ?? false)} ` +
+      `index_is_valid=${String(verification?.index_is_valid ?? false)}`
+  );
+}
+
+export async function applyNonTransactionalMigration(
+  client: pg.Client,
+  filename: string,
+  sql: string
+): Promise<void> {
+  await client.query(sql);
+  await verifyRequiredMigrationSideEffects(client, filename);
+  await client.query(`INSERT INTO ${MIGRATIONS_TABLE} (filename) VALUES ($1)`, [filename]);
 }
 
 export async function detectLegacySchema(client: pg.Client): Promise<boolean> {
@@ -215,8 +279,7 @@ export async function runMigrations(databaseUrl = process.env.DATABASE_URL): Pro
       console.log(`[apply] ${filename}`);
       if (!shouldRunMigrationInTransaction(sql)) {
         try {
-          await client.query(sql);
-          await client.query(`INSERT INTO ${MIGRATIONS_TABLE} (filename) VALUES ($1)`, [filename]);
+          await applyNonTransactionalMigration(client, filename, sql);
           console.log(`[done] ${filename}`);
         } catch (err) {
           console.error(`[failed] ${filename}`);

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -7,6 +7,7 @@ import pg from 'pg';
 const { Client } = pg;
 const MIGRATIONS_DIR = path.resolve(process.cwd(), 'src/db/migrations');
 const MIGRATIONS_TABLE = 'schema_migrations';
+const NON_TRANSACTIONAL_MIGRATION_MARKER = '-- migrate: no-transaction';
 const LEGACY_MIGRATION_SENTINEL_TABLES = ['posts', 'governance_epochs', 'post_scores'] as const;
 
 const LEGACY_MIGRATION_PROBES: Record<string, string> = {
@@ -122,6 +123,10 @@ async function queryBoolean(client: pg.Client, sql: string): Promise<boolean> {
   return result.rows[0]?.applied === true;
 }
 
+export function shouldRunMigrationInTransaction(sql: string): boolean {
+  return !sql.includes(NON_TRANSACTIONAL_MIGRATION_MARKER);
+}
+
 export async function detectLegacySchema(client: pg.Client): Promise<boolean> {
   for (const tableName of LEGACY_MIGRATION_SENTINEL_TABLES) {
     const result = await client.query<{ exists: boolean }>(
@@ -208,6 +213,18 @@ export async function runMigrations(databaseUrl = process.env.DATABASE_URL): Pro
       const sql = await readFile(migrationPath, 'utf8');
 
       console.log(`[apply] ${filename}`);
+      if (!shouldRunMigrationInTransaction(sql)) {
+        try {
+          await client.query(sql);
+          await client.query(`INSERT INTO ${MIGRATIONS_TABLE} (filename) VALUES ($1)`, [filename]);
+          console.log(`[done] ${filename}`);
+        } catch (err) {
+          console.error(`[failed] ${filename}`);
+          throw err;
+        }
+        continue;
+      }
+
       await client.query('BEGIN');
       try {
         await client.query(sql);

--- a/src/db/migrations/024_post_scores_run_scope_index.sql
+++ b/src/db/migrations/024_post_scores_run_scope_index.sql
@@ -1,0 +1,19 @@
+-- migrate: no-transaction
+-- Migration 024: Run-scoped post score lookup index
+--
+-- Current-run transparency reads filter post_scores by:
+--   epoch_id = ?
+--   component_details->>'run_id' = ?
+--
+-- Without an expression index, production stats/rank queries can scan a large
+-- active-epoch score set before narrowing to the latest scoring run. This must
+-- be built concurrently on production data, so this file opts out of the
+-- migration runner's transaction wrapper. Keep the index partial so legacy rows
+-- without run metadata do not bloat it.
+--
+-- Rollback, if needed:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_scores_epoch_run_total;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_scores_epoch_run_total
+ON post_scores (epoch_id, (component_details->>'run_id'), total_score DESC)
+WHERE component_details ? 'run_id';

--- a/src/scoring/score-reader.ts
+++ b/src/scoring/score-reader.ts
@@ -361,13 +361,37 @@ export async function readEpochComponentStats(options: {
 
   if (config.SCORE_LONGTABLE_READ_ENABLED) {
     const params: unknown[] = [epochId, componentKey];
-    let runClause = '';
     if (runId) {
-      // The run_id filter lives on post_scores.component_details. Long-table
-      // rows don't carry it directly, so join through post_scores.
       params.push(runId);
-      runClause = `AND ps.component_details->>'run_id' = $${params.length}`;
+      const result = await db.query<{
+        avg: string | null;
+        median: string | null;
+        count: string;
+      }>(
+        `SELECT
+           AVG(psc.raw)::text as avg,
+           PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY psc.raw)::text as median,
+           COUNT(*)::text as count
+         FROM post_scores ps
+         JOIN post_score_components psc
+           ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id
+         WHERE ps.epoch_id = $1
+           AND psc.component_key = $2
+           AND ps.component_details->>'run_id' = $${params.length}`,
+        params
+      );
+      const row = result.rows[0];
+      const count = parseInt(row?.count ?? '0', 10);
+      if (count === 0 || row?.avg === null || row?.median === null) {
+        return null;
+      }
+      return {
+        avg: parseFloat(row.avg),
+        median: parseFloat(row.median),
+        count,
+      };
     }
+
     const result = await db.query<{
       avg: string | null;
       median: string | null;
@@ -378,9 +402,8 @@ export async function readEpochComponentStats(options: {
          PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY psc.raw)::text as median,
          COUNT(*)::text as count
        FROM post_score_components psc
-       ${runClause ? `JOIN post_scores ps ON ps.post_uri = psc.post_uri AND ps.epoch_id = psc.epoch_id` : ''}
        WHERE psc.epoch_id = $1 AND psc.component_key = $2
-         ${runClause}`,
+      `,
       params
     );
     const row = result.rows[0];

--- a/src/transparency/routes/feed-stats.ts
+++ b/src/transparency/routes/feed-stats.ts
@@ -15,11 +15,18 @@ import { config } from '../../config.js';
 import { db } from '../../db/client.js';
 import { logger } from '../../lib/logger.js';
 import { ErrorResponseSchema } from '../../lib/openapi.js';
+import { readEpochComponentStats } from '../../scoring/score-reader.js';
 import type { FeedStats } from '../transparency.types.js';
 
 interface CurrentScoringRunValue {
   run_id?: unknown;
   epoch_id?: unknown;
+}
+
+interface BaseFeedStatsRow {
+  total_posts: string;
+  unique_authors: string;
+  median_total: string | null;
 }
 
 async function getCurrentScoringRunScope(): Promise<{ runId: string; epochId: number } | null> {
@@ -125,50 +132,42 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
       const epochId = epoch.id;
       const runScope = await getCurrentScoringRunScope();
 
-      // Aggregate metrics for current epoch. The wide-column path is the
-      // original single-query aggregation; the long-table path uses FILTER
-      // expressions over post_score_components for per-component aggregates
-      // while keeping total_score / author_did on post_scores. Both paths
-      // emit one query that returns the same six fields.
-      const statsParams: unknown[] = [epochId];
+      // Keep feed-level stats on post_scores so the long-table read path does
+      // not multiply every score row by every component row. Per-component
+      // distributions are fetched below via the storage-agnostic score reader.
+      const baseStatsParams: unknown[] = [epochId];
       let runScopeClause = '';
       if (runScope && runScope.epochId === epochId) {
-        statsParams.push(runScope.runId);
-        runScopeClause = `AND ps.component_details->>'run_id' = $${statsParams.length}`;
+        baseStatsParams.push(runScope.runId);
+        runScopeClause = `AND ps.component_details->>'run_id' = $${baseStatsParams.length}`;
       }
 
-      const statsSql = config.SCORE_LONGTABLE_READ_ENABLED
-        ? `
-          SELECT
-            COUNT(DISTINCT ps.post_uri) as total_posts,
-            COUNT(DISTINCT p.author_did) as unique_authors,
-            AVG(psc.raw) FILTER (WHERE psc.component_key = 'bridging') as avg_bridging,
-            AVG(psc.raw) FILTER (WHERE psc.component_key = 'engagement') as avg_engagement,
-            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY psc.raw)
-              FILTER (WHERE psc.component_key = 'bridging') as median_bridging,
-            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.total_score) as median_total
-          FROM post_scores ps
-          JOIN posts p ON ps.post_uri = p.uri
-          LEFT JOIN post_score_components psc
-            ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id
-          WHERE ps.epoch_id = $1
-            ${runScopeClause}
-          `
-        : `
-          SELECT
-            COUNT(*) as total_posts,
-            COUNT(DISTINCT p.author_did) as unique_authors,
-            AVG(ps.bridging_score) as avg_bridging,
-            AVG(ps.engagement_score) as avg_engagement,
-            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.bridging_score) as median_bridging,
-            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.total_score) as median_total
-          FROM post_scores ps
-          JOIN posts p ON ps.post_uri = p.uri
-          WHERE ps.epoch_id = $1
-            ${runScopeClause}
-          `;
+      const baseStatsResult = await db.query<BaseFeedStatsRow>(
+        `SELECT
+           COUNT(*)::text as total_posts,
+           COUNT(DISTINCT p.author_did)::text as unique_authors,
+           PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.total_score)::text as median_total
+         FROM post_scores ps
+         JOIN posts p ON ps.post_uri = p.uri
+         WHERE ps.epoch_id = $1
+           ${runScopeClause}`,
+        baseStatsParams
+      );
 
-      const statsResult = await db.query(statsSql, statsParams);
+      const componentStatsOptions = runScope && runScope.epochId === epochId
+        ? { epochId, runId: runScope.runId }
+        : { epochId };
+
+      const [bridgingStats, engagementStats] = await Promise.all([
+        readEpochComponentStats({
+          ...componentStatsOptions,
+          componentKey: 'bridging',
+        }),
+        readEpochComponentStats({
+          ...componentStatsOptions,
+          componentKey: 'engagement',
+        }),
+      ]);
 
       // Vote count for current epoch
       const voteCountResult = await db.query(
@@ -182,7 +181,7 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
         [epochId]
       );
 
-      const stats = statsResult.rows[0];
+      const stats = baseStatsResult.rows[0];
       const metrics = metricsResult.rows[0];
 
       const response: FeedStats = {
@@ -199,12 +198,12 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
           created_at: epoch.created_at,
         },
         feed_stats: {
-          total_posts_scored: parseInt(stats.total_posts, 10) || 0,
-          unique_authors: parseInt(stats.unique_authors, 10) || 0,
-          avg_bridging_score: parseFloat(stats.avg_bridging) || 0,
-          avg_engagement_score: parseFloat(stats.avg_engagement) || 0,
-          median_bridging_score: parseFloat(stats.median_bridging) || 0,
-          median_total_score: parseFloat(stats.median_total) || 0,
+          total_posts_scored: parseInt(stats?.total_posts ?? '0', 10) || 0,
+          unique_authors: parseInt(stats?.unique_authors ?? '0', 10) || 0,
+          avg_bridging_score: bridgingStats?.avg ?? 0,
+          avg_engagement_score: engagementStats?.avg ?? 0,
+          median_bridging_score: bridgingStats?.median ?? 0,
+          median_total_score: parseFloat(stats?.median_total ?? '0') || 0,
         },
         governance: {
           votes_this_epoch: parseInt(voteCountResult.rows[0].count, 10) || 0,

--- a/tests/migrate-bootstrap.test.ts
+++ b/tests/migrate-bootstrap.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Client } from 'pg';
-import { bootstrapLegacyMigrations, shouldRunMigrationInTransaction } from '../scripts/migrate.ts';
+import {
+  applyNonTransactionalMigration,
+  bootstrapLegacyMigrations,
+  MigrationVerificationError,
+  shouldRunMigrationInTransaction,
+  verifyRequiredMigrationSideEffects,
+} from '../scripts/migrate.ts';
 
 function asClient(queryImpl: Client['query']): Client {
   return { query: queryImpl } as unknown as Client;
@@ -8,10 +14,64 @@ function asClient(queryImpl: Client['query']): Client {
 
 describe('migration bootstrap for legacy schemas', () => {
   it('detects migrations that must run outside transaction wrappers', () => {
+    expect(shouldRunMigrationInTransaction('')).toBe(true);
     expect(shouldRunMigrationInTransaction('CREATE TABLE example (id int);')).toBe(true);
     expect(shouldRunMigrationInTransaction('-- migrate: no-transaction')).toBe(false);
     expect(shouldRunMigrationInTransaction('SELECT 1;\n-- migrate: no-transaction')).toBe(false);
     expect(shouldRunMigrationInTransaction('-- migrate: no-transaction\nCREATE INDEX CONCURRENTLY idx ON example(id);')).toBe(false);
+    expect(shouldRunMigrationInTransaction('-- migrate: no-transactional')).toBe(true);
+    expect(shouldRunMigrationInTransaction("SELECT '-- migrate: no-transaction';")).toBe(true);
+  });
+
+  it('verifies the run-scoped post score index for migration 024', async () => {
+    const queryMock = vi.fn(async () => ({
+      rows: [{ index_exists: true, index_is_valid: true }],
+    }));
+
+    await expect(
+      verifyRequiredMigrationSideEffects(
+        asClient(queryMock as Client['query']),
+        '024_post_scores_run_scope_index.sql'
+      )
+    ).resolves.toBeUndefined();
+
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining('pg_index.indisvalid'), [
+      'public.idx_scores_epoch_run_total',
+      'public',
+      'idx_scores_epoch_run_total',
+    ]);
+  });
+
+  it('refuses to mark migration 024 applied when the concurrent index is invalid', async () => {
+    const inserted: string[] = [];
+    const queryMock = vi.fn(async (sql: unknown, params?: unknown[]) => {
+      const queryText = String(sql);
+
+      if (queryText.includes('CREATE INDEX CONCURRENTLY')) {
+        return { rows: [] };
+      }
+
+      if (queryText.includes('pg_index.indisvalid')) {
+        return { rows: [{ index_exists: true, index_is_valid: false }] };
+      }
+
+      if (queryText.includes('INSERT INTO schema_migrations')) {
+        inserted.push(String(params?.[0] ?? ''));
+        return { rows: [] };
+      }
+
+      throw new Error(`Unexpected query: ${queryText}`);
+    });
+
+    await expect(
+      applyNonTransactionalMigration(
+        asClient(queryMock as Client['query']),
+        '024_post_scores_run_scope_index.sql',
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_scores_epoch_run_total ON post_scores (epoch_id)'
+      )
+    ).rejects.toThrow(MigrationVerificationError);
+
+    expect(inserted).toEqual([]);
   });
 
   it('marks detected legacy migrations as applied when tracking table is empty', async () => {

--- a/tests/migrate-bootstrap.test.ts
+++ b/tests/migrate-bootstrap.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Client } from 'pg';
-import { bootstrapLegacyMigrations } from '../scripts/migrate.ts';
+import { bootstrapLegacyMigrations, shouldRunMigrationInTransaction } from '../scripts/migrate.ts';
 
 function asClient(queryImpl: Client['query']): Client {
   return { query: queryImpl } as unknown as Client;
 }
 
 describe('migration bootstrap for legacy schemas', () => {
+  it('detects migrations that must run outside transaction wrappers', () => {
+    expect(shouldRunMigrationInTransaction('CREATE TABLE example (id int);')).toBe(true);
+    expect(shouldRunMigrationInTransaction('-- migrate: no-transaction')).toBe(false);
+    expect(shouldRunMigrationInTransaction('SELECT 1;\n-- migrate: no-transaction')).toBe(false);
+    expect(shouldRunMigrationInTransaction('-- migrate: no-transaction\nCREATE INDEX CONCURRENTLY idx ON example(id);')).toBe(false);
+  });
+
   it('marks detected legacy migrations as applied when tracking table is empty', async () => {
     const inserted: string[] = [];
     const queryMock = vi.fn(async (sql: unknown, params?: unknown[]) => {

--- a/tests/score-reader-parity.test.ts
+++ b/tests/score-reader-parity.test.ts
@@ -299,6 +299,64 @@ describe('readEpochComponentStats parity', () => {
     expect(wide).toBeNull();
     expect(long).toBeNull();
   });
+
+  it('starts run-scoped long-table component stats from post_scores', async () => {
+    configMock.SCORE_LONGTABLE_READ_ENABLED = true;
+    dbQueryMock.mockResolvedValueOnce({
+      rows: [{ avg: '0.42', median: '0.40', count: '50' }],
+    });
+
+    const stats = await readEpochComponentStats({
+      epochId: EPOCH_ID,
+      componentKey: 'bridging',
+      runId: 'run-xyz',
+    });
+
+    const query = String(dbQueryMock.mock.calls[0]?.[0]);
+    expect(stats).toEqual({ avg: 0.42, median: 0.4, count: 50 });
+    expect(query).toContain('FROM post_scores ps');
+    expect(query).toContain('JOIN post_score_components psc');
+    expect(query).toContain("ps.component_details->>'run_id'");
+    expect(dbQueryMock.mock.calls[0]?.[1]).toEqual([EPOCH_ID, 'bridging', 'run-xyz']);
+  });
+
+  it('keeps unscoped long-table component stats on the component index path', async () => {
+    configMock.SCORE_LONGTABLE_READ_ENABLED = true;
+    dbQueryMock.mockResolvedValueOnce({
+      rows: [{ avg: '0.42', median: '0.40', count: '50' }],
+    });
+
+    const stats = await readEpochComponentStats({
+      epochId: EPOCH_ID,
+      componentKey: 'bridging',
+    });
+
+    const query = String(dbQueryMock.mock.calls[0]?.[0]);
+    expect(stats).toEqual({ avg: 0.42, median: 0.4, count: 50 });
+    expect(query).toContain('FROM post_score_components psc');
+    expect(query).not.toContain('FROM post_scores ps');
+    expect(query).not.toContain("component_details->>'run_id'");
+    expect(dbQueryMock.mock.calls[0]?.[1]).toEqual([EPOCH_ID, 'bridging']);
+  });
+
+  it('applies run scoping on the wide component stats path', async () => {
+    configMock.SCORE_LONGTABLE_READ_ENABLED = false;
+    dbQueryMock.mockResolvedValueOnce({
+      rows: [{ avg: '0.42', median: '0.40', count: '50' }],
+    });
+
+    const stats = await readEpochComponentStats({
+      epochId: EPOCH_ID,
+      componentKey: 'bridging',
+      runId: 'run-xyz',
+    });
+
+    const query = String(dbQueryMock.mock.calls[0]?.[0]);
+    expect(stats).toEqual({ avg: 0.42, median: 0.4, count: 50 });
+    expect(query).toContain('FROM post_scores');
+    expect(query).toContain("component_details->>'run_id'");
+    expect(dbQueryMock.mock.calls[0]?.[1]).toEqual([EPOCH_ID, 'run-xyz']);
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/tests/transparency-run-scope.test.ts
+++ b/tests/transparency-run-scope.test.ts
@@ -29,7 +29,13 @@ describe('transparency routes current-run scoping', () => {
         rows: [{ value: { run_id: 'run-1', epoch_id: 2 } }],
       })
       .mockResolvedValueOnce({
-        rows: [{ total_posts: '10', unique_authors: '8', avg_bridging: '0.3', avg_engagement: '0.4', median_bridging: '0.25', median_total: '0.5' }],
+        rows: [{ total_posts: '10', unique_authors: '8', median_total: '0.5' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ avg: '0.3', median: '0.25', count: '10' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ avg: '0.4', median: '0.35', count: '10' }],
       })
       .mockResolvedValueOnce({ rows: [{ count: '5' }] })
       .mockResolvedValueOnce({ rows: [] });
@@ -44,6 +50,15 @@ describe('transparency routes current-run scoping', () => {
 
     expect(response.statusCode).toBe(200);
     expect(String(dbQueryMock.mock.calls[2]?.[0])).toContain("component_details->>'run_id'");
+
+    const scopedPostScoreCalls = dbQueryMock.mock.calls
+      .map((call) => String(call[0]))
+      .filter((query) => query.includes('FROM post_scores ps'));
+
+    expect(scopedPostScoreCalls.length).toBeGreaterThanOrEqual(3);
+    for (const query of scopedPostScoreCalls) {
+      expect(query).toContain("ps.component_details->>'run_id'");
+    }
 
     await app.close();
   });

--- a/tests/web-next-demo-fixtures.test.ts
+++ b/tests/web-next-demo-fixtures.test.ts
@@ -111,9 +111,28 @@ function sanitizedReceiptScanContent(content: string): string {
   return sanitizeStringLiterals([content]).join('\n');
 }
 
+function extractBareJsxText(content: string): string[] {
+  const textNodes: string[] = [];
+  const textNodePattern = /<([A-Za-z][A-Za-z0-9.:_-]*)(?:\s[^<>]*)?>([^<>{}]*)<\/\1>/g;
+  let match = textNodePattern.exec(content);
+
+  while (match !== null) {
+    const textNode = (match[2] ?? '').replace(/\s+/g, ' ').trim();
+    if (textNode.length > 0) {
+      textNodes.push(textNode);
+    }
+    match = textNodePattern.exec(content);
+  }
+
+  return textNodes;
+}
+
 function expectAnonymizedLiveReceiptContent(content: string, label: string): void {
   const sanitizedContent = sanitizedReceiptScanContent(content);
-  const stringLiterals = sanitizeStringLiterals(extractStringLiterals(content)).join('\n');
+  const domainHandleScanContent = sanitizeStringLiterals([
+    ...extractStringLiterals(content),
+    ...extractBareJsxText(content),
+  ]).join('\n');
 
   for (const forbiddenPattern of FULL_CONTENT_LIVE_RECEIPT_PATTERNS) {
     expect(
@@ -123,7 +142,7 @@ function expectAnonymizedLiveReceiptContent(content: string, label: string): voi
   }
 
   expect(
-    stringLiterals,
+    domainHandleScanContent,
     `${label} contains domain-style handle`,
   ).not.toMatch(DOMAIN_HANDLE_PATTERN);
 }
@@ -328,6 +347,15 @@ describe('web-next demo receipt fixtures', () => {
     expect(() => expectAnonymizedLiveReceiptContent(commentOnlyLeak, 'synthetic comment leak')).toThrow(
       /synthetic comment leak contains PLC DID/,
     );
+  });
+
+  it('catches domain-style handles in bare JSX text nodes', () => {
+    expect(() =>
+      expectAnonymizedLiveReceiptContent(
+        '<div className="receipt-row">leaked-author.example.social</div>',
+        'synthetic JSX text leak',
+      )
+    ).toThrow(/synthetic JSX text leak contains domain-style handle/);
   });
 
   it('extracts markdown sections with explicit edge behavior', () => {

--- a/tests/web-next-demo-fixtures.test.ts
+++ b/tests/web-next-demo-fixtures.test.ts
@@ -49,6 +49,9 @@ const FORBIDDEN_LIVE_RECEIPT_PATTERNS = [
   { name: 'Bluesky handle', pattern: /[a-z0-9._-]+\.bsky\.social/i },
   { name: 'domain-style handle', pattern: DOMAIN_HANDLE_PATTERN },
 ];
+const FULL_CONTENT_LIVE_RECEIPT_PATTERNS = FORBIDDEN_LIVE_RECEIPT_PATTERNS.filter(
+  (forbiddenPattern) => forbiddenPattern.name !== 'domain-style handle',
+);
 
 const FORBIDDEN_PUBLIC_DOC_RECEIPT_PATTERNS = [
   { name: 'raw PLC DID', pattern: /did:plc:[a-z0-9]{20,}/i },
@@ -102,6 +105,27 @@ function sanitizeStringLiterals(literals: string[]): string[] {
   return literals
     .map((literal) => literal.replace(/https?:\/\/\S+/gi, ''))
     .filter((literal) => literal.length > 0);
+}
+
+function sanitizedReceiptScanContent(content: string): string {
+  return sanitizeStringLiterals([content]).join('\n');
+}
+
+function expectAnonymizedLiveReceiptContent(content: string, label: string): void {
+  const sanitizedContent = sanitizedReceiptScanContent(content);
+  const stringLiterals = sanitizeStringLiterals(extractStringLiterals(content)).join('\n');
+
+  for (const forbiddenPattern of FULL_CONTENT_LIVE_RECEIPT_PATTERNS) {
+    expect(
+      sanitizedContent,
+      `${label} contains ${forbiddenPattern.name}`,
+    ).not.toMatch(forbiddenPattern.pattern);
+  }
+
+  expect(
+    stringLiterals,
+    `${label} contains domain-style handle`,
+  ).not.toMatch(DOMAIN_HANDLE_PATTERN);
 }
 
 function listCodeFiles(directory: string): string[] {
@@ -235,14 +259,7 @@ describe('web-next demo receipt fixtures', () => {
   it('keeps public UI fixtures anonymized while preserving numeric receipts', () => {
     for (const fixtureFile of UI_FIXTURE_FILES) {
       const content = readFixtureFile(fixtureFile);
-      const stringLiterals = sanitizeStringLiterals(extractStringLiterals(content));
-
-      for (const forbiddenPattern of FORBIDDEN_LIVE_RECEIPT_PATTERNS) {
-        expect(
-          stringLiterals.join('\n'),
-          `${path.relative(REPO_ROOT, fixtureFile)} contains ${forbiddenPattern.name}`,
-        ).not.toMatch(forbiddenPattern.pattern);
-      }
+      expectAnonymizedLiveReceiptContent(content, path.relative(REPO_ROOT, fixtureFile));
     }
   });
 
@@ -300,6 +317,17 @@ describe('web-next demo receipt fixtures', () => {
 
     expect(stringLiterals).toMatch(/did:plc:/i);
     expect(stringLiterals).toMatch(/[a-z0-9._-]+\.bsky\.social/i);
+  });
+
+  it('catches live identifiers outside string literals in fixture content', () => {
+    const commentOnlyLeak = [
+      '// did:plc:commentonlyleak1234567890',
+      '/* author.bsky.social */',
+    ].join('\n');
+
+    expect(() => expectAnonymizedLiveReceiptContent(commentOnlyLeak, 'synthetic comment leak')).toThrow(
+      /synthetic comment leak contains PLC DID/,
+    );
   });
 
   it('extracts markdown sections with explicit edge behavior', () => {

--- a/tests/web-next-demo-fixtures.test.ts
+++ b/tests/web-next-demo-fixtures.test.ts
@@ -1,0 +1,187 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  LIVE_FEED_POSTS,
+  LIVE_METRICS_SNAPSHOT,
+  LIVE_RANK_ONE_COMPONENTS,
+  LIVE_RANK_ONE_EXPLANATION,
+} from '../web-next/lib/live-metrics-snapshot';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const WEB_NEXT_ROOT = path.join(REPO_ROOT, 'web-next');
+const LIVE_METRICS_SNAPSHOT_FILE = path.join(WEB_NEXT_ROOT, 'lib', 'live-metrics-snapshot.ts');
+
+const UI_FIXTURE_FILES = [
+  path.join(REPO_ROOT, 'web-next', 'app', 'demo', 'page.tsx'),
+  path.join(REPO_ROOT, 'web-next', 'components', 'dashboard-preview.tsx'),
+  path.join(REPO_ROOT, 'web-next', 'components', 'hero-section.tsx'),
+  LIVE_METRICS_SNAPSHOT_FILE,
+];
+
+const DOMAIN_HANDLE_PATTERN =
+  /\b(?![a-z0-9.-]+\.(?:cjs|css|gif|ico|jpe?g|json|jsx|mjs|md|png|svg|tsx?|webp)\b)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z][a-z0-9-]{1,62})+\b/i;
+const CODE_FILE_EXTENSIONS = new Set(['.ts', '.tsx']);
+const IGNORED_DIRECTORY_NAMES = new Set(['.next', 'dist', 'node_modules', 'out']);
+
+const FORBIDDEN_LIVE_RECEIPT_PATTERNS = [
+  { name: 'AT Protocol post URI', pattern: /at:\/\/did:/i },
+  { name: 'PLC DID', pattern: /did:plc:/i },
+  { name: 'Bluesky handle', pattern: /[a-z0-9._-]+\.bsky\.social/i },
+  { name: 'domain-style handle', pattern: DOMAIN_HANDLE_PATTERN },
+  { name: 'known receipt handle', pattern: /\b(elainesque|waveforest|kdinjenzenvo|sonicstadium)\b/i },
+  { name: 'known receipt text', pattern: /Also, this is just funny\./i },
+];
+
+function readFixtureFile(fixtureFile: string): string {
+  try {
+    return readFileSync(fixtureFile, 'utf8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to read fixture ${path.relative(REPO_ROOT, fixtureFile)}: ${message}`);
+  }
+}
+
+function extractStringLiterals(content: string): string[] {
+  const literals: string[] = [];
+  const literalPattern = /(["'`])((?:\\[\s\S]|(?!\1)[\s\S])*)\1/g;
+  let match = literalPattern.exec(content);
+
+  while (match !== null) {
+    literals.push((match[2] ?? '').replace(/\$\{[^}]*\}/g, ''));
+    match = literalPattern.exec(content);
+  }
+
+  return literals;
+}
+
+function sanitizeStringLiterals(literals: string[]): string[] {
+  return literals
+    .map((literal) => literal.replace(/https?:\/\/\S+/gi, ''))
+    .filter((literal) => literal.length > 0);
+}
+
+function listCodeFiles(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+        files.push(...listCodeFiles(entryPath));
+      }
+      continue;
+    }
+
+    if (entry.isFile() && CODE_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function findLiveMetricsSnapshotFixtureFiles(): string[] {
+  const importers = listCodeFiles(WEB_NEXT_ROOT).filter((codeFile) => {
+    if (codeFile === LIVE_METRICS_SNAPSHOT_FILE) {
+      return false;
+    }
+
+    return readFixtureFile(codeFile).includes('live-metrics-snapshot');
+  });
+
+  return [...importers, LIVE_METRICS_SNAPSHOT_FILE].sort();
+}
+
+function relativeFixturePaths(fixtureFiles: string[]): string[] {
+  return fixtureFiles.map((fixtureFile) => path.relative(REPO_ROOT, fixtureFile)).sort();
+}
+
+describe('web-next demo receipt fixtures', () => {
+  it('keeps the scanned fixture set exhaustive for live snapshot importers', () => {
+    expect(relativeFixturePaths(UI_FIXTURE_FILES)).toEqual(
+      relativeFixturePaths(findLiveMetricsSnapshotFixtureFiles()),
+    );
+  });
+
+  it('keeps public UI fixtures anonymized while preserving numeric receipts', () => {
+    for (const fixtureFile of UI_FIXTURE_FILES) {
+      const content = readFixtureFile(fixtureFile);
+      const stringLiterals = sanitizeStringLiterals(extractStringLiterals(content));
+
+      for (const forbiddenPattern of FORBIDDEN_LIVE_RECEIPT_PATTERNS) {
+        expect(
+          stringLiterals.join('\n'),
+          `${path.relative(REPO_ROOT, fixtureFile)} contains ${forbiddenPattern.name}`,
+        ).not.toMatch(forbiddenPattern.pattern);
+      }
+    }
+  });
+
+  it('extracts multiline template literals for live identifier checks', () => {
+    const content = [
+      'const fixture = `',
+      'Public copy line',
+      'did:plc:multilineexample123',
+      'author.bsky.social',
+      '`;',
+    ].join('\n');
+    const stringLiterals = sanitizeStringLiterals(extractStringLiterals(content)).join('\n');
+
+    expect(stringLiterals).toMatch(/did:plc:/i);
+    expect(stringLiterals).toMatch(/[a-z0-9._-]+\.bsky\.social/i);
+  });
+
+  it('proves forbidden receipt patterns catch synthetic live identifiers', () => {
+    const samples = [
+      { name: 'AT Protocol post URI', value: 'at://did:plc:example/app.bsky.feed.post/abc' },
+      { name: 'PLC DID', value: 'did:plc:example1234567890' },
+      { name: 'Bluesky handle', value: 'author.bsky.social' },
+      { name: 'domain-style handle', value: 'author.example.social' },
+      { name: 'known receipt handle', value: 'elainesque' },
+      { name: 'known receipt text', value: 'Also, this is just funny.' },
+    ];
+
+    for (const sample of samples) {
+      const forbiddenPattern = FORBIDDEN_LIVE_RECEIPT_PATTERNS.find(
+        (pattern) => pattern.name === sample.name,
+      );
+
+      expect(forbiddenPattern, `Missing forbidden pattern fixture for ${sample.name}`).toBeDefined();
+      expect(sample.value).toMatch(forbiddenPattern?.pattern ?? /$^/);
+    }
+  });
+
+  it('distinguishes domain-style handles from benign dotted file literals', () => {
+    expect('author.example.social').toMatch(DOMAIN_HANDLE_PATTERN);
+    expect('styles.css').not.toMatch(DOMAIN_HANDLE_PATTERN);
+    expect('page.tsx').not.toMatch(DOMAIN_HANDLE_PATTERN);
+  });
+
+  it('keeps rank-one score receipts internally consistent', () => {
+    const componentTotal = LIVE_RANK_ONE_COMPONENTS.reduce(
+      (total, component) => total + component.weighted,
+      0,
+    );
+
+    expect(componentTotal).toBeCloseTo(LIVE_RANK_ONE_EXPLANATION.totalScore, 12);
+    expect(LIVE_FEED_POSTS[0]?.score).toBe(LIVE_RANK_ONE_EXPLANATION.totalScore);
+    expect(LIVE_METRICS_SNAPSHOT.scoredPosts).toBe(3348);
+    expect(LIVE_METRICS_SNAPSHOT.uniqueAuthors).toBe(3007);
+  });
+
+  it('keeps snapshot authors as anonymized receipt labels', () => {
+    const authorLabels = [
+      LIVE_RANK_ONE_EXPLANATION.authorLabel,
+      ...LIVE_FEED_POSTS.map((post) => post.author),
+    ];
+
+    for (const authorLabel of authorLabels) {
+      expect(authorLabel).toMatch(/^Production receipt \d{3}$/);
+      expect(authorLabel).not.toMatch(DOMAIN_HANDLE_PATTERN);
+    }
+  });
+});

--- a/tests/web-next-demo-fixtures.test.ts
+++ b/tests/web-next-demo-fixtures.test.ts
@@ -12,12 +12,30 @@ import {
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const WEB_NEXT_ROOT = path.join(REPO_ROOT, 'web-next');
 const LIVE_METRICS_SNAPSHOT_FILE = path.join(WEB_NEXT_ROOT, 'lib', 'live-metrics-snapshot.ts');
+const README_FILE = path.join(REPO_ROOT, 'README.md');
+const DEV_JOURNAL_FILE = path.join(REPO_ROOT, 'docs', 'dev-journal.md');
+const LAB_METRICS_PACKET_FILE = path.join(
+  REPO_ROOT,
+  'docs',
+  'lab',
+  '2026-07-07-recsys-live-metrics-packet.md',
+);
 
 const UI_FIXTURE_FILES = [
   path.join(REPO_ROOT, 'web-next', 'app', 'demo', 'page.tsx'),
   path.join(REPO_ROOT, 'web-next', 'components', 'dashboard-preview.tsx'),
   path.join(REPO_ROOT, 'web-next', 'components', 'hero-section.tsx'),
   LIVE_METRICS_SNAPSHOT_FILE,
+];
+
+const PUBLIC_RECEIPT_DOC_FILES = [
+  README_FILE,
+  DEV_JOURNAL_FILE,
+  LAB_METRICS_PACKET_FILE,
+];
+
+const PUBLIC_RECEIPT_EXAMPLE_SECTION_FILES = [
+  LAB_METRICS_PACKET_FILE,
 ];
 
 const DOMAIN_HANDLE_PATTERN =
@@ -30,9 +48,33 @@ const FORBIDDEN_LIVE_RECEIPT_PATTERNS = [
   { name: 'PLC DID', pattern: /did:plc:/i },
   { name: 'Bluesky handle', pattern: /[a-z0-9._-]+\.bsky\.social/i },
   { name: 'domain-style handle', pattern: DOMAIN_HANDLE_PATTERN },
-  { name: 'known receipt handle', pattern: /\b(elainesque|waveforest|kdinjenzenvo|sonicstadium)\b/i },
-  { name: 'known receipt text', pattern: /Also, this is just funny\./i },
 ];
+
+const FORBIDDEN_PUBLIC_DOC_RECEIPT_PATTERNS = [
+  { name: 'raw PLC DID', pattern: /did:plc:[a-z0-9]{20,}/i },
+  { name: 'encoded PLC DID', pattern: /did%3Aplc%3A[a-z0-9]{20,}/i },
+  { name: 'raw AT Protocol URI', pattern: /at:\/\/did:plc:[a-z0-9]+\/[a-z0-9.]+\/[a-z0-9._-]+/i },
+  {
+    name: 'encoded AT Protocol URI',
+    pattern: /at%3A%2F%2Fdid%3Aplc%3A[a-z0-9]+%2F[a-z0-9.]+%2F[a-z0-9._-]+/i,
+  },
+  { name: 'Bluesky handle', pattern: /[a-z0-9._-]+\.bsky\.social/i },
+];
+
+const FORBIDDEN_PUBLIC_DOC_EXAMPLE_SECTION_PATTERNS = [
+  { name: 'raw PLC DID', pattern: /did:plc:[a-z0-9]{20,}/i },
+  { name: 'raw AT Protocol post URI', pattern: /at:\/\/did:plc:[a-z0-9]+\/app\.bsky\.feed\.post\/[a-z0-9]+/i },
+  {
+    name: 'encoded AT Protocol post URI',
+    pattern: /at%3A%2F%2Fdid%3Aplc%3A[a-z0-9]+%2Fapp\.bsky\.feed\.post%2F[a-z0-9]+/i,
+  },
+  { name: 'Bluesky handle', pattern: /[a-z0-9._-]+\.bsky\.social/i },
+];
+
+interface PublicReceiptDocSection {
+  readonly label: string;
+  readonly content: string;
+}
 
 function readFixtureFile(fixtureFile: string): string {
   try {
@@ -100,6 +142,89 @@ function relativeFixturePaths(fixtureFiles: string[]): string[] {
   return fixtureFiles.map((fixtureFile) => path.relative(REPO_ROOT, fixtureFile)).sort();
 }
 
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractMarkdownSection(content: string, heading: string): string {
+  const headingPattern = new RegExp(`^## ${escapeRegExp(heading)}\\s*\\r?$`, 'm');
+  const headingMatch = headingPattern.exec(content);
+
+  if (headingMatch === null) {
+    throw new Error(`Unable to find markdown section: ${heading}`);
+  }
+
+  const sectionStartIndex = headingMatch.index + headingMatch[0].length;
+  const afterHeading = content.slice(sectionStartIndex);
+  const remainingContent = afterHeading.startsWith('\r\n')
+    ? afterHeading.slice(2)
+    : afterHeading.startsWith('\n')
+      ? afterHeading.slice(1)
+      : afterHeading;
+  const nextSectionMatch = /^## /m.exec(remainingContent);
+
+  if (nextSectionMatch === null) {
+    return remainingContent;
+  }
+
+  return remainingContent.slice(0, nextSectionMatch.index);
+}
+
+function extractMarkdownSectionByHeadingFragment(content: string, headingFragment: string): string {
+  const headingPattern = new RegExp(`^## .*${escapeRegExp(headingFragment)}.*\\r?$`, 'm');
+  const headingMatch = headingPattern.exec(content);
+
+  if (headingMatch === null) {
+    throw new Error(`Unable to find markdown section containing: ${headingFragment}`);
+  }
+
+  const heading = headingMatch[0].replace(/^##\s+/, '').trim();
+  return extractMarkdownSection(content, heading);
+}
+
+function extractLineContaining(content: string, needle: string): string {
+  const line = content.split(/\r?\n/).find((candidate) => candidate.includes(needle));
+
+  if (line === undefined) {
+    throw new Error(`Unable to find line containing: ${needle}`);
+  }
+
+  return line;
+}
+
+function publicReceiptDocSections(): PublicReceiptDocSection[] {
+  const readme = readFixtureFile(README_FILE);
+  const devJournal = readFixtureFile(DEV_JOURNAL_FILE);
+  const labMetricsPacket = readFixtureFile(LAB_METRICS_PACKET_FILE);
+
+  return [
+    {
+      label: 'README.md live production snapshot',
+      content: extractLineContaining(readme, 'Live production snapshot:'),
+    },
+    {
+      label: 'docs/dev-journal.md PROJ-1433 entry',
+      content: extractMarkdownSectionByHeadingFragment(devJournal, 'PROJ-1433 live metrics packet'),
+    },
+    {
+      label: 'metrics packet receipt commands',
+      content: extractMarkdownSection(labMetricsPacket, 'Receipt Commands'),
+    },
+    {
+      label: 'metrics packet live production claims',
+      content: extractMarkdownSection(labMetricsPacket, 'Live Production Claims'),
+    },
+    {
+      label: 'metrics packet post explanation',
+      content: extractMarkdownSection(labMetricsPacket, 'Post Explanation Example'),
+    },
+    {
+      label: 'metrics packet copy guidance',
+      content: extractMarkdownSection(labMetricsPacket, 'Copy Guidance'),
+    },
+  ];
+}
+
 describe('web-next demo receipt fixtures', () => {
   it('keeps the scanned fixture set exhaustive for live snapshot importers', () => {
     expect(relativeFixturePaths(UI_FIXTURE_FILES)).toEqual(
@@ -121,6 +246,48 @@ describe('web-next demo receipt fixtures', () => {
     }
   });
 
+  it('keeps public PROJ-1433 receipt docs anonymized for the rank-one example', () => {
+    expect(relativeFixturePaths(PUBLIC_RECEIPT_DOC_FILES)).toEqual([
+      'README.md',
+      'docs/dev-journal.md',
+      'docs/lab/2026-07-07-recsys-live-metrics-packet.md',
+    ]);
+
+    for (const section of publicReceiptDocSections()) {
+      for (const forbiddenPattern of FORBIDDEN_PUBLIC_DOC_RECEIPT_PATTERNS) {
+        expect(
+          section.content,
+          `${section.label} contains ${forbiddenPattern.name}`,
+        ).not.toMatch(forbiddenPattern.pattern);
+      }
+    }
+  });
+
+  it('keeps the public post explanation section free of structural raw identifiers', () => {
+    for (const fixtureFile of PUBLIC_RECEIPT_EXAMPLE_SECTION_FILES) {
+      const content = readFixtureFile(fixtureFile);
+      const section = extractMarkdownSection(content, 'Post Explanation Example');
+
+      for (const forbiddenPattern of FORBIDDEN_PUBLIC_DOC_EXAMPLE_SECTION_PATTERNS) {
+        expect(
+          section,
+          `${path.relative(REPO_ROOT, fixtureFile)} Post Explanation Example contains ${forbiddenPattern.name}`,
+        ).not.toMatch(forbiddenPattern.pattern);
+      }
+    }
+  });
+
+  it('keeps the public post explanation sensitive fields explicitly redacted', () => {
+    for (const fixtureFile of PUBLIC_RECEIPT_EXAMPLE_SECTION_FILES) {
+      const content = readFixtureFile(fixtureFile);
+      const section = extractMarkdownSection(content, 'Post Explanation Example');
+
+      expect(section).toMatch(/- Post text: redacted from the public tracked packet/);
+      expect(section).toMatch(/- Raw production URI: redacted from the public tracked packet/);
+      expect(section).toMatch(/- Raw author DID and handle: redacted from the public tracked packet/);
+    }
+  });
+
   it('extracts multiline template literals for live identifier checks', () => {
     const content = [
       'const fixture = `',
@@ -135,14 +302,24 @@ describe('web-next demo receipt fixtures', () => {
     expect(stringLiterals).toMatch(/[a-z0-9._-]+\.bsky\.social/i);
   });
 
+  it('extracts markdown sections with explicit edge behavior', () => {
+    expect(() => extractMarkdownSection('## Other\nbody', 'Missing')).toThrow(
+      'Unable to find markdown section: Missing',
+    );
+    expect(extractMarkdownSection('## First\nbody\n## Target\nfinal body', 'Target')).toBe('final body');
+    expect(extractMarkdownSection('## Target\nlast section line 1\nlast section line 2\n', 'Target')).toBe(
+      'last section line 1\nlast section line 2\n',
+    );
+    expect(extractMarkdownSection('## Empty\n## Next\nnext body', 'Empty')).toBe('');
+    expect(extractMarkdownSection('## Target  \r\nbody\r\n## Next\r\nnext body', 'Target')).toBe('body\r\n');
+  });
+
   it('proves forbidden receipt patterns catch synthetic live identifiers', () => {
     const samples = [
       { name: 'AT Protocol post URI', value: 'at://did:plc:example/app.bsky.feed.post/abc' },
       { name: 'PLC DID', value: 'did:plc:example1234567890' },
       { name: 'Bluesky handle', value: 'author.bsky.social' },
       { name: 'domain-style handle', value: 'author.example.social' },
-      { name: 'known receipt handle', value: 'elainesque' },
-      { name: 'known receipt text', value: 'Also, this is just funny.' },
     ];
 
     for (const sample of samples) {

--- a/tests/web-next-live-demo-data.test.ts
+++ b/tests/web-next-live-demo-data.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bskyPostUrlFromAtUri,
+  buildPostHydrationUrl,
+  scoreComponentsFromExplanation,
+  topicBreakdownFromExplanation,
+  LiveDemoDataError,
+} from '../web-next/lib/live-demo-data';
+
+type ExplanationFixture = Parameters<typeof scoreComponentsFromExplanation>[0];
+
+const EXPLANATION_FIXTURE = {
+  post_uri: 'at://did:plc:example123/app.bsky.feed.post/3abc',
+  epoch_id: 2,
+  total_score: 0.83,
+  rank: 1,
+  components: {
+    recency: { raw_score: 0.8, weight: 0.25, weighted: 0.2 },
+    engagement: { raw_score: 0.7, weight: 0.2, weighted: 0.14 },
+    bridging: { raw_score: 0.6, weight: 0.1, weighted: 0.06 },
+    source_diversity: { raw_score: 1, weight: 0.1, weighted: 0.1 },
+    relevance: {
+      raw_score: 0.8,
+      weight: 0.35,
+      weighted: 0.28,
+      topicBreakdown: {
+        'software-development': {
+          postScore: 1,
+          communityWeight: 0.8,
+          contribution: 0.8,
+        },
+      },
+    },
+  },
+  counterfactual: {
+    pure_engagement_rank: 3,
+    community_governed_rank: 1,
+    difference: 2,
+  },
+  scored_at: '2026-07-07T07:44:21.844Z',
+} satisfies ExplanationFixture;
+
+describe('web-next live demo data helpers', () => {
+  it('builds Bluesky source URLs from AT Protocol post URIs', () => {
+    expect(bskyPostUrlFromAtUri('at://did:plc:example123/app.bsky.feed.post/3abc')).toBe(
+      'https://bsky.app/profile/did:plc:example123/post/3abc',
+    );
+  });
+
+  it('rejects non-post AT Protocol URIs', () => {
+    expect(() => bskyPostUrlFromAtUri('at://did:plc:example123/app.bsky.feed.generator/demo')).toThrow(
+      LiveDemoDataError,
+    );
+  });
+
+  it('rejects malformed AT Protocol post URI input', () => {
+    expect(() => bskyPostUrlFromAtUri('not-an-at-uri')).toThrow(LiveDemoDataError);
+    expect(() => bskyPostUrlFromAtUri('')).toThrow(LiveDemoDataError);
+  });
+
+  it('hydrates multiple feed skeleton URIs with repeated AppView params', () => {
+    const url = new URL(
+      buildPostHydrationUrl([
+        'at://did:plc:first/app.bsky.feed.post/3one',
+        'at://did:plc:second/app.bsky.feed.post/3two',
+      ]),
+    );
+
+    expect(url.origin).toBe('https://public.api.bsky.app');
+    expect(url.pathname).toBe('/xrpc/app.bsky.feed.getPosts');
+    expect(url.searchParams.getAll('uris')).toEqual([
+      'at://did:plc:first/app.bsky.feed.post/3one',
+      'at://did:plc:second/app.bsky.feed.post/3two',
+    ]);
+  });
+
+  it('builds an AppView hydration URL with no URI params for an empty feed', () => {
+    const url = new URL(buildPostHydrationUrl([]));
+
+    expect(url.origin).toBe('https://public.api.bsky.app');
+    expect(url.pathname).toBe('/xrpc/app.bsky.feed.getPosts');
+    expect(url.searchParams.getAll('uris')).toEqual([]);
+  });
+
+  it('normalizes live explanation components in display order', () => {
+    const components = scoreComponentsFromExplanation(EXPLANATION_FIXTURE);
+
+    expect(components.map((component) => component.key)).toEqual([
+      'recency',
+      'engagement',
+      'bridging',
+      'source_diversity',
+      'relevance',
+    ]);
+    expect(components[4]?.weighted).toBe(0.28);
+  });
+
+  it('fails explicitly when a required live explanation component is missing', () => {
+    const { relevance: _relevance, ...componentsWithoutRelevance } = EXPLANATION_FIXTURE.components;
+
+    expect(() =>
+      scoreComponentsFromExplanation({
+        ...EXPLANATION_FIXTURE,
+        components: componentsWithoutRelevance,
+      }),
+    ).toThrow(LiveDemoDataError);
+  });
+
+  it('normalizes live relevance topic breakdowns', () => {
+    expect(topicBreakdownFromExplanation(EXPLANATION_FIXTURE)).toEqual([
+      {
+        slug: 'software-development',
+        name: 'Software Development',
+        postScore: 1,
+        communityWeight: 0.8,
+        contribution: 0.8,
+      },
+    ]);
+  });
+
+  it('returns an empty topic list when relevance topic breakdown is absent or empty', () => {
+    expect(
+      topicBreakdownFromExplanation({
+        ...EXPLANATION_FIXTURE,
+        components: {
+          ...EXPLANATION_FIXTURE.components,
+          relevance: {
+            raw_score: 0.8,
+            weight: 0.35,
+            weighted: 0.28,
+          },
+        },
+      }),
+    ).toEqual([]);
+
+    expect(
+      topicBreakdownFromExplanation({
+        ...EXPLANATION_FIXTURE,
+        components: {
+          ...EXPLANATION_FIXTURE.components,
+          relevance: {
+            raw_score: 0.8,
+            weight: 0.35,
+            weighted: 0.28,
+            topicBreakdown: {},
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+});

--- a/tests/web-next-live-demo-data.test.ts
+++ b/tests/web-next-live-demo-data.test.ts
@@ -106,6 +106,34 @@ describe('web-next live demo data helpers', () => {
     ).toThrow(LiveDemoDataError);
   });
 
+  it('fails explicitly when live explanation component fields are non-finite', () => {
+    expect(() =>
+      scoreComponentsFromExplanation({
+        ...EXPLANATION_FIXTURE,
+        components: {
+          ...EXPLANATION_FIXTURE.components,
+          recency: {
+            ...EXPLANATION_FIXTURE.components.recency,
+            raw_score: Number.NaN,
+          },
+        },
+      }),
+    ).toThrow(LiveDemoDataError);
+
+    expect(() =>
+      scoreComponentsFromExplanation({
+        ...EXPLANATION_FIXTURE,
+        components: {
+          ...EXPLANATION_FIXTURE.components,
+          relevance: {
+            ...EXPLANATION_FIXTURE.components.relevance,
+            weighted: Number.POSITIVE_INFINITY,
+          },
+        },
+      }),
+    ).toThrow(LiveDemoDataError);
+  });
+
   it('normalizes live relevance topic breakdowns', () => {
     expect(topicBreakdownFromExplanation(EXPLANATION_FIXTURE)).toEqual([
       {

--- a/web-next/app/demo/page.tsx
+++ b/web-next/app/demo/page.tsx
@@ -232,7 +232,7 @@ function StepCounterfactual() {
     },
     {
       label: moved === "up" ? "Positions gained" : moved === "down" ? "Positions lost" : "Rank change",
-      value: moved === "up" ? `+${diff}` : moved === "down" ? `${diff}` : "—",
+      value: moved === "up" ? `+${diff}` : moved === "down" ? `${Math.abs(diff)}` : "—",
       sub: moved === "up" ? "Moved up by community governance" : moved === "down" ? "Moved down by community governance" : "No rank movement",
       color: diff > 0 ? "text-success" : diff < 0 ? "text-tongue-foreground" : "text-foreground/40",
       bg: diff > 0 ? "bg-success/10 border-success/20" : diff < 0 ? "bg-tongue/10 border-tongue/20" : "bg-biscuit border-border",

--- a/web-next/app/demo/page.tsx
+++ b/web-next/app/demo/page.tsx
@@ -1,17 +1,19 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { AppShell } from "@/components/app-shell"
 import { ScoreBreakdown } from "@/components/ui/score-breakdown"
 import { ScoreRadar } from "@/components/ui/score-radar"
 import { WeightBar } from "@/components/ui/weight-bar"
 import { StatusChip } from "@/components/ui/status-chip"
+import type { LiveDemoData, LiveDemoExplanation, LiveDemoFeedPost } from "@/lib/live-demo-data"
+import { fetchLiveDemoData } from "@/lib/live-demo-data"
 import { LIVE_FEED_POSTS, LIVE_METRICS_SNAPSHOT, LIVE_RANK_ONE_EXPLANATION } from "@/lib/live-metrics-snapshot"
 
-// ── Live snapshot view-models (API-exact field names) ────────────────────────
+// ── Snapshot fallback view-models (API-exact field names) ─────────────────────
 
-const LIVE_STATS = {
+const SNAPSHOT_STATS = {
   epoch: { id: LIVE_METRICS_SNAPSHOT.epochId, phase: "live" as const },
   feed_stats: {
     total_posts_scored: LIVE_METRICS_SNAPSHOT.scoredPosts,
@@ -24,11 +26,11 @@ const LIVE_STATS = {
   governance: { votes_this_epoch: LIVE_METRICS_SNAPSHOT.votesThisEpoch },
 }
 
-const LIVE_WEIGHTS = LIVE_METRICS_SNAPSHOT.weights
+const SNAPSHOT_WEIGHTS = LIVE_METRICS_SNAPSHOT.weights
 
-const LIVE_TOPICS = LIVE_METRICS_SNAPSHOT.topics
+const SNAPSHOT_TOPICS = LIVE_METRICS_SNAPSHOT.topics
 
-const LIVE_EXPLANATION = {
+const SNAPSHOT_EXPLANATION = {
   post_uri: LIVE_RANK_ONE_EXPLANATION.receiptId,
   author: LIVE_RANK_ONE_EXPLANATION.authorLabel,
   text: LIVE_RANK_ONE_EXPLANATION.text,
@@ -36,12 +38,77 @@ const LIVE_EXPLANATION = {
   total_score: LIVE_RANK_ONE_EXPLANATION.totalScore,
   rank: LIVE_RANK_ONE_EXPLANATION.rank,
   components: LIVE_RANK_ONE_EXPLANATION.components,
-  governance_weights: LIVE_WEIGHTS,
+  governance_weights: SNAPSHOT_WEIGHTS,
   counterfactual: {
     pure_engagement_rank: LIVE_RANK_ONE_EXPLANATION.counterfactual.pureEngagementRank,
     community_governed_rank: LIVE_RANK_ONE_EXPLANATION.counterfactual.communityGovernedRank,
     difference: LIVE_RANK_ONE_EXPLANATION.counterfactual.difference,
   },
+}
+
+const DATE_TIME_FORMAT = new Intl.DateTimeFormat("en", {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZoneName: "short",
+})
+
+interface StepProps {
+  readonly liveData: LiveDemoData | null
+  readonly liveError: string | null
+  readonly loading: boolean
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return DATE_TIME_FORMAT.format(date)
+}
+
+function compactError(error: string): string {
+  return error.length > 160 ? `${error.slice(0, 157)}...` : error
+}
+
+function snapshotPostUrl(rank: number): string {
+  return `/demo#snapshot-rank-${rank}`
+}
+
+function feedPostsForDemo(liveData: LiveDemoData | null): readonly LiveDemoFeedPost[] {
+  if (liveData !== null && liveData.posts.length > 0) {
+    return liveData.posts
+  }
+
+  return LIVE_FEED_POSTS.map((post) => ({
+    rank: post.rank,
+    uri: `snapshot-rank-${post.rank}`,
+    bskyUrl: snapshotPostUrl(post.rank),
+    authorHandle: post.author,
+    authorDisplayName: post.author,
+    text: post.text,
+    indexedAt: null,
+    likeCount: null,
+    repostCount: null,
+    replyCount: null,
+    score: post.score,
+  }))
+}
+
+function explanationForDemo(liveData: LiveDemoData | null): {
+  readonly explanation: LiveDemoExplanation | null
+  readonly post: LiveDemoFeedPost | null
+  readonly source: "live" | "snapshot"
+} {
+  if (liveData?.explanation !== null && liveData?.explanation !== undefined) {
+    const post = liveData.posts.find((candidate) => candidate.uri === liveData.explanation?.postUri) ?? null
+    return { explanation: liveData.explanation, post, source: "live" }
+  }
+
+  return { explanation: null, post: null, source: "snapshot" }
 }
 
 // ── Step definitions ──────────────────────────────────────────────────────────
@@ -56,8 +123,28 @@ const STEPS = [
 
 // ── Step content components ───────────────────────────────────────────────────
 
-function StepStats() {
-  const { feed_stats, epoch, governance } = LIVE_STATS
+function StepStats({ liveData, liveError, loading }: StepProps) {
+  const liveStats = liveData?.stats ?? null
+  const liveWeights = liveData?.weights ?? null
+  const feed_stats = liveStats === null
+    ? SNAPSHOT_STATS.feed_stats
+    : {
+      total_posts_scored: liveStats.totalPostsScored,
+      unique_authors: liveStats.uniqueAuthors,
+      avg_bridging: liveStats.avgBridging,
+      avg_engagement: liveStats.avgEngagement,
+      median_bridging: liveStats.medianBridging,
+      median_total: liveStats.medianTotal,
+    }
+  const epoch = {
+    id: liveStats?.epochId ?? liveWeights?.epochId ?? SNAPSHOT_STATS.epoch.id,
+    phase: liveWeights?.status === "active" ? "live" : SNAPSHOT_STATS.epoch.phase,
+  }
+  const governance = {
+    votes_this_epoch: liveStats?.votesThisEpoch ?? liveWeights?.voteCount ?? SNAPSHOT_STATS.governance.votes_this_epoch,
+  }
+  const statsSource = liveStats === null ? "snapshot" : "live"
+  const statsError = liveData?.errors.find((error) => error.includes("transparency stats")) ?? null
   const stats = [
     { label: "Posts scored",    value: feed_stats.total_posts_scored.toLocaleString() },
     { label: "Authors",         value: feed_stats.unique_authors.toLocaleString() },
@@ -95,48 +182,111 @@ function StepStats() {
       </div>
       <div className="flex items-center gap-2 p-4 rounded-xl bg-biscuit/60 text-sm text-foreground/60 leading-relaxed">
         <StatusChip phase={epoch.phase} />
-        <span>Round #{epoch.id} is active. Snapshot refreshed from public endpoints on {LIVE_METRICS_SNAPSHOT.collectedAtLabel}.</span>
+        <span>
+          {loading
+            ? "Checking live Corgi endpoints..."
+            : statsSource === "live"
+              ? `Round #${epoch.id} is active. Aggregate stats loaded live at ${formatTimestamp(liveData?.fetchedAt ?? new Date().toISOString())}.`
+              : `Round #${epoch.id} weights are live; aggregate stats are the ${LIVE_METRICS_SNAPSHOT.collectedAtLabel} receipt because /api/transparency/stats is not healthy.`}
+        </span>
       </div>
+      {(statsError !== null || liveError !== null) && (
+        <div className="rounded-xl border border-tongue/25 bg-tongue/10 px-4 py-3 text-xs text-foreground/60 leading-relaxed">
+          {statsError !== null
+            ? compactError(statsError)
+            : liveError !== null
+              ? compactError(liveError)
+              : null}
+        </div>
+      )}
     </div>
   )
 }
 
-const LIVE_FEED_VIEW_POSTS = LIVE_FEED_POSTS
-
-function StepFeed() {
+function StepFeed({ liveData, liveError, loading }: StepProps) {
+  const posts = feedPostsForDemo(liveData)
+  const showingLivePosts = liveData !== null && liveData.posts.length > 0
+  const hydrationError = liveData?.errors.find((error) => error.includes("Bluesky AppView")) ?? null
+  const feedError = liveData?.errors.find((error) => error.includes("feed skeleton")) ?? null
   return (
     <div className="flex flex-col gap-3">
-      {LIVE_FEED_VIEW_POSTS.map((post) => (
-        <div key={post.rank} className="flex items-start gap-4 rounded-xl border border-border bg-card px-5 py-4">
+      {posts.map((post) => (
+        <div key={post.uri} className="flex items-start gap-4 rounded-xl border border-border bg-card px-5 py-4">
           <span className="text-xl font-mono font-bold text-foreground/25 tabular-nums w-7 flex-shrink-0 pt-0.5">
             {post.rank}
           </span>
           <div className="flex-1 flex flex-col gap-2 min-w-0">
             <div className="flex items-center justify-between gap-3">
-              <span className="text-xs font-mono text-foreground/50">@{post.author}</span>
-              <span className="text-xs font-mono font-semibold px-2 py-0.5 rounded-full bg-primary/10 text-primary border border-primary/15">
-                {post.score.toFixed(2)}
+              <span className="text-xs font-mono text-foreground/50 truncate">
+                @{post.authorHandle}
               </span>
+              {post.score === null ? (
+                <span className="text-xs font-mono font-semibold px-2 py-0.5 rounded-full bg-biscuit text-foreground/45 border border-border">
+                  live
+                </span>
+              ) : (
+                <span className="text-xs font-mono font-semibold px-2 py-0.5 rounded-full bg-primary/10 text-primary border border-primary/15">
+                  {post.score.toFixed(3)}
+                </span>
+              )}
             </div>
-            <p className="text-sm text-foreground/80 leading-relaxed">{post.text}</p>
+            <p className="text-sm text-foreground/80 leading-relaxed break-words">{post.text}</p>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-foreground/40">
+              <span>{post.authorDisplayName}</span>
+              {post.indexedAt !== null && <span>{formatTimestamp(post.indexedAt)}</span>}
+              {post.likeCount !== null && <span>{post.likeCount.toLocaleString()} likes</span>}
+              {post.repostCount !== null && <span>{post.repostCount.toLocaleString()} reposts</span>}
+              {post.replyCount !== null && <span>{post.replyCount.toLocaleString()} replies</span>}
+              {showingLivePosts && (
+                <a
+                  href={post.bskyUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Open on Bluesky
+                </a>
+              )}
+            </div>
           </div>
         </div>
       ))}
       <p className="text-xs text-foreground/40 text-center pt-2">
-        Top scored posts from the anonymized {LIVE_METRICS_SNAPSHOT.collectedAtLabel} production transparency receipt.
+        {loading
+          ? "Loading the current Corgi feed skeleton and Bluesky post content..."
+          : showingLivePosts
+            ? `Current Corgi feed skeleton hydrated through Bluesky AppView at ${formatTimestamp(liveData.fetchedAt)}.`
+            : `Snapshot fallback from the anonymized ${LIVE_METRICS_SNAPSHOT.collectedAtLabel} production receipt.`}
       </p>
+      {(feedError !== null || hydrationError !== null || liveError !== null) && (
+        <div className="rounded-xl border border-tongue/25 bg-tongue/10 px-4 py-3 text-xs text-foreground/60 leading-relaxed">
+          {compactError(feedError ?? hydrationError ?? liveError ?? "Live feed unavailable")}
+        </div>
+      )}
     </div>
   )
 }
 
-function StepTopics() {
+function StepTopics({ liveData }: StepProps) {
+  const explanationView = explanationForDemo(liveData)
+  const liveTopics = explanationView.explanation?.topicBreakdown.map((topic) => ({
+    slug: topic.slug,
+    name: topic.name,
+    currentWeight: topic.communityWeight,
+    communityAvg: topic.communityWeight,
+  })) ?? []
+  const topics = liveTopics.length > 0 ? liveTopics : SNAPSHOT_TOPICS
+  const source = liveTopics.length > 0 ? "live" : "snapshot"
+
   return (
     <div className="flex flex-col gap-6">
       <p className="text-sm text-foreground/55 leading-relaxed">
-        The explained post carried a stored relevance topic breakdown. This is public explanation data for that post, not a claim about all current feed topics.
+        {source === "live"
+          ? "The current rank-one post carries this relevance topic breakdown from the live explanation endpoint."
+          : "The explained post uses the stored receipt topic breakdown because the live explanation is unavailable."}
       </p>
       <div className="flex flex-col">
-        {LIVE_TOPICS.map((t) => {
+        {topics.map((t) => {
           const boosted  = t.currentWeight > 0.55
           const reduced  = t.currentWeight < 0.45
           const direction = boosted ? "Boosted" : reduced ? "Reduced" : "Neutral"
@@ -169,8 +319,16 @@ function StepTopics() {
   )
 }
 
-function StepExplain() {
-  const { components, total_score, text, author, rank } = LIVE_EXPLANATION
+function StepExplain({ liveData }: StepProps) {
+  const explanationView = explanationForDemo(liveData)
+  const liveExplanation = explanationView.explanation
+  const components = liveExplanation?.components ?? SNAPSHOT_EXPLANATION.components
+  const total_score = liveExplanation?.totalScore ?? SNAPSHOT_EXPLANATION.total_score
+  const rank = liveExplanation?.rank ?? SNAPSHOT_EXPLANATION.rank
+  const text = explanationView.post?.text ?? SNAPSHOT_EXPLANATION.text
+  const author = explanationView.post?.authorHandle ?? SNAPSHOT_EXPLANATION.author
+  const epochId = liveExplanation?.epochId ?? SNAPSHOT_EXPLANATION.epoch_id
+  const source = liveExplanation === null ? "snapshot" : "live"
   const radarSignals = components.map((c) => ({
     key: c.key,
     label: c.label,
@@ -181,8 +339,20 @@ function StepExplain() {
     <div className="flex flex-col gap-6">
       {/* Post being explained */}
       <div className="rounded-xl border border-border bg-card px-5 py-4 flex flex-col gap-2">
-        <span className="text-xs font-mono text-foreground/45">@{author} · rank #{rank}</span>
-        <p className="text-sm text-foreground/80 leading-relaxed">{text}</p>
+        <span className="text-xs font-mono text-foreground/45">
+          @{author} · rank #{rank} · {source === "live" ? "live explanation" : "snapshot receipt"}
+        </span>
+        <p className="text-sm text-foreground/80 leading-relaxed break-words">{text}</p>
+        {explanationView.post !== null && (
+          <a
+            href={explanationView.post.bskyUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs font-semibold text-primary hover:underline w-fit"
+          >
+            Open source post
+          </a>
+        )}
       </div>
       {/* Breakdown + radar side-by-side on large */}
       <div className="flex flex-col lg:flex-row gap-6">
@@ -193,7 +363,7 @@ function StepExplain() {
           <ScoreBreakdown
             components={components}
             total_score={total_score}
-            epochLabel={`Round #${LIVE_EXPLANATION.epoch_id} · community weighted`}
+            epochLabel={`Round #${epochId} · community weighted`}
           />
         </div>
         <div className="lg:w-72 rounded-xl border border-border bg-card px-4 py-4 flex flex-col gap-3">
@@ -205,8 +375,17 @@ function StepExplain() {
   )
 }
 
-function StepCounterfactual() {
-  const { counterfactual, total_score, rank } = LIVE_EXPLANATION
+function StepCounterfactual({ liveData }: StepProps) {
+  const explanationView = explanationForDemo(liveData)
+  const liveExplanation = explanationView.explanation
+  const counterfactual = liveExplanation?.counterfactual ?? {
+    pureEngagementRank: SNAPSHOT_EXPLANATION.counterfactual.pure_engagement_rank,
+    communityGovernedRank: SNAPSHOT_EXPLANATION.counterfactual.community_governed_rank,
+    difference: SNAPSHOT_EXPLANATION.counterfactual.difference,
+  }
+  const total_score = liveExplanation?.totalScore ?? SNAPSHOT_EXPLANATION.total_score
+  const rank = liveExplanation?.rank ?? SNAPSHOT_EXPLANATION.rank
+  const epochId = liveExplanation?.epochId ?? SNAPSHOT_EXPLANATION.epoch_id
   const diff = counterfactual.difference
   const moved = diff > 0 ? "up" : diff < 0 ? "down" : "same"
   const governanceExplanation =
@@ -218,14 +397,14 @@ function StepCounterfactual() {
   const boxes = [
     {
       label: "Engagement-only rank",
-      value: `#${counterfactual.pure_engagement_rank}`,
+      value: `#${counterfactual.pureEngagementRank}`,
       sub: "If sorted by likes alone",
       color: "text-tongue-foreground",
       bg: "bg-tongue/10 border-tongue/20",
     },
     {
       label: "Community-governed rank",
-      value: `#${counterfactual.community_governed_rank}`,
+      value: `#${counterfactual.communityGovernedRank}`,
       sub: "With your community's weights applied",
       color: "text-success",
       bg: "bg-success/10 border-success/20",
@@ -241,7 +420,7 @@ function StepCounterfactual() {
   return (
     <div className="flex flex-col gap-8">
       <p className="text-sm text-foreground/55 leading-relaxed max-w-xl">
-        This post scored <span className="font-mono font-semibold text-foreground">{total_score.toFixed(2)}</span> and ranked <span className="font-mono font-semibold text-foreground">#{rank}</span>. A pure engagement sort would have placed it at rank #{counterfactual.pure_engagement_rank}.
+        This post scored <span className="font-mono font-semibold text-foreground">{total_score.toFixed(3)}</span> and ranked <span className="font-mono font-semibold text-foreground">#{rank}</span>. A pure engagement sort would have placed it at rank #{counterfactual.pureEngagementRank}.
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         {boxes.map((box) => (
@@ -261,7 +440,7 @@ function StepCounterfactual() {
           href="/vote"
           className="mt-1 inline-flex items-center gap-1.5 text-sm font-semibold text-primary hover:text-primary-dark transition-colors"
         >
-          Cast your vote in Round #{LIVE_EXPLANATION.epoch_id}
+          Cast your vote in Round #{epochId}
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
@@ -275,18 +454,51 @@ function StepCounterfactual() {
 
 export default function DemoPage() {
   const [step, setStep] = useState(0) // 0-indexed
+  const [liveData, setLiveData] = useState<LiveDemoData | null>(null)
+  const [liveError, setLiveError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    setLoading(true)
+    setLiveError(null)
+
+    fetchLiveDemoData(controller.signal)
+      .then((data) => {
+        setLiveData(data)
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) {
+          return
+        }
+
+        setLiveError(error instanceof Error ? error.message : String(error))
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      controller.abort()
+    }
+  }, [])
 
   const total = STEPS.length
   const current = STEPS[step]
   const isFirst = step === 0
   const isLast = step === total - 1
+  const isLiveFeedVisible = liveData !== null && liveData.posts.length > 0
+  const hasSnapshotStats = liveData?.stats === null || liveData?.stats === undefined
 
   const stepContent = [
-    <StepStats key="stats" />,
-    <StepFeed key="feed" />,
-    <StepTopics key="topics" />,
-    <StepExplain key="explain" />,
-    <StepCounterfactual key="counterfactual" />,
+    <StepStats key="stats" liveData={liveData} liveError={liveError} loading={loading} />,
+    <StepFeed key="feed" liveData={liveData} liveError={liveError} loading={loading} />,
+    <StepTopics key="topics" liveData={liveData} liveError={liveError} loading={loading} />,
+    <StepExplain key="explain" liveData={liveData} liveError={liveError} loading={loading} />,
+    <StepCounterfactual key="counterfactual" liveData={liveData} liveError={liveError} loading={loading} />,
   ]
 
   return (
@@ -298,8 +510,23 @@ export default function DemoPage() {
           <span className="text-[10px] font-mono uppercase tracking-widest text-foreground/35">Guided walkthrough</span>
           <h1 className="font-display text-2xl font-bold text-foreground tracking-normal">How Corgi works</h1>
           <p className="text-sm text-foreground/50 leading-relaxed max-w-lg">
-            A 5-step tour using a dated live-production receipt. Read-only; your feed is unchanged.
+            A read-only tour that uses the current Corgi feed and Bluesky posts when available, with dated receipts only where a live endpoint is unavailable.
           </p>
+          <div className="flex flex-wrap items-center gap-2 pt-2">
+            <StatusChip phase={isLiveFeedVisible ? "live" : loading ? "running" : "waiting"} />
+            <span className="text-xs text-foreground/40">
+              {loading
+                ? "Refreshing live feed..."
+                : isLiveFeedVisible
+                  ? `Live feed refreshed ${formatTimestamp(liveData.fetchedAt)}`
+                  : "Showing snapshot fallback"}
+            </span>
+            {hasSnapshotStats && !loading && (
+              <span className="text-xs text-foreground/40">
+                Stats snapshot: {LIVE_METRICS_SNAPSHOT.collectedAtLabel}
+              </span>
+            )}
+          </div>
         </div>
 
         {/* ── Step rail ────────────────────────────────────────────── */}
@@ -405,7 +632,7 @@ export default function DemoPage() {
 
         {/* ── Footer note ──────────────────────────────────────────── */}
         <p className="text-center text-xs text-foreground/35 leading-relaxed">
-          This walkthrough uses the {LIVE_METRICS_SNAPSHOT.collectedAtLabel} live-production metrics packet. Current feed data is live at{" "}
+          Current posts come from the Corgi live feed skeleton and the Bluesky public AppView when those endpoints respond. Snapshot receipts are labeled inline. Current feed data is also live at{" "}
           <Link href="/dashboard" className="text-primary hover:underline">Overview</Link>.
         </p>
       </div>

--- a/web-next/app/demo/page.tsx
+++ b/web-next/app/demo/page.tsx
@@ -3,73 +3,53 @@
 import { useState } from "react"
 import Link from "next/link"
 import { AppShell } from "@/components/app-shell"
-import { ScoreBreakdown, type ScoreComponent } from "@/components/ui/score-breakdown"
+import { ScoreBreakdown } from "@/components/ui/score-breakdown"
 import { ScoreRadar } from "@/components/ui/score-radar"
 import { WeightBar } from "@/components/ui/weight-bar"
 import { StatusChip } from "@/components/ui/status-chip"
+import { LIVE_FEED_POSTS, LIVE_METRICS_SNAPSHOT, LIVE_RANK_ONE_EXPLANATION } from "@/lib/live-metrics-snapshot"
 
-// ── Mock data (seam-exact field names) ───────────────────────────────────────
+// ── Live snapshot view-models (API-exact field names) ────────────────────────
 
-const MOCK_STATS = {
-  epoch: { id: 47, phase: "voting" as const },
+const LIVE_STATS = {
+  epoch: { id: LIVE_METRICS_SNAPSHOT.epochId, phase: "live" as const },
   feed_stats: {
-    total_posts_scored: 1240,
-    unique_authors: 318,
-    avg_bridging: 0.41,
-    avg_total: 0.57,
+    total_posts_scored: LIVE_METRICS_SNAPSHOT.scoredPosts,
+    unique_authors: LIVE_METRICS_SNAPSHOT.uniqueAuthors,
+    avg_bridging: LIVE_METRICS_SNAPSHOT.avgBridging,
+    avg_engagement: LIVE_METRICS_SNAPSHOT.avgEngagement,
+    median_bridging: LIVE_METRICS_SNAPSHOT.medianBridging,
+    median_total: LIVE_METRICS_SNAPSHOT.medianTotal,
   },
-  governance: { votes_this_epoch: 312 },
-  metrics: {
-    author_gini: 0.34,
-    vs_chronological_overlap: 0.61,
-    vs_engagement_overlap: 0.44,
-  },
+  governance: { votes_this_epoch: LIVE_METRICS_SNAPSHOT.votesThisEpoch },
 }
 
-const MOCK_WEIGHTS = {
-  recency: 0.35,
-  engagement: 0.25,
-  bridging: 0.20,
-  source_diversity: 0.15,
-  relevance: 0.05,
-}
+const LIVE_WEIGHTS = LIVE_METRICS_SNAPSHOT.weights
 
-const MOCK_TOPICS = [
-  { slug: "machine-learning", name: "Machine learning", currentWeight: 0.62, communityAvg: 0.55 },
-  { slug: "open-source", name: "Open source", currentWeight: 0.71, communityAvg: 0.60 },
-  { slug: "science", name: "Science", currentWeight: 0.50, communityAvg: 0.50 },
-  { slug: "politics", name: "Politics", currentWeight: 0.32, communityAvg: 0.41 },
-  { slug: "sports", name: "Sports", currentWeight: 0.28, communityAvg: 0.35 },
-]
+const LIVE_TOPICS = LIVE_METRICS_SNAPSHOT.topics
 
-const MOCK_EXPLANATION = {
-  post_uri: "at://did:plc:abc123/app.bsky.feed.post/xyz789",
-  author: "maya.bsky.social",
-  text: "New benchmark results show open-source models closing the gap with proprietary ones on reasoning tasks.",
-  epoch_id: 47,
-  total_score: 0.57,
-  rank: 3,
-  components: [
-    { key: "recency",          label: "Recency",          raw_score: 0.82, weight: 0.35, weighted: 0.287 },
-    { key: "engagement",       label: "Engagement",       raw_score: 0.61, weight: 0.25, weighted: 0.153 },
-    { key: "bridging",         label: "Bridging",         raw_score: 0.44, weight: 0.20, weighted: 0.088 },
-    { key: "source_diversity", label: "Source diversity", raw_score: 0.29, weight: 0.15, weighted: 0.044 },
-    { key: "relevance",        label: "Relevance",        raw_score: 0.40, weight: 0.05, weighted: 0.020 },
-  ] satisfies ScoreComponent[],
-  governance_weights: MOCK_WEIGHTS,
+const LIVE_EXPLANATION = {
+  post_uri: LIVE_RANK_ONE_EXPLANATION.receiptId,
+  author: LIVE_RANK_ONE_EXPLANATION.authorLabel,
+  text: LIVE_RANK_ONE_EXPLANATION.text,
+  epoch_id: LIVE_RANK_ONE_EXPLANATION.epochId,
+  total_score: LIVE_RANK_ONE_EXPLANATION.totalScore,
+  rank: LIVE_RANK_ONE_EXPLANATION.rank,
+  components: LIVE_RANK_ONE_EXPLANATION.components,
+  governance_weights: LIVE_WEIGHTS,
   counterfactual: {
-    pure_engagement_rank: 9,
-    community_governed_rank: 3,
-    difference: 6,
+    pure_engagement_rank: LIVE_RANK_ONE_EXPLANATION.counterfactual.pureEngagementRank,
+    community_governed_rank: LIVE_RANK_ONE_EXPLANATION.counterfactual.communityGovernedRank,
+    difference: LIVE_RANK_ONE_EXPLANATION.counterfactual.difference,
   },
 }
 
 // ── Step definitions ──────────────────────────────────────────────────────────
 
 const STEPS = [
-  { id: 1, label: "Feed stats",    title: "How the feed performed" },
+  { id: 1, label: "Feed stats",    title: "Live production snapshot" },
   { id: 2, label: "Live feed",     title: "Posts ranked by your community" },
-  { id: 3, label: "Topic weights", title: "What your community amplifies" },
+  { id: 3, label: "Topic signal",  title: "What this post matched" },
   { id: 4, label: "Explain a post", title: "See exactly why this post ranked" },
   { id: 5, label: "Counterfactual", title: "What would have happened instead" },
 ]
@@ -77,17 +57,17 @@ const STEPS = [
 // ── Step content components ───────────────────────────────────────────────────
 
 function StepStats() {
-  const { feed_stats, epoch, governance, metrics } = MOCK_STATS
+  const { feed_stats, epoch, governance } = LIVE_STATS
   const stats = [
     { label: "Posts scored",    value: feed_stats.total_posts_scored.toLocaleString() },
     { label: "Authors",         value: feed_stats.unique_authors.toLocaleString() },
     { label: "Votes this round", value: governance.votes_this_epoch.toLocaleString() },
-    { label: "Avg score",       value: feed_stats.avg_total.toFixed(2) },
+    { label: "Median score",    value: feed_stats.median_total.toFixed(2) },
   ]
   const health = [
-    { label: "vs Chronological", value: `${Math.round(metrics.vs_chronological_overlap * 100)}%`, hint: "posts in common with time-sorted" },
-    { label: "vs Engagement-only", value: `${Math.round(metrics.vs_engagement_overlap * 100)}%`, hint: "posts in common with likes-sorted" },
-    { label: "Author diversity", value: metrics.author_gini.toFixed(2), hint: "Gini coefficient — lower is more diverse" },
+    { label: "Average bridging", value: feed_stats.avg_bridging.toFixed(2), hint: "mean raw bridging score" },
+    { label: "Average engagement", value: feed_stats.avg_engagement.toFixed(2), hint: "mean raw engagement score" },
+    { label: "Median bridging", value: feed_stats.median_bridging.toFixed(2), hint: "middle raw bridging score" },
   ]
   return (
     <div className="flex flex-col gap-8">
@@ -115,24 +95,18 @@ function StepStats() {
       </div>
       <div className="flex items-center gap-2 p-4 rounded-xl bg-biscuit/60 text-sm text-foreground/60 leading-relaxed">
         <StatusChip phase={epoch.phase} />
-        <span>Round #{epoch.id} is currently open for voting. Results update once the round closes.</span>
+        <span>Round #{epoch.id} is active. Snapshot refreshed from public endpoints on {LIVE_METRICS_SNAPSHOT.collectedAtLabel}.</span>
       </div>
     </div>
   )
 }
 
-const MOCK_FEED_POSTS = [
-  { rank: 1, author: "alice.bsky.social",  score: 0.74, text: "Open-source models are catching up fast — new reasoning benchmark shows parity with GPT-4." },
-  { rank: 2, author: "bob.bsky.social",    score: 0.68, text: "Science funding in the EU set to double over the next decade. Good news for open research." },
-  { rank: 3, author: "maya.bsky.social",   score: 0.57, text: "New benchmark results show open-source models closing the gap with proprietary ones." },
-  { rank: 4, author: "carlos.bsky.social", score: 0.51, text: "Some really thoughtful work coming out of independent ML labs this week." },
-  { rank: 5, author: "dana.bsky.social",   score: 0.44, text: "Bridging score matters more than you'd think — posts that connect different clusters bubble up." },
-]
+const LIVE_FEED_VIEW_POSTS = LIVE_FEED_POSTS
 
 function StepFeed() {
   return (
     <div className="flex flex-col gap-3">
-      {MOCK_FEED_POSTS.map((post) => (
+      {LIVE_FEED_VIEW_POSTS.map((post) => (
         <div key={post.rank} className="flex items-start gap-4 rounded-xl border border-border bg-card px-5 py-4">
           <span className="text-xl font-mono font-bold text-foreground/25 tabular-nums w-7 flex-shrink-0 pt-0.5">
             {post.rank}
@@ -149,7 +123,7 @@ function StepFeed() {
         </div>
       ))}
       <p className="text-xs text-foreground/40 text-center pt-2">
-        Ranked by community-voted weights, not engagement alone.
+        Top scored posts from the anonymized {LIVE_METRICS_SNAPSHOT.collectedAtLabel} production transparency receipt.
       </p>
     </div>
   )
@@ -159,10 +133,10 @@ function StepTopics() {
   return (
     <div className="flex flex-col gap-6">
       <p className="text-sm text-foreground/55 leading-relaxed">
-        Your community votes to boost or suppress topics. The bar shows the community&apos;s current applied weight — right of centre boosts, left reduces.
+        The explained post carried a stored relevance topic breakdown. This is public explanation data for that post, not a claim about all current feed topics.
       </p>
       <div className="flex flex-col">
-        {MOCK_TOPICS.map((t) => {
+        {LIVE_TOPICS.map((t) => {
           const boosted  = t.currentWeight > 0.55
           const reduced  = t.currentWeight < 0.45
           const direction = boosted ? "Boosted" : reduced ? "Reduced" : "Neutral"
@@ -196,7 +170,7 @@ function StepTopics() {
 }
 
 function StepExplain() {
-  const { components, total_score, text, author, rank } = MOCK_EXPLANATION
+  const { components, total_score, text, author, rank } = LIVE_EXPLANATION
   const radarSignals = components.map((c) => ({
     key: c.key,
     label: c.label,
@@ -219,7 +193,7 @@ function StepExplain() {
           <ScoreBreakdown
             components={components}
             total_score={total_score}
-            epochLabel="Round #47 · community weighted"
+            epochLabel={`Round #${LIVE_EXPLANATION.epoch_id} · community weighted`}
           />
         </div>
         <div className="lg:w-72 rounded-xl border border-border bg-card px-4 py-4 flex flex-col gap-3">
@@ -232,9 +206,15 @@ function StepExplain() {
 }
 
 function StepCounterfactual() {
-  const { counterfactual, total_score, rank } = MOCK_EXPLANATION
-  const diff = counterfactual.pure_engagement_rank - counterfactual.community_governed_rank
+  const { counterfactual, total_score, rank } = LIVE_EXPLANATION
+  const diff = counterfactual.difference
   const moved = diff > 0 ? "up" : diff < 0 ? "down" : "same"
+  const governanceExplanation =
+    moved === "up"
+      ? "The feed ranked this post higher because the active epoch weights relevance and recency alongside engagement, and the stored explanation exposes each contribution."
+      : moved === "down"
+        ? "The feed ranked this post lower once relevance and recency were weighted alongside engagement, and the stored explanation exposes each contribution."
+        : "The active epoch weights relevance and recency alongside engagement; for this post that produced the same rank, and the stored explanation exposes each contribution."
   const boxes = [
     {
       label: "Engagement-only rank",
@@ -251,9 +231,9 @@ function StepCounterfactual() {
       bg: "bg-success/10 border-success/20",
     },
     {
-      label: "Positions gained",
+      label: moved === "up" ? "Positions gained" : moved === "down" ? "Positions lost" : "Rank change",
       value: moved === "up" ? `+${diff}` : moved === "down" ? `${diff}` : "—",
-      sub: "Moved up by community governance",
+      sub: moved === "up" ? "Moved up by community governance" : moved === "down" ? "Moved down by community governance" : "No rank movement",
       color: diff > 0 ? "text-success" : diff < 0 ? "text-tongue-foreground" : "text-foreground/40",
       bg: diff > 0 ? "bg-success/10 border-success/20" : diff < 0 ? "bg-tongue/10 border-tongue/20" : "bg-biscuit border-border",
     },
@@ -261,7 +241,7 @@ function StepCounterfactual() {
   return (
     <div className="flex flex-col gap-8">
       <p className="text-sm text-foreground/55 leading-relaxed max-w-xl">
-        This post scored <span className="font-mono font-semibold text-foreground">{total_score.toFixed(2)}</span> and ranked <span className="font-mono font-semibold text-foreground">#{rank}</span>. Without community governance, a pure engagement sort would have placed it much lower.
+        This post scored <span className="font-mono font-semibold text-foreground">{total_score.toFixed(2)}</span> and ranked <span className="font-mono font-semibold text-foreground">#{rank}</span>. A pure engagement sort would have placed it at rank #{counterfactual.pure_engagement_rank}.
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         {boxes.map((box) => (
@@ -275,13 +255,13 @@ function StepCounterfactual() {
       <div className="rounded-xl bg-biscuit/60 border border-border px-5 py-4 flex flex-col gap-2">
         <p className="text-sm font-semibold text-foreground">This is what community governance means.</p>
         <p className="text-sm text-foreground/55 leading-relaxed">
-          The feed ranked this post higher not because it got the most likes, but because your community voted for bridging and source diversity — and this post delivered on both.
+          {governanceExplanation}
         </p>
         <Link
           href="/vote"
           className="mt-1 inline-flex items-center gap-1.5 text-sm font-semibold text-primary hover:text-primary-dark transition-colors"
         >
-          Cast your vote in Round #47
+          Cast your vote in Round #{LIVE_EXPLANATION.epoch_id}
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
@@ -318,7 +298,7 @@ export default function DemoPage() {
           <span className="text-[10px] font-mono uppercase tracking-widest text-foreground/35">Guided walkthrough</span>
           <h1 className="font-display text-2xl font-bold text-foreground tracking-normal">How Corgi works</h1>
           <p className="text-sm text-foreground/50 leading-relaxed max-w-lg">
-            A 5-step tour of the transparency loop — from community votes to ranked posts. Read-only; your feed is unchanged.
+            A 5-step tour using a dated live-production receipt. Read-only; your feed is unchanged.
           </p>
         </div>
 
@@ -425,7 +405,7 @@ export default function DemoPage() {
 
         {/* ── Footer note ──────────────────────────────────────────── */}
         <p className="text-center text-xs text-foreground/35 leading-relaxed">
-          This walkthrough uses sample data. Your actual feed data is live at{" "}
+          This walkthrough uses the {LIVE_METRICS_SNAPSHOT.collectedAtLabel} live-production metrics packet. Current feed data is live at{" "}
           <Link href="/dashboard" className="text-primary hover:underline">Overview</Link>.
         </p>
       </div>

--- a/web-next/components/animated-section.tsx
+++ b/web-next/components/animated-section.tsx
@@ -1,20 +1,23 @@
 "use client"
 
 import { motion } from "framer-motion"
-import type { HTMLAttributes, ReactNode } from "react"
+import type { HTMLMotionProps } from "framer-motion"
+import type { ReactNode } from "react"
 
-interface AnimatedSectionProps extends HTMLAttributes<HTMLDivElement> {
+interface AnimatedSectionProps extends Omit<HTMLMotionProps<"div">, "children" | "initial" | "whileInView" | "viewport" | "transition"> {
   children: ReactNode
   delay?: number
 }
 
-export function AnimatedSection({ children, className, delay = 0, ...props }: AnimatedSectionProps) {
+export function AnimatedSection({ children, className, delay, ...props }: AnimatedSectionProps) {
+  const transitionDelay = delay ?? 0
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20, scale: 0.98 }}
       whileInView={{ opacity: 1, y: 0, scale: 1 }}
       viewport={{ once: true }}
-      transition={{ duration: 0.8, ease: [0.33, 1, 0.68, 1], delay }}
+      transition={{ duration: 0.8, ease: [0.33, 1, 0.68, 1], delay: transitionDelay }}
       className={className}
       {...props}
     >

--- a/web-next/components/dashboard-preview.tsx
+++ b/web-next/components/dashboard-preview.tsx
@@ -1,12 +1,15 @@
 // Score breakdown card — the "killer feature" UI shown below the hero
+import { LIVE_METRICS_SNAPSHOT, LIVE_RANK_ONE_EXPLANATION } from "@/lib/live-metrics-snapshot"
+
 export function DashboardPreview() {
-  const signals = [
-    { label: "Recency", weight: 0.35, value: "+0.82", bar: 82, positive: true },
-    { label: "Reply depth", weight: 0.25, value: "+0.61", bar: 61, positive: true },
-    { label: "Follows author", weight: 0.20, value: "+0.44", bar: 44, positive: true },
-    { label: "Quality score", weight: 0.15, value: "+0.29", bar: 29, positive: true },
-    { label: "Spam risk", weight: 0.05, value: "-0.04", bar: 8, positive: false },
-  ]
+  const signals = LIVE_RANK_ONE_EXPLANATION.components.map((component) => ({
+    label: component.label,
+    weight: component.weight,
+    value: `+${component.raw_score.toFixed(2)}`,
+    bar: Math.round(component.raw_score * 100),
+    positive: component.weighted >= 0,
+  }))
+  const totalScorePrefix = LIVE_RANK_ONE_EXPLANATION.totalScore >= 0 ? "+" : "-"
 
   return (
     <div className="w-full max-w-[900px]">
@@ -22,14 +25,14 @@ export function DashboardPreview() {
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1 flex-wrap">
-              <span className="text-foreground font-semibold text-sm">alicia.bsky.social</span>
-              <span className="text-foreground/40 text-xs">· 2h</span>
+              <span className="text-foreground font-semibold text-sm">{LIVE_RANK_ONE_EXPLANATION.authorLabel}</span>
+              <span className="text-foreground/40 text-xs">· anonymized live receipt</span>
               <span className="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-semibold font-mono">
-                score: 0.57
+                score: {LIVE_RANK_ONE_EXPLANATION.totalScore.toFixed(2)}
               </span>
             </div>
             <p className="text-foreground/80 text-sm leading-relaxed">
-              The governance model here is genuinely novel. Watching my community vote in real time and see the feed update is unlike anything else on Bluesky.
+              {LIVE_RANK_ONE_EXPLANATION.text}
             </p>
           </div>
         </div>
@@ -67,10 +70,12 @@ export function DashboardPreview() {
           {/* Total — anchors the right side and ties the math together */}
           <div className="mt-4 pt-3 border-t border-border flex items-center justify-between">
             <span className="text-foreground text-sm font-semibold">Total score</span>
-            <span className="text-primary text-lg font-bold font-mono">+0.57</span>
+            <span className="text-primary text-lg font-bold font-mono">
+              {totalScorePrefix}{Math.abs(LIVE_RANK_ONE_EXPLANATION.totalScore).toFixed(2)}
+            </span>
           </div>
           <div className="mt-3 flex items-center justify-between">
-            <span className="text-foreground/40 text-xs">Epoch #47 · voted by 312 members</span>
+            <span className="text-foreground/40 text-xs">Epoch #{LIVE_METRICS_SNAPSHOT.epochId} · refreshed {LIVE_METRICS_SNAPSHOT.collectedAtLabel}</span>
             <button className="text-primary text-xs font-medium hover:underline">
               View epoch history &rarr;
             </button>

--- a/web-next/components/dashboard-preview.tsx
+++ b/web-next/components/dashboard-preview.tsx
@@ -5,7 +5,7 @@ export function DashboardPreview() {
   const signals = LIVE_RANK_ONE_EXPLANATION.components.map((component) => ({
     label: component.label,
     weight: component.weight,
-    value: `+${component.raw_score.toFixed(2)}`,
+    value: `${component.raw_score >= 0 ? "+" : "-"}${Math.abs(component.raw_score).toFixed(2)}`,
     bar: Math.round(component.raw_score * 100),
     positive: component.weighted >= 0,
   }))

--- a/web-next/components/hero-section.tsx
+++ b/web-next/components/hero-section.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
+import { LIVE_METRICS_SNAPSHOT } from "@/lib/live-metrics-snapshot"
 
 export function HeroSection() {
   return (
@@ -166,6 +167,9 @@ export function HeroSection() {
       {/* Trust line */}
       <p className="relative z-10 mt-3 text-xs text-foreground/40 font-medium">
         Free &middot; App-password secure &middot; Leave anytime
+      </p>
+      <p className="relative z-10 mt-2 text-xs text-foreground/40 font-medium">
+        Live snapshot, {LIVE_METRICS_SNAPSHOT.collectedAtLabel}: {LIVE_METRICS_SNAPSHOT.scoredPosts.toLocaleString("en-US")} scored posts &middot; {LIVE_METRICS_SNAPSHOT.uniqueAuthors.toLocaleString("en-US")} authors &middot; epoch {LIVE_METRICS_SNAPSHOT.epochId} active
       </p>
     </section>
   )

--- a/web-next/components/ui/score-breakdown.tsx
+++ b/web-next/components/ui/score-breakdown.tsx
@@ -11,7 +11,7 @@ export interface ScoreComponent {
 }
 
 interface ScoreBreakdownProps {
-  components: ScoreComponent[]
+  components: readonly ScoreComponent[]
   total_score: number
   /** Context label shown in footer */
   epochLabel?: string

--- a/web-next/components/ui/score-radar.tsx
+++ b/web-next/components/ui/score-radar.tsx
@@ -43,10 +43,10 @@ function GingerDot(props: {
 /* Custom tooltip */
 function RadarTooltip({ active, payload }: {
   active?: boolean
-  payload?: Array<{ name: string; value: number; dataKey: string }>
+  payload?: Array<{ name: string; value: number; dataKey: string; payload?: { label?: string } }>
 }) {
   if (!active || !payload?.length) return null
-  const label = payload[0]?.payload?.label as string | undefined
+  const label = payload[0]?.payload?.label
   return (
     <div className="rounded-lg border border-border bg-card shadow-md px-3 py-2 text-xs">
       <p className="font-semibold text-foreground mb-1.5">{label}</p>

--- a/web-next/lib/live-demo-data.ts
+++ b/web-next/lib/live-demo-data.ts
@@ -1,0 +1,634 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? ""
+const BLUESKY_APPVIEW_BASE_URL = "https://public.api.bsky.app"
+const LIVE_FEED_LIMIT = 4
+const REQUEST_TIMEOUT_MS = 12_000
+
+export const CORGI_COMMUNITY_FEED_URI =
+  "at://did:plc:amzyknmm4auxijvykyfgznw2/app.bsky.feed.generator/community-gov"
+
+export interface LiveDemoWeights {
+  readonly epochId: number
+  readonly status: string
+  readonly voteCount: number
+  readonly createdAt: string
+  readonly weights: {
+    readonly recency: number
+    readonly engagement: number
+    readonly bridging: number
+    readonly source_diversity: number
+    readonly relevance: number
+  }
+}
+
+export interface LiveDemoStats {
+  readonly epochId: number
+  readonly totalPostsScored: number
+  readonly uniqueAuthors: number
+  readonly avgBridging: number
+  readonly avgEngagement: number
+  readonly medianBridging: number
+  readonly medianTotal: number
+  readonly votesThisEpoch: number
+}
+
+export interface LiveDemoFeedPost {
+  readonly rank: number
+  readonly uri: string
+  readonly bskyUrl: string
+  readonly authorHandle: string
+  readonly authorDisplayName: string
+  readonly text: string
+  readonly indexedAt: string | null
+  readonly likeCount: number | null
+  readonly repostCount: number | null
+  readonly replyCount: number | null
+  readonly score: number | null
+}
+
+export interface LiveDemoScoreComponent {
+  readonly key: string
+  readonly label: string
+  readonly raw_score: number
+  readonly weight: number
+  readonly weighted: number
+}
+
+export interface LiveDemoTopicBreakdown {
+  readonly slug: string
+  readonly name: string
+  readonly postScore: number
+  readonly communityWeight: number
+  readonly contribution: number
+}
+
+export interface LiveDemoExplanation {
+  readonly postUri: string
+  readonly epochId: number
+  readonly totalScore: number
+  readonly rank: number
+  readonly components: readonly LiveDemoScoreComponent[]
+  readonly counterfactual: {
+    readonly pureEngagementRank: number
+    readonly communityGovernedRank: number
+    readonly difference: number
+  }
+  readonly scoredAt: string
+  readonly topicBreakdown: readonly LiveDemoTopicBreakdown[]
+}
+
+export interface LiveDemoData {
+  readonly fetchedAt: string
+  readonly feedCursor: string | null
+  readonly posts: readonly LiveDemoFeedPost[]
+  readonly weights: LiveDemoWeights | null
+  readonly stats: LiveDemoStats | null
+  readonly explanation: LiveDemoExplanation | null
+  readonly errors: readonly string[]
+}
+
+export class LiveDemoDataError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "LiveDemoDataError"
+  }
+}
+
+interface FeedSkeletonResponse {
+  readonly feed?: readonly { readonly post?: unknown }[]
+  readonly cursor?: unknown
+}
+
+interface GovernanceWeightsResponse {
+  readonly epoch_id?: unknown
+  readonly status?: unknown
+  readonly vote_count?: unknown
+  readonly created_at?: unknown
+  readonly weights?: {
+    readonly recency?: unknown
+    readonly engagement?: unknown
+    readonly bridging?: unknown
+    readonly sourceDiversity?: unknown
+    readonly source_diversity?: unknown
+    readonly relevance?: unknown
+  }
+}
+
+interface FeedStatsResponse {
+  readonly epoch?: {
+    readonly id?: unknown
+  }
+  readonly feed_stats?: {
+    readonly total_posts_scored?: unknown
+    readonly unique_authors?: unknown
+    readonly avg_bridging_score?: unknown
+    readonly avg_engagement_score?: unknown
+    readonly median_bridging_score?: unknown
+    readonly median_total_score?: unknown
+  }
+  readonly governance?: {
+    readonly votes_this_epoch?: unknown
+  }
+}
+
+interface HydratedPostResponse {
+  readonly posts?: readonly HydratedPostApi[]
+}
+
+interface HydratedPostApi {
+  readonly uri?: unknown
+  readonly author?: {
+    readonly handle?: unknown
+    readonly displayName?: unknown
+  }
+  readonly record?: {
+    readonly text?: unknown
+  }
+  readonly indexedAt?: unknown
+  readonly likeCount?: unknown
+  readonly repostCount?: unknown
+  readonly replyCount?: unknown
+}
+
+interface ScoreComponentApi {
+  readonly raw_score?: unknown
+  readonly weight?: unknown
+  readonly weighted?: unknown
+}
+
+interface RelevanceScoreComponentApi extends ScoreComponentApi {
+  readonly topicBreakdown?: Record<string, TopicBreakdownApi>
+}
+
+interface TopicBreakdownApi {
+  readonly postScore?: unknown
+  readonly communityWeight?: unknown
+  readonly contribution?: unknown
+}
+
+interface PostExplanationResponse {
+  readonly post_uri?: unknown
+  readonly epoch_id?: unknown
+  readonly total_score?: unknown
+  readonly rank?: unknown
+  readonly components?: {
+    readonly recency?: ScoreComponentApi
+    readonly engagement?: ScoreComponentApi
+    readonly bridging?: ScoreComponentApi
+    readonly source_diversity?: ScoreComponentApi
+    readonly relevance?: RelevanceScoreComponentApi
+  }
+  readonly counterfactual?: {
+    readonly pure_engagement_rank?: unknown
+    readonly community_governed_rank?: unknown
+    readonly difference?: unknown
+  }
+  readonly scored_at?: unknown
+}
+
+const SCORE_COMPONENTS = [
+  { key: "recency", label: "Recency" },
+  { key: "engagement", label: "Engagement" },
+  { key: "bridging", label: "Bridging" },
+  { key: "source_diversity", label: "Source diversity" },
+  { key: "relevance", label: "Relevance" },
+] as const
+
+function buildCorgiUrl(path: string): string {
+  if (API_BASE_URL.length === 0) {
+    return path
+  }
+
+  return new URL(path, API_BASE_URL).toString()
+}
+
+export function buildPostHydrationUrl(postUris: readonly string[]): string {
+  const url = new URL("/xrpc/app.bsky.feed.getPosts", BLUESKY_APPVIEW_BASE_URL)
+
+  for (const postUri of postUris) {
+    url.searchParams.append("uris", postUri)
+  }
+
+  return url.toString()
+}
+
+export function bskyPostUrlFromAtUri(postUri: string): string {
+  const match = /^at:\/\/([^/]+)\/app\.bsky\.feed\.post\/([^/]+)$/.exec(postUri)
+
+  if (match === null) {
+    throw new LiveDemoDataError(`Unable to build Bluesky URL from post URI: ${postUri}`)
+  }
+
+  const repo = match[1]
+  const rkey = match[2]
+
+  if (repo === undefined || rkey === undefined) {
+    throw new LiveDemoDataError(`Unable to parse Bluesky post URI: ${postUri}`)
+  }
+
+  return `https://bsky.app/profile/${repo}/post/${rkey}`
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}
+
+function asString(value: unknown, field: string): string {
+  if (typeof value === "string" && value.length > 0) {
+    return value
+  }
+
+  throw new LiveDemoDataError(`Expected ${field} to be a non-empty string`)
+}
+
+function asNumber(value: unknown, field: string): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+
+  throw new LiveDemoDataError(`Expected ${field} to be a finite number`)
+}
+
+function asOptionalNumber(value: unknown, field: string): number | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  return asNumber(value, field)
+}
+
+function humanizeSlug(slug: string): string {
+  return slug
+    .split("-")
+    .filter((part) => part.length > 0)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ")
+}
+
+function createTimedSignal(
+  parentSignal: AbortSignal,
+  timeoutMs: number,
+  context: string,
+): { readonly signal: AbortSignal; readonly dispose: () => void } {
+  const controller = new AbortController()
+  const timeoutId: ReturnType<typeof globalThis.setTimeout> = globalThis.setTimeout(() => {
+    controller.abort(new LiveDemoDataError(`${context} timed out after ${timeoutMs}ms`))
+  }, timeoutMs)
+  const abortFromParent = (): void => {
+    controller.abort(parentSignal.reason)
+  }
+
+  if (parentSignal.aborted) {
+    abortFromParent()
+  } else {
+    parentSignal.addEventListener("abort", abortFromParent, { once: true })
+  }
+
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      globalThis.clearTimeout(timeoutId)
+      parentSignal.removeEventListener("abort", abortFromParent)
+    },
+  }
+}
+
+async function fetchJson<TResponse>(
+  url: string,
+  signal: AbortSignal,
+  context: string,
+): Promise<TResponse> {
+  const timedSignal = createTimedSignal(signal, REQUEST_TIMEOUT_MS, context)
+
+  try {
+    const response = await fetch(url, {
+      signal: timedSignal.signal,
+      headers: {
+        Accept: "application/json",
+      },
+    })
+    const body = await response.text()
+
+    if (!response.ok) {
+      throw new LiveDemoDataError(
+        `${context} failed with HTTP ${response.status} ${response.statusText}: ${body.slice(0, 500)}`,
+      )
+    }
+
+    try {
+      return JSON.parse(body) as TResponse
+    } catch (error) {
+      throw new LiveDemoDataError(`${context} returned invalid JSON: ${errorMessage(error)}`)
+    }
+  } catch (error) {
+    if (error instanceof LiveDemoDataError) {
+      throw error
+    }
+
+    if (timedSignal.signal.aborted && timedSignal.signal.reason instanceof Error) {
+      throw new LiveDemoDataError(`${context} aborted: ${timedSignal.signal.reason.message}`)
+    }
+
+    throw new LiveDemoDataError(`${context} request failed: ${errorMessage(error)}`)
+  } finally {
+    timedSignal.dispose()
+  }
+}
+
+function normalizeFeedSkeleton(response: FeedSkeletonResponse): {
+  readonly postUris: readonly string[]
+  readonly cursor: string | null
+} {
+  if (!Array.isArray(response.feed)) {
+    throw new LiveDemoDataError("Corgi feed skeleton response did not include a feed array")
+  }
+
+  const postUris = response.feed.map((item, index) =>
+    asString(item.post, `feed[${index}].post`),
+  )
+
+  return {
+    postUris,
+    cursor: typeof response.cursor === "string" && response.cursor.length > 0 ? response.cursor : null,
+  }
+}
+
+function normalizeWeights(response: GovernanceWeightsResponse): LiveDemoWeights {
+  const weights = response.weights
+
+  if (weights === undefined) {
+    throw new LiveDemoDataError("Governance weights response did not include weights")
+  }
+
+  return {
+    epochId: asNumber(response.epoch_id, "weights.epoch_id"),
+    status: asString(response.status, "weights.status"),
+    voteCount: asNumber(response.vote_count, "weights.vote_count"),
+    createdAt: asString(response.created_at, "weights.created_at"),
+    weights: {
+      recency: asNumber(weights.recency, "weights.recency"),
+      engagement: asNumber(weights.engagement, "weights.engagement"),
+      bridging: asNumber(weights.bridging, "weights.bridging"),
+      source_diversity: asNumber(
+        weights.sourceDiversity ?? weights.source_diversity,
+        "weights.source_diversity",
+      ),
+      relevance: asNumber(weights.relevance, "weights.relevance"),
+    },
+  }
+}
+
+function normalizeStats(response: FeedStatsResponse): LiveDemoStats {
+  if (response.epoch === undefined || response.feed_stats === undefined || response.governance === undefined) {
+    throw new LiveDemoDataError("Transparency stats response did not include epoch, feed_stats, and governance")
+  }
+
+  return {
+    epochId: asNumber(response.epoch.id, "stats.epoch.id"),
+    totalPostsScored: asNumber(response.feed_stats.total_posts_scored, "stats.feed_stats.total_posts_scored"),
+    uniqueAuthors: asNumber(response.feed_stats.unique_authors, "stats.feed_stats.unique_authors"),
+    avgBridging: asNumber(response.feed_stats.avg_bridging_score, "stats.feed_stats.avg_bridging_score"),
+    avgEngagement: asNumber(response.feed_stats.avg_engagement_score, "stats.feed_stats.avg_engagement_score"),
+    medianBridging: asNumber(response.feed_stats.median_bridging_score, "stats.feed_stats.median_bridging_score"),
+    medianTotal: asNumber(response.feed_stats.median_total_score, "stats.feed_stats.median_total_score"),
+    votesThisEpoch: asNumber(response.governance.votes_this_epoch, "stats.governance.votes_this_epoch"),
+  }
+}
+
+function normalizeHydratedPosts(
+  response: HydratedPostResponse,
+  postUris: readonly string[],
+  explanation: LiveDemoExplanation | null,
+): readonly LiveDemoFeedPost[] {
+  if (!Array.isArray(response.posts)) {
+    throw new LiveDemoDataError("Bluesky AppView response did not include a posts array")
+  }
+
+  const rankByUri = new Map(postUris.map((postUri, index) => [postUri, index + 1]))
+
+  return response.posts.map((post) => {
+    const uri = asString(post.uri, "post.uri")
+    const rank = rankByUri.get(uri)
+
+    if (rank === undefined) {
+      throw new LiveDemoDataError(`Bluesky AppView returned an unexpected post URI: ${uri}`)
+    }
+
+    return {
+      rank,
+      uri,
+      bskyUrl: bskyPostUrlFromAtUri(uri),
+      authorHandle: asString(post.author?.handle, `post ${uri} author.handle`),
+      authorDisplayName:
+        typeof post.author?.displayName === "string" && post.author.displayName.length > 0
+          ? post.author.displayName
+          : asString(post.author?.handle, `post ${uri} author.handle`),
+      text:
+        typeof post.record?.text === "string" && post.record.text.length > 0
+          ? post.record.text
+          : "Post text unavailable from Bluesky AppView.",
+      indexedAt: typeof post.indexedAt === "string" && post.indexedAt.length > 0 ? post.indexedAt : null,
+      likeCount: asOptionalNumber(post.likeCount, `post ${uri} likeCount`),
+      repostCount: asOptionalNumber(post.repostCount, `post ${uri} repostCount`),
+      replyCount: asOptionalNumber(post.replyCount, `post ${uri} replyCount`),
+      score: explanation?.postUri === uri ? explanation.totalScore : null,
+    }
+  }).sort((left, right) => left.rank - right.rank)
+}
+
+export function scoreComponentsFromExplanation(
+  response: PostExplanationResponse,
+): readonly LiveDemoScoreComponent[] {
+  if (response.components === undefined) {
+    throw new LiveDemoDataError("Post explanation response did not include components")
+  }
+
+  return SCORE_COMPONENTS.map((component) => {
+    const apiComponent = response.components?.[component.key]
+
+    if (apiComponent === undefined) {
+      throw new LiveDemoDataError(`Post explanation response omitted ${component.key} component`)
+    }
+
+    return {
+      key: component.key,
+      label: component.label,
+      raw_score: asNumber(apiComponent.raw_score, `explanation.components.${component.key}.raw_score`),
+      weight: asNumber(apiComponent.weight, `explanation.components.${component.key}.weight`),
+      weighted: asNumber(apiComponent.weighted, `explanation.components.${component.key}.weighted`),
+    }
+  })
+}
+
+export function topicBreakdownFromExplanation(
+  response: PostExplanationResponse,
+): readonly LiveDemoTopicBreakdown[] {
+  const breakdown = response.components?.relevance?.topicBreakdown
+
+  if (breakdown === undefined) {
+    return []
+  }
+
+  return Object.entries(breakdown)
+    .map(([slug, topic]) => ({
+      slug,
+      name: humanizeSlug(slug),
+      postScore: asNumber(topic.postScore, `topic ${slug} postScore`),
+      communityWeight: asNumber(topic.communityWeight, `topic ${slug} communityWeight`),
+      contribution: asNumber(topic.contribution, `topic ${slug} contribution`),
+    }))
+    .sort((left, right) => right.contribution - left.contribution)
+}
+
+function normalizeExplanation(response: PostExplanationResponse): LiveDemoExplanation {
+  if (response.counterfactual === undefined) {
+    throw new LiveDemoDataError("Post explanation response did not include counterfactual")
+  }
+
+  return {
+    postUri: asString(response.post_uri, "explanation.post_uri"),
+    epochId: asNumber(response.epoch_id, "explanation.epoch_id"),
+    totalScore: asNumber(response.total_score, "explanation.total_score"),
+    rank: asNumber(response.rank, "explanation.rank"),
+    components: scoreComponentsFromExplanation(response),
+    counterfactual: {
+      pureEngagementRank: asNumber(
+        response.counterfactual.pure_engagement_rank,
+        "explanation.counterfactual.pure_engagement_rank",
+      ),
+      communityGovernedRank: asNumber(
+        response.counterfactual.community_governed_rank,
+        "explanation.counterfactual.community_governed_rank",
+      ),
+      difference: asNumber(response.counterfactual.difference, "explanation.counterfactual.difference"),
+    },
+    scoredAt: asString(response.scored_at, "explanation.scored_at"),
+    topicBreakdown: topicBreakdownFromExplanation(response),
+  }
+}
+
+async function fetchFeedSkeleton(signal: AbortSignal): Promise<{
+  readonly postUris: readonly string[]
+  readonly cursor: string | null
+}> {
+  const url = new URL(buildCorgiUrl("/xrpc/app.bsky.feed.getFeedSkeleton"), window.location.origin)
+  url.searchParams.set("feed", CORGI_COMMUNITY_FEED_URI)
+  url.searchParams.set("limit", String(LIVE_FEED_LIMIT))
+  const response = await fetchJson<FeedSkeletonResponse>(url.toString(), signal, "Corgi feed skeleton")
+  return normalizeFeedSkeleton(response)
+}
+
+async function fetchWeights(signal: AbortSignal): Promise<LiveDemoWeights> {
+  const response = await fetchJson<GovernanceWeightsResponse>(
+    buildCorgiUrl("/api/governance/weights"),
+    signal,
+    "Corgi governance weights",
+  )
+  return normalizeWeights(response)
+}
+
+async function fetchStats(signal: AbortSignal): Promise<LiveDemoStats> {
+  const response = await fetchJson<FeedStatsResponse>(
+    buildCorgiUrl("/api/transparency/stats"),
+    signal,
+    "Corgi transparency stats",
+  )
+  return normalizeStats(response)
+}
+
+async function fetchExplanation(postUri: string, signal: AbortSignal): Promise<LiveDemoExplanation> {
+  const response = await fetchJson<PostExplanationResponse>(
+    buildCorgiUrl(`/api/transparency/post/${encodeURIComponent(postUri)}`),
+    signal,
+    "Corgi post explanation",
+  )
+  return normalizeExplanation(response)
+}
+
+async function fetchHydratedPosts(
+  postUris: readonly string[],
+  explanation: LiveDemoExplanation | null,
+  signal: AbortSignal,
+): Promise<readonly LiveDemoFeedPost[]> {
+  const response = await fetchJson<HydratedPostResponse>(
+    buildPostHydrationUrl(postUris),
+    signal,
+    "Bluesky AppView post hydration",
+  )
+  return normalizeHydratedPosts(response, postUris, explanation)
+}
+
+export async function fetchLiveDemoData(signal: AbortSignal): Promise<LiveDemoData> {
+  const [feedResult, weightsResult, statsResult] = await Promise.allSettled([
+    fetchFeedSkeleton(signal),
+    fetchWeights(signal),
+    fetchStats(signal),
+  ])
+  const errors: string[] = []
+
+  if (weightsResult.status === "rejected") {
+    errors.push(errorMessage(weightsResult.reason))
+  }
+
+  if (statsResult.status === "rejected") {
+    errors.push(errorMessage(statsResult.reason))
+  }
+
+  if (feedResult.status === "rejected") {
+    errors.push(errorMessage(feedResult.reason))
+    return {
+      fetchedAt: new Date().toISOString(),
+      feedCursor: null,
+      posts: [],
+      weights: weightsResult.status === "fulfilled" ? weightsResult.value : null,
+      stats: statsResult.status === "fulfilled" ? statsResult.value : null,
+      explanation: null,
+      errors,
+    }
+  }
+
+  const topPostUri = feedResult.value.postUris[0]
+
+  if (topPostUri === undefined) {
+    errors.push("Corgi feed skeleton returned no posts")
+    return {
+      fetchedAt: new Date().toISOString(),
+      feedCursor: feedResult.value.cursor,
+      posts: [],
+      weights: weightsResult.status === "fulfilled" ? weightsResult.value : null,
+      stats: statsResult.status === "fulfilled" ? statsResult.value : null,
+      explanation: null,
+      errors,
+    }
+  }
+
+  const explanationResult = await Promise.allSettled([fetchExplanation(topPostUri, signal)])
+  const explanation =
+    explanationResult[0]?.status === "fulfilled" ? explanationResult[0].value : null
+
+  if (explanationResult[0]?.status === "rejected") {
+    errors.push(errorMessage(explanationResult[0].reason))
+  }
+
+  const postsResult = await Promise.allSettled([
+    fetchHydratedPosts(feedResult.value.postUris, explanation, signal),
+  ])
+  const posts = postsResult[0]?.status === "fulfilled" ? postsResult[0].value : []
+
+  if (postsResult[0]?.status === "rejected") {
+    errors.push(errorMessage(postsResult[0].reason))
+  }
+
+  return {
+    fetchedAt: new Date().toISOString(),
+    feedCursor: feedResult.value.cursor,
+    posts,
+    weights: weightsResult.status === "fulfilled" ? weightsResult.value : null,
+    stats: statsResult.status === "fulfilled" ? statsResult.value : null,
+    explanation,
+    errors,
+  }
+}

--- a/web-next/lib/live-metrics-snapshot.ts
+++ b/web-next/lib/live-metrics-snapshot.ts
@@ -1,0 +1,101 @@
+export interface LiveScoreComponent {
+  readonly key: string
+  readonly label: string
+  readonly raw_score: number
+  readonly weight: number
+  readonly weighted: number
+}
+
+export interface LiveFeedPostPreview {
+  readonly rank: number
+  readonly author: string
+  readonly score: number
+  readonly text: string
+}
+
+export interface LiveRankOneExplanation {
+  readonly receiptId: string
+  readonly authorLabel: string
+  readonly text: string
+  readonly epochId: number
+  readonly totalScore: number
+  readonly rank: number
+  readonly components: readonly LiveScoreComponent[]
+  readonly counterfactual: {
+    readonly pureEngagementRank: number
+    readonly communityGovernedRank: number
+    readonly difference: number
+  }
+}
+
+export const LIVE_METRICS_SNAPSHOT = {
+  collectedAtLabel: "2026-07-07 03:00 UTC",
+  epochId: 2,
+  scoredPosts: 3348,
+  uniqueAuthors: 3007,
+  votesThisEpoch: 0,
+  avgBridging: 0.7276394256303051,
+  avgEngagement: 0.3226783153401943,
+  medianBridging: 0.9186194653299917,
+  medianTotal: 0.5312066730135393,
+  weights: {
+    recency: 0.25,
+    engagement: 0.20,
+    bridging: 0.10,
+    source_diversity: 0.10,
+    relevance: 0.35,
+  },
+  topics: [
+    { slug: "decentralized-social", name: "Decentralized social", currentWeight: 0.90, communityAvg: 0.90 },
+  ],
+} as const
+
+export const LIVE_RANK_ONE_COMPONENTS = [
+  { key: "recency", label: "Recency", raw_score: 0.971876150243864, weight: LIVE_METRICS_SNAPSHOT.weights.recency, weighted: 0.242969037560966 },
+  { key: "engagement", label: "Engagement", raw_score: 0.45384361090898817, weight: LIVE_METRICS_SNAPSHOT.weights.engagement, weighted: 0.09076872218179764 },
+  { key: "bridging", label: "Bridging", raw_score: 0.9988304093567251, weight: LIVE_METRICS_SNAPSHOT.weights.bridging, weighted: 0.09988304093567252 },
+  { key: "source_diversity", label: "Source diversity", raw_score: 1, weight: LIVE_METRICS_SNAPSHOT.weights.source_diversity, weighted: 0.1 },
+  { key: "relevance", label: "Relevance", raw_score: 0.9, weight: LIVE_METRICS_SNAPSHOT.weights.relevance, weighted: 0.315 },
+] as const satisfies readonly LiveScoreComponent[]
+
+export const LIVE_RANK_ONE_EXPLANATION = {
+  receiptId: "production-receipt-rank-1",
+  authorLabel: "Production receipt 001",
+  text: "Public post text redacted; score structure preserved from the production receipt.",
+  epochId: LIVE_METRICS_SNAPSHOT.epochId,
+  totalScore: 0.8486208006784361,
+  rank: 1,
+  components: LIVE_RANK_ONE_COMPONENTS,
+  counterfactual: {
+    pureEngagementRank: 4,
+    communityGovernedRank: 1,
+    difference: 3,
+  },
+} as const satisfies LiveRankOneExplanation
+
+export const LIVE_FEED_POSTS = [
+  {
+    rank: 1,
+    author: "Production receipt 001",
+    score: 0.8486208006784361,
+    text: "Public post text redacted; score structure preserved from the production receipt.",
+  },
+  {
+    rank: 2,
+    author: "Production receipt 002",
+    score: 0.8447181456756023,
+    text: "Public post text redacted; receipt categorized around AI terminology and LLMs.",
+  },
+  {
+    rank: 3,
+    author: "Production receipt 003",
+    score: 0.8447074117364842,
+    text: "Public post text redacted; receipt categorized around generative AI adoption.",
+  },
+  {
+    rank: 4,
+    author: "Production receipt 004",
+    score: 0.8442263537240301,
+    text: "Public post text redacted; receipt categorized around generative AI in games.",
+  },
+] as const satisfies readonly LiveFeedPostPreview[]


### PR DESCRIPTION
## Summary

- Add a dated PROJ-1433 live metrics packet sourced from public production endpoints.
- Refresh README and Corgi `web-next` demo/homepage figures from fake or stale values to the 2026-07-07 03:00 UTC production snapshot.
- Replace the demo's fake epoch 47 / 312-vote fixture with epoch 2, 3,348 scored posts, 3,007 unique authors, 0 current-epoch votes, and an anonymized rank-1 production receipt.
- Centralize the shared live snapshot values for `web-next` and add a regression guard that prevents live handles, DIDs, AT-URIs, known receipt text, or unscanned new snapshot importers from landing in public UI fixtures.
- Fix two pre-existing `web-next` TypeScript validation blockers found while checking the final branch.

## Receipts

- `GET /api/transparency/stats`: epoch 2 active, 3,348 scored posts, 3,007 unique authors, 0 current-epoch votes, median total score 0.5312066730135393.
- `GET /api/governance/weights`: recency 0.25, engagement 0.20, bridging 0.10, source diversity 0.10, relevance 0.35.
- `getFeedSkeleton` with `limit=100`: returned 100 post URIs plus a cursor, recorded only as a served-page receipt.
- Engagement-heavy counterfactual top-10 receipt: 4 posts moved up, 6 moved down, max rank change 13, average absolute rank change 4.1.

## Validation

- `git diff --check`
- `npm run docs:verify`: 14 tracked docs / 29 markdown files scanned.
- `npx tsc --noEmit` from `web-next`
- `npx vitest tests/web-next-demo-fixtures.test.ts --run`: 1 file / 7 tests.
- `npm run verify` with dummy non-production env and loopback/IPC permission: root build, 98 Vitest files / 885 tests, CLI build, MCP-local skip, SDK build, SDK fixture, web lint/build, and web-next build.
- CodeRabbit CLI final committed review on `9e71720`: 6 findings, all lower-severity (`minor`/`trivial`); 0 major/high-medium blockers remain.

## Notes

- Production receipts used public endpoints only: no admin export, database query, cookie, bearer token, or host mutation.
- Sybil-resistance wording is intentionally caveated as simulation/mechanism evidence, not a live production proof.
- Real source handles/URIs remain in the internal lab packet only; public site/demo copy uses anonymized receipt labels while preserving numeric proof.
- The external workspace paper draft `corgi-recsys2026-paper-draft.md` was refreshed locally with the same numbers and final verification counts, but it is outside this repository and not part of this PR.

Linear: PROJ-1433