### PR TITLE
[PROJ-1573] Remove unsupported deploy workflow input

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          script_stop: true
           command_timeout: 10m
           script: |
             set -euo pipefail


### PR DESCRIPTION
## Summary
- Removes the unsupported `script_stop: true` input from the `Deploy to VPS` workflow.
- Keeps the remote deploy script fail-fast behavior through the existing `set -euo pipefail` line.
- Leaves deploy host, secrets, SSH key handling, build commands, rollback logic, systemd, DNS, and runtime env untouched.

## Verification
- `git diff --check`: pass.
- `gh workflow view deploy.yml --ref dev/PROJ-1573-remove-unsupported-script-stop-input-from-corgi-deploy --yaml`: pass; rendered workflow no longer includes `script_stop`, while `command_timeout: 10m` and `set -euo pipefail` remain.
- Diff scope: `.github/workflows/deploy.yml`, one deletion only.

## Deploy Note
Merging this PR triggers the normal production `Deploy to VPS` workflow on `main`. Post-merge closeout must confirm the deploy succeeds and the old `Unexpected input(s) script_stop` annotation is gone.

Closes PROJ-1573