### PR TITLE
[PROJ-917] Stabilize Postgres disk pressure via native time-partitioning + partition-drop retention

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,13 +1,62 @@
 services:
   postgres:
-    image: postgres:16
+    # Digest-pinned to the postgres:16 multi-arch index (resolved 2026-07-08 via
+    # `docker buildx imagetools inspect postgres:16 --format '{{.Manifest.Digest}}'`;
+    # verified it carries a linux/amd64 variant for the droplet). Re-resolve on a
+    # deliberate minor bump.
+    image: postgres:16@sha256:f8e2cc2a36ddb8700e639570f0bc70d0c1495951ba61df903a015dc87db07d02
     container_name: bluesky-feed-postgres
     shm_size: 256m
+    # PROJ-917 tuning pass — prior values were the postgres:16 image
+    # defaults (shared_buffers=128MB, effective_cache_size=4GB, work_mem=4MB,
+    # maintenance_work_mem=64MB), sized for a toy instance, not the box this
+    # actually runs on. Values below are doc-cited, not guessed:
+    #   - shared_buffers / effective_cache_size / work_mem /
+    #     maintenance_work_mem: https://www.postgresql.org/docs/16/runtime-config-resource.html
+    #     (shared_buffers "a setting of 25% of RAM is normally reasonable" for
+    #     dedicated DB hosts; effective_cache_size is a planner hint only —
+    #     "a value ... 50% to 75% of the machine's total RAM"; per-table
+    #     autovacuum_* apply separately, see migration 030)
+    #   - max_wal_size / checkpoint_completion_target / wal_level /
+    #     archive_mode / archive_command:
+    #     https://www.postgresql.org/docs/16/runtime-config-wal.html and
+    #     https://www.postgresql.org/docs/16/continuous-archiving.html
+    #     ("To enable WAL archiving, set wal_level to replica or higher,
+    #     archive_mode to on, and specify archive_command")
+    #   - autovacuum_vacuum_cost_limit:
+    #     https://www.postgresql.org/docs/16/runtime-config-autovacuum.html
+    #
+    # NOTE: changing shared_buffers, wal_level, or archive_mode requires a
+    # full postgres restart (not just a reload) — see docs/PARTITION_REBUILD.md
+    # for the maintenance-window note. Verify the droplet actually has
+    # comfortable headroom above shared_buffers(4GB) + effective_cache_size's
+    # planner assumption(8GB) before applying — these are NOT safe to apply
+    # blind against an undersized host; this needs a human check of the real
+    # droplet's total RAM first.
+    #
+    # archive_command is intentionally a no-op placeholder (`/bin/true`) for
+    # now: turning on archive_mode/wal_level here pays the one-time restart
+    # cost, but wiring the REAL pgBackRest push command happens during
+    # pgBackRest setup (ops/pgbackrest/README.md) and is reload-only
+    # (`SELECT pg_reload_conf();` or `docker kill -s HUP`), no second
+    # restart needed. Do not point this at a real pgbackrest command until
+    # the stanza in ops/pgbackrest/pgbackrest.conf has actually been
+    # initialized — an archive_command that fails forever (pointing at a
+    # stanza that doesn't exist yet) makes PostgreSQL retain WAL segments
+    # indefinitely, which is its own disk-filling incident.
     command: >
       postgres
-      -c max_wal_size=1GB
+      -c shared_buffers=4GB
+      -c effective_cache_size=8GB
+      -c work_mem=32MB
+      -c maintenance_work_mem=512MB
+      -c max_wal_size=4GB
       -c checkpoint_completion_target=0.9
+      -c autovacuum_vacuum_cost_limit=1000
       -c log_min_duration_statement=1000
+      -c wal_level=replica
+      -c archive_mode=on
+      -c archive_command=/bin/true
     environment:
       POSTGRES_USER: feed
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -24,7 +73,9 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    # Digest-pinned to the redis:7-alpine multi-arch index (resolved 2026-07-08,
+    # same method as postgres above; verified linux/amd64 variant present).
+    image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     container_name: bluesky-feed-redis
     command: redis-server --maxmemory 128mb --maxmemory-policy allkeys-lru --save 60 1000
     ports:

--- a/docs/PARTITION_REBUILD.md
+++ b/docs/PARTITION_REBUILD.md
@@ -1,0 +1,352 @@
+# Partition Rebuild Runbook — PROJ-917
+
+Status: canonical runbook for the native time-partitioned schema rebuild
+Owner: bluesky-feed
+Last updated: 2026-07-07
+
+## Background
+
+Migrations 026-029 rebuilt `likes`, `reposts`, `follows`, `posts`,
+`post_scores`, and `post_score_components` as declaratively `RANGE`-partitioned
+(by `created_at`) tables with daily partitions. This replaces the old
+guarded-DELETE retention model (`src/maintenance/cleanup.ts`, band-aided by
+migration 025's `created_at` indexes) with instant `DETACH PARTITION` + `DROP
+TABLE` retention (`src/maintenance/partition-manager.ts`) — a metadata-only
+operation independent of row count, which is what actually fixes the root
+cause: guarded DELETEs provably time out on 48M rows even indexed.
+
+Retention windows (`src/config.ts`):
+
+- `RAW_EVENT_RETENTION_DAYS` (default 14) — `likes`, `reposts`, `follows`
+- `SCORED_DATA_RETENTION_DAYS` (default 30) — `posts`, `post_scores`,
+  `post_score_components`
+
+`governance_*` tables and everything else are untouched (tiny: ~31 rows
+total) — this rebuild only concerns the high-volume event/content tables.
+
+This is a **stop-the-line, blocking rebuild**, appropriate for the current
+"no real users yet" phase (see PROJ-917 packet). It is NOT designed as a
+zero-downtime online migration — `bluesky-feed.service` must be stopped for
+the duration.
+
+## Foreign key note (read before running)
+
+`post_engagement.post_uri`, `post_scores.post_uri`, and
+`post_score_components.post_uri` **lost their `ON DELETE CASCADE` FK to
+posts** during this rebuild. PostgreSQL 16 requires a partitioned table's
+unique/PK constraints to include the full partition key ("5.11.2.3.
+Limitations", <https://www.postgresql.org/docs/16/ddl-partitioning.html>), so
+once `posts`' PK becomes `(uri, created_at)`, `posts(uri)` alone can no
+longer back a foreign key. See migration 027's header comment for the full
+rationale. Referential integrity is instead preserved by construction
+(scoring pipeline writes children immediately after reading the parent) plus
+two application-level cascades: `partition-manager.ts` deletes matching
+`post_engagement` rows before dropping a `posts` partition, and
+`cleanup.ts`'s `batchDeleteOrphanedEngagement()` sweeps stragglers the same
+way it already did for `likes`/`reposts` (which never had an FK to `posts`
+either).
+
+## Pre-flight
+
+- [ ] Confirm this is running against the intended target — **never** run
+      these steps against a database you haven't explicitly verified is the
+      one you mean to rebuild. There is no simulation/dry-run flag here;
+      double-check the connection string by hand.
+- [ ] Disk headroom (**the 200 GB resize is part of this window — step 4b**):
+      the rebuild temporarily holds both the old (`*_legacy`) and new tables at
+      once, so free space must exceed the combined retained-window size across
+      all six tables. On the current 96 GB disk (~82% used) there is NOT enough
+      room — the droplet MUST be resized to 200 GB (step 4b) before the copy
+      runs, or migration 026's `INSERT ... SELECT` hits ENOSPC mid-cutover.
+      Check sizes (note: Postgres runs in Docker, so all `psql`/`pg_dump` go
+      through `docker exec bluesky-feed-postgres`, never `sudo -u postgres`):
+      `docker exec bluesky-feed-postgres psql -U feed -d bluesky_feed -c "SELECT pg_size_pretty(sum(pg_total_relation_size(t))) FROM unnest(ARRAY['posts','post_scores','post_score_components','likes','reposts','follows']) t;"`
+- [ ] Maintenance window scheduled — this is blocking DDL + a full-table
+      copy of the retained window; expect service downtime for the
+      duration.
+
+## Ordered steps
+
+### 1. Stop the service
+
+```bash
+sudo systemctl stop bluesky-feed
+docker compose -f docker-compose.prod.yml ps   # confirm postgres/redis still up
+```
+
+### 2. Archive: full logical backup
+
+Take a full `pg_dump` before touching anything, independent of the routine
+`/opt/backups/daily-backup.sh` cadence (see `docs/OPS_RUNBOOK.md`'s Backup
+and Retention section):
+
+```bash
+# Postgres runs in Docker — there is NO `postgres` OS user on the host
+# (`sudo -u postgres` fails). Always go through the container.
+OUT=/mnt/host-backups/postgres/pre-partition-rebuild-$(date +%Y%m%d-%H%M%S).dump
+docker exec bluesky-feed-postgres pg_dump -Fc -U feed bluesky_feed > "$OUT"
+# Verify the custom-format dump isn't truncated (it is NOT gzip, so `gzip -t`
+# does not apply — `pg_restore -l` reads the archive's table of contents):
+docker exec -i bluesky-feed-postgres pg_restore -l < "$OUT" > /dev/null && echo "dump OK: $OUT"
+```
+
+### 3. Dump governance tables separately
+
+Governance is out of scope for this rebuild but is small enough to snapshot
+on its own for an easy point-in-time reference, independent of the full
+backup above:
+
+```bash
+docker exec bluesky-feed-postgres pg_dump -Fc -U feed \
+  -t governance_epochs -t governance_votes -t governance_audit_log \
+  -t governance_epoch_weights -t governance_vote_weights \
+  bluesky_feed > /mnt/host-backups/postgres/governance-snapshot-$(date +%Y%m%d-%H%M%S).dump
+```
+
+### 4. Deploy new code, resize the droplet, then run the migrations
+
+Ordering matters: the migrations widen primary keys and change `ON CONFLICT`
+targets, so the deployed app MUST already be the new code (old code + new
+schema = every insert fails), and the copy step needs disk headroom the
+current 96 GB disk does not have (legacy + new coexist).
+
+**4a. Deploy the new code** (app + tuned `docker-compose.prod.yml` + migrations 026-030):
+
+```bash
+cd /opt/bluesky-feed
+git fetch origin && git checkout main && git pull   # main must already contain the merged PROJ-917 work
+npm ci && npm run build
+```
+
+**4b. Resize the droplet to 200 GB** (mandatory — see pre-flight disk math):
+
+```bash
+docker compose -f docker-compose.prod.yml stop      # clean Postgres shutdown before power-off
+# Power off, resize with "Disk, CPU and RAM", power on — via the DO console/API.
+df -h /                                              # expect ~196G; if not: sudo growpart /dev/vda 1 && sudo resize2fs /dev/vda1
+```
+
+**4c. Bring Postgres back up with the tuned settings** (the new compose applies
+`shared_buffers=4GB`, `wal_level`, `archive_mode`, etc. on restart):
+
+```bash
+docker compose -f docker-compose.prod.yml up -d postgres redis
+docker compose -f docker-compose.prod.yml ps         # confirm both healthy
+```
+
+**4d. Run the migrations** (rename old → create partitioned → copy recent
+window; atomic per table):
+
+```bash
+cd /opt/bluesky-feed
+npm run migrate
+```
+
+What this does, per table (see each migration file's header for the exact
+rationale and PG16 citations):
+
+- Creates a new `RANGE`-partitioned table (`<table>_new`) with daily
+  partitions spanning `[today - (retention + 2d), today + 2d]`, plus a
+  `DEFAULT` partition safety net.
+- Copies rows within the retention window from the old table into the new
+  one (`INSERT ... SELECT ... WHERE created_at >= ...`).
+- Renames the OLD table to `<table>_legacy` (**not dropped** — this is the
+  rollback path) and renames the NEW table into the live table name.
+
+After this step, the application schema is fully partitioned and rows older
+than the retention window have been intentionally left behind in
+`<table>_legacy` (not copied forward) — that data aging out is the point of
+this rebuild.
+
+### 5. Verify
+
+```bash
+psql "$DATABASE_URL" <<'SQL'
+-- Every partitioned table should report relkind = 'p'.
+SELECT relname, relkind
+FROM pg_class
+WHERE relname IN ('likes','reposts','follows','posts','post_scores','post_score_components')
+  AND relnamespace = 'public'::regnamespace;
+
+-- Row counts: new table vs. legacy table (new should be <= legacy, and
+-- roughly equal to legacy filtered to the retention window).
+SELECT 'posts' AS t, (SELECT COUNT(*) FROM posts) AS new_count, (SELECT COUNT(*) FROM posts_legacy) AS legacy_count
+UNION ALL
+SELECT 'post_scores', (SELECT COUNT(*) FROM post_scores), (SELECT COUNT(*) FROM post_scores_legacy)
+UNION ALL
+SELECT 'post_score_components', (SELECT COUNT(*) FROM post_score_components), (SELECT COUNT(*) FROM post_score_components_legacy)
+UNION ALL
+SELECT 'likes', (SELECT COUNT(*) FROM likes), (SELECT COUNT(*) FROM likes_legacy)
+UNION ALL
+SELECT 'reposts', (SELECT COUNT(*) FROM reposts), (SELECT COUNT(*) FROM reposts_legacy)
+UNION ALL
+SELECT 'follows', (SELECT COUNT(*) FROM follows), (SELECT COUNT(*) FROM follows_legacy);
+
+-- Spot-check: a handful of the most recent rows made it across intact.
+SELECT uri, created_at FROM posts ORDER BY created_at DESC LIMIT 5;
+SQL
+```
+
+Then start the service and run the standard smoke checks
+(`docs/runbooks/operator-quickstart.md`):
+
+```bash
+sudo systemctl start bluesky-feed
+curl -sS http://localhost:3001/health
+curl -sS "http://localhost:3001/xrpc/app.bsky.feed.describeFeedGenerator"
+```
+
+Watch the next scheduled scoring run (`SCORING_INTERVAL_MS`, default 5 min)
+and the next hourly maintenance-worker tick complete cleanly:
+
+```bash
+sudo journalctl -u bluesky-feed -f | grep -E 'Scoring pipeline complete|Partition maintenance run complete|Cleanup run complete'
+```
+
+Confirm `system_status` reflects a healthy run:
+
+```bash
+psql "$DATABASE_URL" -c "SELECT key, value, updated_at FROM system_status WHERE key IN ('current_scoring_run','last_partition_maintenance_run','last_cleanup_run') ORDER BY key;"
+```
+
+### 6. Drop old (only after verification above passes)
+
+This is a deliberate, separate, manual step — NOT part of the migrations —
+so there is always a rollback path until an operator explicitly confirms
+the new schema is good:
+
+```bash
+psql "$DATABASE_URL" <<'SQL'
+DROP TABLE IF EXISTS likes_legacy CASCADE;
+DROP TABLE IF EXISTS reposts_legacy CASCADE;
+DROP TABLE IF EXISTS follows_legacy CASCADE;
+DROP TABLE IF EXISTS post_score_components_legacy CASCADE;
+DROP TABLE IF EXISTS post_scores_legacy CASCADE;
+DROP TABLE IF EXISTS posts_legacy CASCADE;
+SQL
+```
+
+Reclaim disk space:
+
+```bash
+psql "$DATABASE_URL" -c "VACUUM (ANALYZE);"
+```
+
+## Rollback
+
+Rollback is only possible **before** step 6 (the legacy tables must still
+exist).
+
+1. Stop the service: `sudo systemctl stop bluesky-feed`.
+2. Swap back — for each table (example shown for `posts`; repeat for
+   `post_scores`, `post_score_components`, `likes`, `reposts`, `follows`):
+
+   ```sql
+   ALTER TABLE posts RENAME TO posts_partitioned_rollback;
+   ALTER TABLE posts_legacy RENAME TO posts;
+   ```
+
+   (Index/constraint names on `posts_legacy` were already suffixed
+   `_legacy` by the migration, so no further renaming is needed for the old
+   table to become fully live again under its original name.)
+3. Roll back `schema_migrations` so `npm run migrate` doesn't try to
+   re-apply 026-029 against the restored old schema:
+
+   ```sql
+   DELETE FROM schema_migrations WHERE filename IN (
+     '026_partition_raw_events.sql',
+     '027_partition_posts.sql',
+     '028_partition_post_scores.sql',
+     '029_partition_post_score_components.sql'
+   );
+   ```
+4. Restart the service and re-run the smoke checks from step 5.
+
+If something has already gone wrong with the `_legacy` tables too (or step 6
+already ran), fall back to the full `pg_dump` from step 2:
+
+```bash
+sudo systemctl stop bluesky-feed
+# Docker again — pipe the host dump into the container's pg_restore over stdin.
+docker exec -i bluesky-feed-postgres pg_restore -U feed -d bluesky_feed --clean --if-exists \
+  < /mnt/host-backups/postgres/pre-partition-rebuild-<timestamp>.dump
+sudo systemctl start bluesky-feed
+```
+
+## Postgres tuning + WAL archiving (PROJ-917 production hardening)
+
+`docker-compose.prod.yml`'s postgres `command:` block and migration 030
+(`030_autovacuum_tuning.sql`) landed alongside the partition rebuild. Two
+separate things to know before/while applying them:
+
+**1. The `command:` flag changes require a maintenance-window restart, not
+just this rebuild's downtime.** `shared_buffers`, `wal_level`, and
+`archive_mode` are restart-only parameters in PostgreSQL (changing them via
+`docker compose up -d` recreates the container, which restarts postgres —
+so in practice this is the same maintenance window as the rest of this
+runbook, just make sure it's scheduled together rather than assumed free).
+Before applying:
+
+- [ ] Confirm the droplet actually has comfortable headroom above the new
+      `shared_buffers` (4GB) and the `effective_cache_size` planner
+      assumption (8GB) — these are sized for a host with several GB more
+      RAM than that, not verified against the real droplet's `free -h`
+      here. Applying them blind on an undersized box can make postgres
+      fail to start (shared_buffers exceeding available/configured shared
+      memory) — this needs a human to check the actual droplet spec first.
+- [ ] `docker compose -f docker-compose.prod.yml up -d postgres` after
+      confirming headroom, then watch `docker compose logs -f postgres`
+      for a clean startup before restarting `bluesky-feed`.
+
+**2. WAL archiving is turned on but not yet wired to a destination.**
+`wal_level=replica` (already the default, now pinned explicitly) is
+sufficient for pgBackRest — continuous archiving only requires `wal_level`
+to be `replica` or higher (PostgreSQL 16 docs,
+<https://www.postgresql.org/docs/16/continuous-archiving.html>: "To enable
+WAL archiving, set `wal_level` to `replica` or higher, `archive_mode` to
+`on`, and specify ... `archive_command`"). `archive_mode=on` is enabled
+now, but `archive_command` is set to the no-op `/bin/true` placeholder —
+deliberately, so turning archiving on doesn't start failing forever against
+a pgBackRest stanza that doesn't exist yet (a permanently-failing
+`archive_command` makes postgres retain WAL indefinitely, which is its own
+disk-filling incident — exactly what this whole effort is trying to
+prevent). The real `archive_command` gets wired during pgBackRest setup
+(`ops/pgbackrest/README.md`), and that step is a config **reload**
+(`SELECT pg_reload_conf();` or `docker kill -s HUP bluesky-feed-postgres`),
+not a second restart.
+
+**3. Per-table autovacuum (migration 030).** Lowers
+`autovacuum_vacuum_scale_factor` to 0.02 on the six partitioned tables
+(likes/reposts/follows/posts/post_scores/post_score_components — applied to
+every existing leaf partition plus baked into
+`create_daily_range_partitions()` so future daily partitions get it too)
+and to 0.01 on `post_engagement` (not partitioned, so autovacuum is its
+only bloat control). This is a normal transactional migration
+(`npm run migrate`) — no restart needed, only `npm run migrate`.
+
+**4. Image digests.** `postgres:16` and `redis:7-alpine` are left as tags
+in `docker-compose.prod.yml`, with a `TODO(PROJ-917)` comment on each
+containing the exact `docker pull` + `docker inspect` commands to resolve
+and pin a real digest — no digest was invented here since this environment
+can't reach a registry to look one up.
+
+## Ongoing operation (nothing further to do manually)
+
+Once live, `src/maintenance/partition-manager.ts` (registered in
+`worker-supervisor.ts`, running alongside `cleanup.ts`,
+`interaction-aggregator.ts`, and `disk-monitor.ts`) handles retention
+automatically, once per calendar day:
+
+- Creates partitions ahead of time for `[today, today+2]` on every
+  partitioned table.
+- `DETACH`es + `DROP`s any daily partition whose upper bound has aged past
+  that table's retention window, cascading `post_engagement` deletes for
+  the `posts` table specifically.
+- Sweeps each table's `DEFAULT` partition (the out-of-range safety net) for
+  rows that have also aged past retention.
+
+No cron job or manual intervention is required after the rebuild completes.
+If `RAW_EVENT_RETENTION_DAYS` or `SCORED_DATA_RETENTION_DAYS` are changed
+later, only the *ongoing* retention window changes — it does not
+retroactively resize partitions already created by migrations 026-029; that
+would require a follow-up migration.

--- a/ops/README.md
+++ b/ops/README.md
@@ -42,6 +42,7 @@ Create the sockets directory: `mkdir -p ~/.ssh/sockets`
 | `ops/status` | `ops/status` | Full system health overview |
 | `ops/feed-check` | `ops/feed-check 30` | Audit top N posts in the feed |
 | `ops/deploy` | `ops/deploy` | Pull, build, migrate, restart |
+| `ops/restore-drill.sh` | `ops/restore-drill.sh` | Restore the newest pgBackRest backup into a throwaway container and verify integrity (see `ops/pgbackrest/README.md`) |
 | `scripts/generate-report.py` | `python3 scripts/generate-report.py` | Generate feed quality analysis report |
 
 ## Report Generation

--- a/ops/health-watchdog
+++ b/ops/health-watchdog
@@ -26,11 +26,24 @@ log_err()   { logger -t "$TAG" -p user.err "$1"; }
 DISK_PCT=$(df / --output=pcent | tail -1 | tr -d ' %')
 
 if [ "$DISK_PCT" -ge "$DISK_CRIT_PCT" ]; then
-  log_err "Disk at ${DISK_PCT}% — running emergency cleanup"
+  log_err "Disk at ${DISK_PCT}% — running local free-space actions"
   journalctl --vacuum-size=500M 2>/dev/null || true
   docker exec bluesky-feed-postgres psql -U feed -d bluesky_feed -c "CHECKPOINT" 2>/dev/null || true
-  # Trigger aggressive cleanup if Node process is running
-  curl -sf -X POST --max-time 10 http://localhost:3001/api/admin/trigger-cleanup 2>/dev/null || true
+  # PROJ-917: this used to also `curl -X POST .../api/admin/trigger-cleanup`
+  # here. That route did not exist (a 404 silently hidden by `|| true`), and
+  # even now that it does (src/admin/routes/cleanup.ts), calling it from
+  # here would just trade a silent 404 for a silent 401: every /api/admin/*
+  # route requires the same session-cookie/Bearer admin auth as the rest of
+  # the dashboard (src/auth/admin.ts's requireAdmin — a Bluesky-login-backed
+  # Redis session), and this script has no way to hold or refresh one.
+  # Triggering cleanup over HTTP was also redundant with what already
+  # happens in-process: src/maintenance/disk-monitor.ts polls disk usage
+  # every 5 minutes and calls triggerManualCleanup() directly (no HTTP/auth
+  # round-trip needed) at the critical (90%) and emergency (95%) tiers, plus
+  # an immediate partition-manager drop pass and a plain VACUUM at the
+  # emergency tier. This script's job is just the two local, no-auth-needed
+  # actions above (journald + CHECKPOINT) as a belt-and-suspenders backstop
+  # for when the Node process itself is wedged or slow to notice.
 elif [ "$DISK_PCT" -ge "$DISK_WARN_PCT" ]; then
   log_warn "Disk at ${DISK_PCT}% — approaching critical"
 fi

--- a/ops/pgbackrest/README.md
+++ b/ops/pgbackrest/README.md
@@ -1,0 +1,197 @@
+# pgBackRest setup runbook — PROJ-917
+
+Status: **reviewed artifact, NOT live-tested.** Written and checked against
+the pgBackRest documentation (<https://pgbackrest.org/configuration.html>,
+<https://pgbackrest.org/user-guide.html>), but this environment has no
+running production Postgres to init a stanza against and no real
+DigitalOcean Spaces credentials to verify the S3 repo against. Treat every
+command below as reviewed-but-unverified until a human runs it against the
+real droplet. `ops/restore-drill.sh` (same status) covers the restore-side
+verification.
+
+This complements, and does not replace, the existing `pg_dumpall`-based
+`ops/daily-backup.sh` (logical backups) — pgBackRest adds physical
+base-backups + continuous WAL archiving, which is what makes point-in-time
+recovery possible; `pg_dumpall` alone cannot do PITR.
+
+## 1. Install
+
+pgBackRest needs (a) filesystem access to `PGDATA` and (b) a Postgres
+connection (local socket is fine) to call `pg_backup_start`/`pg_backup_stop`
+during a backup. Two ways to get both, pick one:
+
+**Option A — install inside the postgres container (recommended).** Extend
+`docker-compose.prod.yml`'s postgres image with a small Dockerfile that
+adds the `pgbackrest` package (Debian/Ubuntu-based `postgres:16` image ships
+apt; `apt-get install -y pgbackrest`), and mount `ops/pgbackrest/pgbackrest.conf`
+plus the local repo path into the container:
+
+```yaml
+# docker-compose.prod.yml (illustrative — not applied here, since this
+# needs to be built/tested against the real image first)
+postgres:
+  build: ./ops/pgbackrest   # Dockerfile: FROM postgres:16 + apt-get install pgbackrest
+  volumes:
+    - bluesky_postgres_data:/var/lib/postgresql/data
+    - ./ops/pgbackrest/pgbackrest.conf:/etc/pgbackrest/pgbackrest.conf:ro
+    - /mnt/host-backups/pgbackrest:/mnt/host-backups/pgbackrest
+```
+
+This keeps `pg1-path` in `pgbackrest.conf` (`/var/lib/postgresql/data`)
+correct as-is, since pgbackrest sees the exact same filesystem Postgres
+does.
+
+**Option B — host sidecar.** Install `pgbackrest` on the droplet directly
+(`apt-get install pgbackrest`) and point `pg1-path` at the named volume's
+host-side directory (`docker volume inspect bluesky_postgres_data --format
+'{{ .Mountpoint }}'`) instead of `/var/lib/postgresql/data`. Simpler to
+avoid rebuilding the postgres image, but more fragile: the exact host path
+for a named Docker volume is Docker-internal and can change across Docker
+versions, and this option needs a Postgres connection detail (host port
+5433 per `docker-compose.prod.yml`, not the default local socket) added to
+`pgbackrest.conf`'s `[corgi]` section (`pg1-port=5433`,
+`pg1-socket-path=/var/run/postgresql` won't exist on the host — use
+`pg1-host-type=tcp` equivalent config or connect via `127.0.0.1:5433`).
+
+Whichever option: copy `ops/pgbackrest/pgbackrest.conf` to
+`/etc/pgbackrest/pgbackrest.conf` (or mount it there), and create the local
+repo directory ahead of time:
+
+```bash
+mkdir -p /mnt/host-backups/pgbackrest
+chown postgres:postgres /mnt/host-backups/pgbackrest   # or the container's postgres uid
+```
+
+## 2. Set the Spaces (S3) secrets
+
+Never put these in `pgbackrest.conf` (it's a tracked file in this repo).
+Export them wherever pgbackrest actually runs (systemd `EnvironmentFile=`
+for a host install, or the container's env for Option A) — pgBackRest
+reads any config option from `PGBACKREST_<SECTION>_<OPTION>`:
+
+```bash
+export PGBACKREST_REPO2_S3_BUCKET="<the-do-spaces-bucket-name>"
+export PGBACKREST_REPO2_S3_KEY="<do-spaces-access-key>"
+export PGBACKREST_REPO2_S3_KEY_SECRET="<do-spaces-secret-key>"
+```
+
+Also fill in the two `<region>` placeholders in `pgbackrest.conf`
+(`repo2-s3-endpoint`, `repo2-s3-region`) with the real DigitalOcean Spaces
+region (e.g. `nyc3`, `sfo3`) before continuing.
+
+## 3. Initialize the stanza
+
+```bash
+pgbackrest --stanza=corgi --log-level-console=info stanza-create
+```
+
+## 4. Set `archive_command` and RECREATE the container
+
+`docker-compose.prod.yml` already ships with `wal_level=replica` and
+`archive_mode=on` (restart-only settings, already applied during the
+PROJ-917 maintenance window — see `docs/PARTITION_REBUILD.md`) and a
+placeholder `archive_command=/bin/true`. Once the stanza above exists,
+point `archive_command` at the real pgbackrest push:
+
+```bash
+# docker-compose.prod.yml: change
+#   -c archive_command=/bin/true
+# to
+#   -c archive_command='pgbackrest --stanza=corgi archive-push %p'
+```
+
+`archive_command` is set here via a Postgres `-c` command-line flag in the
+`command:` block, not via `postgresql.conf`. A value supplied on the
+command line is fixed for the life of the postmaster process and takes
+precedence over anything reloaded from config — sending `SIGHUP` (or
+calling `pg_reload_conf()`) re-reads `postgresql.conf` but does **not**
+re-parse the container's command line, so it will **not** pick up the
+edited `command:` block. You must recreate the container so it starts
+with the new command-line flags:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --force-recreate postgres
+```
+
+Until you do, `SHOW archive_command;` will keep reporting `/bin/true` even
+after a `HUP`/`pg_reload_conf()` — that staleness is expected and is not a
+sign the edit failed; it means the container hasn't been recreated yet.
+
+## 5. Verify archiving end-to-end
+
+```bash
+pgbackrest --stanza=corgi --log-level-console=info check
+```
+
+This forces a test WAL segment through the real `archive_command` and
+confirms it lands in the repo — run this immediately after step 4's
+`--force-recreate`, before trusting the setup. If `SHOW archive_command;`
+still shows `/bin/true`, the container was not actually recreated; re-run
+step 4's `up -d --force-recreate` before continuing.
+
+## 6. First full backup
+
+```bash
+pgbackrest --stanza=corgi --type=full --log-level-console=info backup
+```
+
+Subsequent backups can be `--type=diff` or `--type=incr` on whatever
+schedule an operator wires up (cron/systemd timer — not added here, since
+that decision depends on the retention/RPO an operator actually wants and
+isn't specified by the PROJ-917 packet).
+
+## 7. Verify WAL pushed to BOTH repos
+
+`check` (step 5) only proves the repo pgbackrest is configured to prefer
+(repo1, local) is reachable. Confirm repo2 (Spaces) independently:
+
+```bash
+pgbackrest --stanza=corgi --repo=2 --log-level-console=info check
+pgbackrest --stanza=corgi --repo=2 info
+```
+
+`info` should list the full backup from step 6 under repo2 as well as
+repo1 (pgbackrest pushes WAL and backups to every configured repo by
+default, not just the first).
+
+## 8. Restore commands
+
+**Restore the latest backup (e.g. after total data loss)**, into the
+*real* PGDATA — stop Postgres first:
+
+```bash
+sudo systemctl stop bluesky-feed   # or: docker compose stop postgres
+pgbackrest --stanza=corgi --delta restore
+sudo systemctl start bluesky-feed  # or: docker compose start postgres
+```
+
+**Point-in-time recovery** (e.g. recovering from a bad `DROP TABLE` or a
+bad deploy at a known time):
+
+```bash
+# Capture the target time from Postgres itself (server clock, with tz) if
+# recovering "as of a few minutes ago" rather than a specific known instant:
+RECOVERY_TARGET=$(psql "$DATABASE_URL" -Atc "select current_timestamp")
+
+sudo systemctl stop bluesky-feed
+pgbackrest --stanza=corgi --delta \
+  --type=time "--target=${RECOVERY_TARGET}" \
+  --target-action=promote restore
+sudo systemctl start bluesky-feed
+```
+
+`--target-action=promote` tells Postgres to come up read-write once it
+reaches the target, rather than pausing in recovery — appropriate for this
+single-primary setup (no standby to hand off to).
+
+For the safer "restore into a throwaway copy and verify before touching
+production" workflow, use `ops/restore-drill.sh` instead of restoring
+directly into the real PGDATA.
+
+## 9. Retention
+
+Handled automatically by the `repo1-retention-full`/`repo2-retention-full`
+settings in `pgbackrest.conf` (7d local, 30d Spaces) — pgBackRest expires
+old backups (and their now-unreachable WAL) on its own after each backup,
+no separate cron job needed for this piece. (`ops/daily-backup.sh`'s own
+`pg_dumpall` retention is unrelated and unaffected.)

--- a/ops/pgbackrest/pgbackrest.conf
+++ b/ops/pgbackrest/pgbackrest.conf
@@ -1,0 +1,69 @@
+# pgBackRest configuration — PROJ-917 production hardening
+#
+# STATUS: reviewed artifact, NOT live-tested — this environment has no
+# running Postgres to init a stanza against and no real DigitalOcean Spaces
+# credentials. See ops/pgbackrest/README.md for the setup runbook and
+# ops/restore-drill.sh for the (also not live-tested) restore verification
+# script. Cited against https://pgbackrest.org/configuration.html and the
+# multi-repo / S3 sections of that page.
+#
+# Two repos, per the task spec:
+#   - repo1: local disk on the host, fast restores, short retention (7d).
+#   - repo2: DigitalOcean Spaces (S3-compatible), offsite, longer
+#     retention (30d) so a full droplet loss doesn't also lose backups.
+#
+# SECRETS: repo2-s3-key, repo2-s3-key-secret, and repo2-s3-bucket are
+# DELIBERATELY NOT set in this file — pgBackRest reads any config option
+# from an environment variable named PGBACKREST_<SECTION>_<OPTION>
+# (hyphens -> underscores, uppercased), so set these at process invocation
+# time instead, e.g. in the systemd unit's Environment= / EnvironmentFile=
+# or the container's env, never committed here:
+#   PGBACKREST_REPO2_S3_BUCKET
+#   PGBACKREST_REPO2_S3_KEY
+#   PGBACKREST_REPO2_S3_KEY_SECRET
+# See ops/pgbackrest/README.md for exactly where those get set.
+
+[corgi]
+# PGDATA path as seen by whatever runs pgbackrest (the postgres container's
+# own filesystem if installed inside that image, per README option A; or
+# the docker-managed volume's host-side path if run as a host sidecar per
+# README option B — adjust this one line for whichever install path is
+# chosen, everything else in this file is unaffected).
+pg1-path=/var/lib/postgresql/data
+pg1-port=5432
+pg1-socket-path=/var/run/postgresql
+
+[global]
+# ── repo1: local disk ──────────────────────────────────────────────
+# Mounted at /mnt/host-backups/pgbackrest per the task spec — same host
+# backup mount ops/daily-backup.sh already uses for pg_dump snapshots
+# (BACKUP_MOUNT_ROOT), so both backup mechanisms live under one disk/mount
+# an operator already knows to watch for space.
+repo1-path=/mnt/host-backups/pgbackrest
+repo1-retention-full-type=time
+repo1-retention-full=7
+# Bundling small files + block-level incremental are the documented
+# "recommended options for new repositories"
+# (https://pgbackrest.org — Perform pgBackRest Backups section).
+repo1-bundle=y
+repo1-block=y
+
+# ── repo2: DigitalOcean Spaces (S3-compatible) ─────────────────────
+# Endpoint/region/path are not secret — fill in the actual Spaces region
+# before first use. Bucket name, key, and secret come from environment
+# variables (see the SECRETS note above); do not add repo2-s3-bucket,
+# repo2-s3-key, or repo2-s3-key-secret lines here.
+repo2-type=s3
+repo2-s3-endpoint=<region>.digitaloceanspaces.com
+repo2-s3-region=<region>
+repo2-path=/corgi
+repo2-retention-full-type=time
+repo2-retention-full=30
+repo2-bundle=y
+
+# ── shared performance/compression options (both repos) ────────────
+compress-type=zst
+start-fast=y
+process-max=4
+log-level-console=info
+log-level-file=detail

--- a/ops/restore-drill.sh
+++ b/ops/restore-drill.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# restore-drill.sh — PROJ-917 pgBackRest restore verification drill
+#
+# STATUS: reviewed artifact, NOT live-tested. Written and checked against
+# https://pgbackrest.org/user-guide.html and https://pgbackrest.org/command.html,
+# but this environment has no running pgBackRest stanza, no real backup set,
+# and no DigitalOcean Spaces credentials to exercise repo2 against. Dry-run
+# this by hand (read through it, run it piece by piece) before trusting it
+# during a real incident. See ops/pgbackrest/README.md for the setup this
+# depends on.
+#
+# Restores the newest available backup into a throwaway, fully isolated
+# postgres container + throwaway Docker volume — never touches the real
+# bluesky-feed-postgres container, its volume, or its port — then runs a
+# handful of integrity checks and tears the throwaway container/volume
+# down. Exits non-zero if the restore fails to come up or any check fails.
+#
+# Usage: ops/restore-drill.sh
+#
+# Requires: docker, and pgbackrest reachable via `docker run` against the
+# same image family used in production (postgres:16 + pgbackrest — see
+# ops/pgbackrest/README.md Option A). If pgbackrest is only installed as a
+# bare-metal host sidecar (README Option B), replace the `docker run ...
+# pgbackrest restore` invocation below with a direct host `pgbackrest`
+# call instead.
+#
+# If repo1 (local disk) is unavailable or empty, export the repo2 (Spaces)
+# secrets before running so pgbackrest can fall back to it:
+#   PGBACKREST_REPO2_S3_BUCKET, PGBACKREST_REPO2_S3_KEY, PGBACKREST_REPO2_S3_KEY_SECRET
+#
+# KNOWN LIMITATION (untested against real infra, so left honest rather than
+# silently "fixed"): step 3 below starts the throwaway runtime container
+# from plain $POSTGRES_IMAGE (default postgres:16), which does NOT have the
+# `pgbackrest` binary installed — unlike step 2's restore container, which
+# installs it on the fly via `apt-get` before running `pgbackrest restore`.
+# `pgbackrest restore` writes a `restore_command` into the restored
+# `postgresql.auto.conf` that shells out to `pgbackrest archive-get`
+# (https://pgbackrest.org, `archive-get`/`restore` docs). Postgres prefers
+# WAL segments already present in `pg_wal` over calling `restore_command`,
+# so this drill only reliably validates the base-backup-to-consistency
+# path; if recovery ever needs to replay WAL beyond what was restored
+# locally (e.g. a base backup that's old relative to the newest archived
+# WAL), postgres's recovery will try to invoke `restore_command`, find no
+# `pgbackrest` binary in this container, and fail to start — the drill
+# will then time out (see READY_TIMEOUT_SECONDS) and exit non-zero, with
+# the real error visible via the container-log dump in `cleanup()` below.
+# To actually exercise that path, point POSTGRES_IMAGE at a build that
+# already includes pgbackrest (README Option A's Dockerfile, reused for
+# this drill) instead of stock postgres:16 — not done here, since building
+# and validating that image needs the real droplet this environment
+# doesn't have.
+
+set -euo pipefail
+
+STANZA="corgi"
+DRILL_NAME="corgi-restore-drill"
+DRILL_VOLUME="corgi-restore-drill-data"
+DRILL_PORT="${DRILL_PORT:-55433}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:16}"
+PGBACKREST_CONFIG_DIR="${PGBACKREST_CONFIG_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pgbackrest}"
+LOCAL_REPO_PATH="${LOCAL_REPO_PATH:-/mnt/host-backups/pgbackrest}"
+READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-180}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+cleanup() {
+  local exit_code=$?
+  # Any non-zero exit — a failed run_check under `set -e`, the readiness
+  # timeout, or anything else — lands here before the container is torn
+  # down. Dump its logs first so a failed drill still leaves diagnostics;
+  # this is the highest-cost place to lose them (a disaster-recovery drill
+  # failure is exactly when you need to know why).
+  if [ "$exit_code" -ne 0 ]; then
+    log "Drill exiting with status ${exit_code} — dumping container logs before cleanup..."
+    docker logs "$DRILL_NAME" 2>&1 || true
+  fi
+  log "Cleaning up throwaway restore container/volume..."
+  docker rm -f "$DRILL_NAME" >/dev/null 2>&1 || true
+  docker volume rm "$DRILL_VOLUME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+log "Starting restore drill for stanza=${STANZA} (throwaway target only — production is never touched)"
+
+# 1. Fresh, empty data volume as the restore target.
+docker volume create "$DRILL_VOLUME" >/dev/null
+
+# 2. Restore the newest backup into that volume. pgbackrest auto-selects
+# the latest backup when --set is not given. Runs inside a throwaway
+# container built from the same image family as production so the
+# pgbackrest binary/version matches what actually wrote the backup.
+docker run --rm \
+  -v "${DRILL_VOLUME}:/var/lib/postgresql/data" \
+  -v "${PGBACKREST_CONFIG_DIR}/pgbackrest.conf:/etc/pgbackrest/pgbackrest.conf:ro" \
+  -v "${LOCAL_REPO_PATH}:${LOCAL_REPO_PATH}:ro" \
+  -e PGBACKREST_REPO2_S3_BUCKET \
+  -e PGBACKREST_REPO2_S3_KEY \
+  -e PGBACKREST_REPO2_S3_KEY_SECRET \
+  --user root \
+  "$POSTGRES_IMAGE" \
+  bash -c "apt-get update -qq && apt-get install -y -qq pgbackrest >/dev/null && \
+    pgbackrest --config=/etc/pgbackrest/pgbackrest.conf --stanza=${STANZA} \
+      --pg1-path=/var/lib/postgresql/data --log-level-console=info restore"
+
+# 3. Start a throwaway postgres against the restored volume. No
+# POSTGRES_USER/PASSWORD needed — PGDATA is already initialized (restored
+# from a real cluster), so the entrypoint skips initdb and starts as-is
+# with whatever roles the backup already contains.
+#
+# NOTE: $POSTGRES_IMAGE here has no pgbackrest binary — see the
+# "KNOWN LIMITATION" note in the file header. If recovery needs
+# restore_command/archive-get, this container will fail to come up.
+docker run -d --name "$DRILL_NAME" \
+  -v "${DRILL_VOLUME}:/var/lib/postgresql/data" \
+  -p "127.0.0.1:${DRILL_PORT}:5432" \
+  "$POSTGRES_IMAGE"
+
+# 4. Wait for it to become ready (WAL replay during recovery can take a
+# while depending on how far behind the base backup is).
+log "Waiting up to ${READY_TIMEOUT_SECONDS}s for restored postgres to become ready..."
+elapsed=0
+until docker exec "$DRILL_NAME" pg_isready -U feed >/dev/null 2>&1; do
+  sleep 5
+  elapsed=$((elapsed + 5))
+  if [ "$elapsed" -ge "$READY_TIMEOUT_SECONDS" ]; then
+    log "ERROR: restored postgres did not become ready within ${READY_TIMEOUT_SECONDS}s"
+    # Logs are dumped uniformly by the cleanup trap below on any non-zero exit.
+    exit 1
+  fi
+done
+log "Restored postgres is ready after ${elapsed}s"
+
+# 5. Integrity checks.
+run_check() {
+  local description="$1" sql="$2"
+  local result
+  result="$(docker exec "$DRILL_NAME" psql -U feed -d bluesky_feed -tA -c "$sql")"
+  log "CHECK: ${description} => ${result}"
+  printf '%s' "$result"
+}
+
+log "Running integrity checks against the restored database..."
+
+posts_count="$(run_check "posts row count" "SELECT COUNT(*) FROM posts;")"
+likes_count="$(run_check "likes row count" "SELECT COUNT(*) FROM likes;")"
+reposts_count="$(run_check "reposts row count" "SELECT COUNT(*) FROM reposts;")"
+follows_count="$(run_check "follows row count" "SELECT COUNT(*) FROM follows;")"
+
+active_epochs="$(run_check "active governance epoch count (expect 1)" \
+  "SELECT COUNT(*) FROM governance_epochs WHERE status = 'active';")"
+
+orphaned_scores="$(run_check "orphaned post_scores count (expect 0)" \
+  "SELECT COUNT(*) FROM post_scores ps WHERE NOT EXISTS (SELECT 1 FROM posts p WHERE p.uri = ps.post_uri);")"
+
+schema_migrations_count="$(run_check "schema_migrations row count" \
+  "SELECT COUNT(*) FROM schema_migrations;")"
+
+log "Summary: posts=${posts_count} likes=${likes_count} reposts=${reposts_count} follows=${follows_count} active_epochs=${active_epochs} orphaned_scores=${orphaned_scores} schema_migrations=${schema_migrations_count}"
+
+failed=0
+if [ "$active_epochs" != "1" ]; then
+  log "FAIL: expected exactly 1 active governance epoch, got ${active_epochs}"
+  failed=1
+fi
+if [ "$orphaned_scores" != "0" ]; then
+  log "FAIL: expected 0 orphaned post_scores rows, got ${orphaned_scores}"
+  failed=1
+fi
+if [ "$schema_migrations_count" -lt 1 ]; then
+  log "FAIL: schema_migrations table is empty — restore looks incomplete"
+  failed=1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  log "RESTORE DRILL FAILED — see FAIL lines above"
+  exit 1
+fi
+
+log "RESTORE DRILL PASSED"

--- a/scripts/backfill-score-components.ts
+++ b/scripts/backfill-score-components.ts
@@ -17,6 +17,8 @@
 
 import { Pool } from 'pg';
 import dotenv from 'dotenv';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 dotenv.config();
 
@@ -117,6 +119,52 @@ interface WideRow {
   source_diversity_weighted: number;
   relevance_weighted: number;
   scored_at: string;
+  // PROJ-917: post_scores gained its own `created_at` in migration 028 (a
+  // denormalized, immutable copy of the scored post's posts.created_at —
+  // see that migration for why). Source it straight from this row instead
+  // of re-deriving it via a JOIN against posts: a post_uri is not
+  // guaranteed globally unique across partitions (see the migration
+  // 026/027 review threads), so joining posts ON uri can fan a single
+  // post_scores row out into multiple joined rows and misattribute which
+  // created_at backs which component set. Reading it directly off this row
+  // is 1:1 by construction, no fan-out possible.
+  created_at: string;
+}
+
+interface ProjectedComponent {
+  post_uri: string;
+  epoch_id: number;
+  component_key: string;
+  raw: number;
+  weight: number;
+  weighted: number;
+  scored_at: string;
+  created_at: string;
+}
+
+/** Project each wide `post_scores` row into one row per registered scoring
+ * component. Pure and DB-free so it's directly unit-testable — in particular
+ * for the case that motivated this refactor: two rows sharing the same
+ * `post_uri` but differing `created_at` must each keep their own
+ * `created_at` on every projected component, never collapsed or
+ * cross-attributed to the other row's value. */
+export function projectWideRows(rows: WideRow[]): ProjectedComponent[] {
+  const projected: ProjectedComponent[] = [];
+  for (const row of rows) {
+    for (const { key, col } of COMPONENT_PROJECTION) {
+      projected.push({
+        post_uri: row.post_uri,
+        epoch_id: row.epoch_id,
+        component_key: key,
+        raw: row[`${col}_score` as keyof WideRow] as number,
+        weight: row[`${col}_weight` as keyof WideRow] as number,
+        weighted: row[`${col}_weighted` as keyof WideRow] as number,
+        scored_at: row.scored_at,
+        created_at: row.created_at,
+      });
+    }
+  }
+  return projected;
 }
 
 async function main(): Promise<void> {
@@ -140,7 +188,7 @@ async function main(): Promise<void> {
 
   let totalRowsScanned = 0;
   let totalRowsInserted = 0;
-  let lastSeen: { post_uri: string; epoch_id: number } | null = null;
+  let lastSeen: { post_uri: string; epoch_id: number; created_at: string } | null = null;
   let batchNumber = 0;
 
   try {
@@ -153,7 +201,12 @@ async function main(): Promise<void> {
       const remaining = limit !== null ? limit - totalRowsScanned : batchSize;
       const currentBatchSize = Math.min(batchSize, remaining);
 
-      // Keyset-paginate by (post_uri, epoch_id) so we don't OFFSET-scan a growing table.
+      // Keyset-paginate by (post_uri, epoch_id, created_at) — the same
+      // triple post_scores' own unique_post_epoch constraint covers
+      // (migration 028) — so we don't OFFSET-scan a growing table, and so
+      // two rows that happen to share a post_uri but differ by created_at
+      // are still ordered and paginated deterministically instead of
+      // colliding on a 2-column key.
       const params: unknown[] = [];
       const where: string[] = [];
 
@@ -162,9 +215,9 @@ async function main(): Promise<void> {
         where.push(`epoch_id = $${params.length}`);
       }
       if (lastSeen !== null) {
-        params.push(lastSeen.post_uri, lastSeen.epoch_id);
+        params.push(lastSeen.post_uri, lastSeen.epoch_id, lastSeen.created_at);
         where.push(
-          `(post_uri, epoch_id) > ($${params.length - 1}, $${params.length})`
+          `(post_uri, epoch_id, created_at) > ($${params.length - 2}, $${params.length - 1}, $${params.length}::timestamptz)`
         );
       }
       params.push(currentBatchSize);
@@ -179,10 +232,10 @@ async function main(): Promise<void> {
                 source_diversity_weight, relevance_weight,
                 recency_weighted, engagement_weighted, bridging_weighted,
                 source_diversity_weighted, relevance_weighted,
-                scored_at
+                scored_at, created_at
          FROM post_scores
          ${whereSql}
-         ORDER BY post_uri, epoch_id
+         ORDER BY post_uri, epoch_id, created_at
          LIMIT $${params.length}`,
         params
       );
@@ -196,46 +249,41 @@ async function main(): Promise<void> {
       totalRowsScanned += result.rows.length;
 
       // Project each wide row into N component rows.
-      const projected: Array<{
-        post_uri: string;
-        epoch_id: number;
-        component_key: string;
-        raw: number;
-        weight: number;
-        weighted: number;
-        scored_at: string;
-      }> = [];
-
-      for (const row of result.rows) {
-        for (const { key, col } of COMPONENT_PROJECTION) {
-          projected.push({
-            post_uri: row.post_uri,
-            epoch_id: row.epoch_id,
-            component_key: key,
-            raw: row[`${col}_score` as keyof WideRow] as number,
-            weight: row[`${col}_weight` as keyof WideRow] as number,
-            weighted: row[`${col}_weighted` as keyof WideRow] as number,
-            scored_at: row.scored_at,
-          });
-        }
-        lastSeen = { post_uri: row.post_uri, epoch_id: row.epoch_id };
-      }
+      const projected = projectWideRows(result.rows);
+      const last = result.rows[result.rows.length - 1];
+      lastSeen = { post_uri: last.post_uri, epoch_id: last.epoch_id, created_at: last.created_at };
 
       if (!dryRun && projected.length > 0) {
         // Batch insert via unnest(...) for one round-trip per batch.
+        //
+        // PROJ-917: post_score_components is now RANGE-partitioned by
+        // created_at (migration 029) — a denormalized copy of the scored
+        // post's own posts.created_at (immutable). Sourced directly from
+        // the post_scores row itself (post_scores gained its own
+        // created_at in migration 028), NOT re-derived via a JOIN against
+        // posts: post_uri is not guaranteed globally unique across
+        // partitions, so a posts JOIN can fan a single post_scores row out
+        // into multiple rows and attach the wrong created_at to a
+        // component set. Threading created_at straight through the
+        // UNNEST from the already-selected post_scores.created_at avoids
+        // that entirely — no join, no fan-out, no COALESCE fallback.
+        // PRIMARY KEY — and this ON CONFLICT target — widened to include
+        // created_at in the same migration.
         const insertResult = await pool.query<{ count: string }>(
           `WITH inserted AS (
-             INSERT INTO post_score_components (post_uri, epoch_id, component_key, raw, weight, weighted, scored_at)
-             SELECT * FROM UNNEST(
+             INSERT INTO post_score_components (post_uri, epoch_id, component_key, raw, weight, weighted, scored_at, created_at)
+             SELECT u.post_uri, u.epoch_id, u.component_key, u.raw, u.weight, u.weighted, u.scored_at, u.created_at
+             FROM UNNEST(
                $1::text[],
                $2::int[],
                $3::text[],
                $4::float[],
                $5::float[],
                $6::float[],
-               $7::timestamptz[]
-             )
-             ON CONFLICT (post_uri, epoch_id, component_key) DO NOTHING
+               $7::timestamptz[],
+               $8::timestamptz[]
+             ) AS u(post_uri, epoch_id, component_key, raw, weight, weighted, scored_at, created_at)
+             ON CONFLICT (post_uri, epoch_id, component_key, created_at) DO NOTHING
              RETURNING 1
            )
            SELECT COUNT(*)::text AS count FROM inserted`,
@@ -247,6 +295,7 @@ async function main(): Promise<void> {
             projected.map((p) => p.weight),
             projected.map((p) => p.weighted),
             projected.map((p) => p.scored_at),
+            projected.map((p) => p.created_at),
           ]
         );
         const insertedCount = parseInt(insertResult.rows[0]?.count ?? '0', 10);
@@ -273,7 +322,18 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error('Backfill failed:', err);
-  process.exit(1);
-});
+function isMainModule(): boolean {
+  if (!process.argv[1]) {
+    return false;
+  }
+  return path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+// Guarded so tests can import projectWideRows() without also kicking off the
+// live CLI (which would call process.exit() against a test's DATABASE_URL).
+if (isMainModule()) {
+  main().catch((err) => {
+    console.error('Backfill failed:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -16,9 +16,22 @@ const NON_TRANSACTIONAL_MIGRATION_MARKER_PATTERN = new RegExp(
   `^\\s*${escapeRegExp(NON_TRANSACTIONAL_MIGRATION_MARKER)}\\s*$`,
   'm'
 );
-const POST_SCORES_RUN_SCOPE_INDEX_MIGRATION = '024_post_scores_run_scope_index.sql';
-const POST_SCORES_RUN_SCOPE_INDEX_NAME = 'idx_scores_epoch_run_total';
-const POST_SCORES_RUN_SCOPE_INDEX_REGCLASS = `public.${POST_SCORES_RUN_SCOPE_INDEX_NAME}`;
+// Migrations that build CREATE INDEX CONCURRENTLY indexes must be verified
+// post-hoc: a canceled/failed concurrent build leaves an INVALID index
+// behind (pg_index.indisvalid = false) rather than rolling back, since
+// CONCURRENTLY doesn't run inside a transaction. Maps migration filename ->
+// the index name(s) (schema `public`) that migration must leave valid.
+const MIGRATION_REQUIRED_INDEXES: Record<string, readonly string[]> = {
+  '024_post_scores_run_scope_index.sql': ['idx_scores_epoch_run_total'],
+  // PROJ-917 thread 8: same statement_timeout-cancellation risk applies to
+  // this migration's three CONCURRENTLY builds (see that migration's own
+  // SET statement_timeout = 0 fix).
+  '025_raw_event_created_at_indexes.sql': [
+    'idx_follows_created',
+    'idx_reposts_created',
+    'idx_likes_created',
+  ],
+};
 const LEGACY_MIGRATION_SENTINEL_TABLES = ['posts', 'governance_epochs', 'post_scores'] as const;
 
 const LEGACY_MIGRATION_PROBES: Record<string, string> = {
@@ -149,36 +162,207 @@ export async function verifyRequiredMigrationSideEffects(
   client: pg.Client,
   filename: string
 ): Promise<void> {
-  if (filename !== POST_SCORES_RUN_SCOPE_INDEX_MIGRATION) {
+  const requiredIndexes = MIGRATION_REQUIRED_INDEXES[filename];
+  if (!requiredIndexes) {
     return;
   }
 
-  const result = await client.query<{ index_exists: boolean; index_is_valid: boolean }>(
-    `
-      SELECT
-        to_regclass($1) IS NOT NULL AS index_exists,
-        COALESCE((
-          SELECT pg_index.indisvalid
-          FROM pg_class index_class
-          JOIN pg_index ON pg_index.indexrelid = index_class.oid
-          JOIN pg_namespace namespace ON namespace.oid = index_class.relnamespace
-          WHERE namespace.nspname = $2
-            AND index_class.relname = $3
-        ), false) AS index_is_valid
-    `,
-    [POST_SCORES_RUN_SCOPE_INDEX_REGCLASS, 'public', POST_SCORES_RUN_SCOPE_INDEX_NAME]
-  );
-  const verification = result.rows[0];
+  const failures: string[] = [];
 
-  if (verification?.index_exists === true && verification.index_is_valid === true) {
+  for (const indexName of requiredIndexes) {
+    const regclass = `public.${indexName}`;
+    const result = await client.query<{ index_exists: boolean; index_is_valid: boolean }>(
+      `
+        SELECT
+          to_regclass($1) IS NOT NULL AS index_exists,
+          COALESCE((
+            SELECT pg_index.indisvalid
+            FROM pg_class index_class
+            JOIN pg_index ON pg_index.indexrelid = index_class.oid
+            JOIN pg_namespace namespace ON namespace.oid = index_class.relnamespace
+            WHERE namespace.nspname = $2
+              AND index_class.relname = $3
+          ), false) AS index_is_valid
+      `,
+      [regclass, 'public', indexName]
+    );
+    const verification = result.rows[0];
+
+    if (verification?.index_exists === true && verification.index_is_valid === true) {
+      continue;
+    }
+
+    failures.push(
+      `${regclass}: index_exists=${String(verification?.index_exists ?? false)} ` +
+        `index_is_valid=${String(verification?.index_is_valid ?? false)}`
+    );
+  }
+
+  if (failures.length === 0) {
     return;
   }
 
   throw new MigrationVerificationError(
-    `Migration ${filename} did not leave a valid ${POST_SCORES_RUN_SCOPE_INDEX_REGCLASS} index: ` +
-      `index_exists=${String(verification?.index_exists ?? false)} ` +
-      `index_is_valid=${String(verification?.index_is_valid ?? false)}`
+    `Migration ${filename} did not leave valid required indexes: ${failures.join('; ')}`
   );
+}
+
+/**
+ * Split a SQL script into individually-executable statements.
+ *
+ * PROJ-917 discovered this the hard way: PostgreSQL's simple query protocol
+ * implicitly wraps multiple `;`-separated statements sent in a *single*
+ * message into one transaction block — and `CREATE INDEX CONCURRENTLY`
+ * refuses to run inside ANY transaction block, explicit or implicit
+ * ("CREATE INDEX CONCURRENTLY cannot run inside a transaction block").
+ * Migration 025 sends a `SET ...;` followed by three
+ * `CREATE INDEX CONCURRENTLY ...;` statements as one file — passing that
+ * whole string to a single `client.query(sql)` call (as this function used
+ * to) hits exactly that error. Migration 024 never hit it only because it
+ * happens to be a single statement. Executing one `client.query()` call per
+ * statement avoids the implicit wrapping entirely; a session-scoped `SET`
+ * still applies to the later statements because they all run on the same
+ * `client` (same underlying connection), regardless of being separate
+ * query() calls.
+ *
+ * Quote/dollar-quote/comment aware, so a `;` inside a string literal,
+ * quoted identifier, `$tag$...$tag$` block, `--` line comment, or a
+ * slash-star block comment is never mistaken for a statement separator —
+ * migration 025 has exactly this case (a `;` inside a `--` comment
+ * sentence).
+ * Deliberately simple — sufficient for the no-transaction migrations this
+ * repo has today (plain DDL, no nested statements); extend it if a future
+ * one needs more.
+ */
+export function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let current = '';
+  let i = 0;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let dollarTag: string | null = null;
+
+  while (i < sql.length) {
+    const ch = sql[i];
+
+    if (inLineComment) {
+      current += ch;
+      if (ch === '\n') {
+        inLineComment = false;
+      }
+      i++;
+      continue;
+    }
+
+    if (inBlockComment) {
+      current += ch;
+      if (ch === '*' && sql[i + 1] === '/') {
+        current += '/';
+        i += 2;
+        inBlockComment = false;
+      } else {
+        i++;
+      }
+      continue;
+    }
+
+    if (dollarTag !== null) {
+      if (sql.startsWith(dollarTag, i)) {
+        current += dollarTag;
+        i += dollarTag.length;
+        dollarTag = null;
+      } else {
+        current += ch;
+        i++;
+      }
+      continue;
+    }
+
+    if (inSingleQuote) {
+      current += ch;
+      if (ch === "'") {
+        inSingleQuote = false;
+      }
+      i++;
+      continue;
+    }
+
+    if (inDoubleQuote) {
+      current += ch;
+      if (ch === '"') {
+        inDoubleQuote = false;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '-' && sql[i + 1] === '-') {
+      inLineComment = true;
+      current += '--';
+      i += 2;
+      continue;
+    }
+
+    if (ch === '/' && sql[i + 1] === '*') {
+      inBlockComment = true;
+      current += '/*';
+      i += 2;
+      continue;
+    }
+
+    if (ch === "'") {
+      inSingleQuote = true;
+      current += ch;
+      i++;
+      continue;
+    }
+
+    if (ch === '"') {
+      inDoubleQuote = true;
+      current += ch;
+      i++;
+      continue;
+    }
+
+    if (ch === '$') {
+      // Dollar-quote tag rules (PostgreSQL docs, "Dollar-Quoted String
+      // Constants"): a tag follows the rules for an unquoted identifier —
+      // must start with a letter or underscore, subsequent characters can
+      // be letters, digits, or underscores — except it additionally cannot
+      // contain a dollar sign. `[a-zA-Z_]*` (no digits at all) rejected
+      // legitimate tags like `$tag1$`, causing any `;` inside that block to
+      // be mis-split as a statement boundary.
+      const match = /^\$([A-Za-z_][A-Za-z0-9_]*)?\$/.exec(sql.slice(i));
+      if (match) {
+        dollarTag = match[0];
+        current += dollarTag;
+        i += dollarTag.length;
+        continue;
+      }
+    }
+
+    if (ch === ';') {
+      const trimmed = current.trim();
+      if (trimmed.length > 0) {
+        statements.push(trimmed);
+      }
+      current = '';
+      i++;
+      continue;
+    }
+
+    current += ch;
+    i++;
+  }
+
+  const trimmedTail = current.trim();
+  if (trimmedTail.length > 0) {
+    statements.push(trimmedTail);
+  }
+
+  return statements;
 }
 
 export async function applyNonTransactionalMigration(
@@ -186,7 +370,9 @@ export async function applyNonTransactionalMigration(
   filename: string,
   sql: string
 ): Promise<void> {
-  await client.query(sql);
+  for (const statement of splitSqlStatements(sql)) {
+    await client.query(statement);
+  }
   await verifyRequiredMigrationSideEffects(client, filename);
   await client.query(`INSERT INTO ${MIGRATIONS_TABLE} (filename) VALUES ($1)`, [filename]);
 }

--- a/src/admin/routes/cleanup.ts
+++ b/src/admin/routes/cleanup.ts
@@ -1,0 +1,103 @@
+/**
+ * Admin Cleanup Routes
+ *
+ * POST /api/admin/trigger-cleanup - Manually trigger the retention cleanup job
+ *
+ * PROJ-917: ops/health-watchdog used to curl this exact path expecting it
+ * to already exist; it never did (a 404 silently swallowed by `|| true`).
+ * This route makes it real for authenticated interactive use (an admin
+ * dashboard "run cleanup now" button, manual incident response over curl
+ * with a real session token).
+ *
+ * It deliberately does NOT make ops/health-watchdog's automated curl call
+ * work: every /api/admin/* route requires the same session-cookie/Bearer
+ * admin auth as the rest of the dashboard (src/auth/admin.ts's
+ * requireAdmin, which resolves a DID via a Bluesky-login-backed Redis
+ * session), and a systemd timer script has no way to hold or refresh one.
+ * Pointing the watchdog's curl at this route would just trade a silent 404
+ * for a silent 401 — see ops/health-watchdog's header comment, which was
+ * updated in the same change to remove that call rather than pretend it
+ * could ever authenticate.
+ */
+
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { db } from '../../db/client.js';
+import { getAdminDid } from '../../auth/admin.js';
+import { triggerManualCleanup } from '../../maintenance/cleanup.js';
+import { adminSecurity, ErrorResponseSchema } from '../../lib/openapi.js';
+import { logger } from '../../lib/logger.js';
+
+const cleanupResultSchema = {
+  type: 'object' as const,
+  nullable: true,
+  properties: {
+    postsDeleted: { type: 'integer' as const },
+    orphanedLikesDeleted: { type: 'integer' as const },
+    orphanedRepostsDeleted: { type: 'integer' as const },
+    orphanedEngagementDeleted: { type: 'integer' as const },
+    staleLikesDeleted: { type: 'integer' as const },
+    staleRepostsDeleted: { type: 'integer' as const },
+    oldFollowsDeleted: { type: 'integer' as const },
+    vacuumRan: { type: 'boolean' as const },
+    durationMs: { type: 'integer' as const },
+  },
+};
+
+export function registerCleanupRoutes(app: FastifyInstance): void {
+  /**
+   * POST /api/admin/trigger-cleanup
+   * Manually triggers the hourly retention cleanup job
+   * (src/maintenance/cleanup.ts's triggerManualCleanup). Logged to audit
+   * trail. Returns a null result (with success: false) if a cleanup run
+   * was already in progress or the scheduler is shutting down — that is
+   * triggerManualCleanup()'s normal "rejected, try again shortly" signal,
+   * not a route error.
+   */
+  app.post('/trigger-cleanup', {
+    schema: {
+      tags: ['Admin'],
+      summary: 'Trigger retention cleanup',
+      description:
+        'Manually triggers the retention cleanup job: hard-deletes unscored posts past retention, orphaned likes/reposts/post_engagement, stale likes/reposts, and old follows. Requires admin access.',
+      security: adminSecurity,
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            success: { type: 'boolean', description: 'False if a cleanup run was already in progress' },
+            result: cleanupResultSchema,
+          },
+          required: ['success', 'result'],
+        },
+        401: ErrorResponseSchema,
+        403: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest, reply: FastifyReply) => {
+    const adminDid = getAdminDid(request);
+
+    logger.info({ adminDid }, 'Manual cleanup triggered by admin');
+
+    const result = await triggerManualCleanup();
+
+    // Audit-log write is best-effort: triggerManualCleanup() already ran and
+    // may have mutated a lot of state, so a failure here must not turn into
+    // a 500 that discards `result` from the caller — mirrors how
+    // src/maintenance/cleanup.ts treats its own system_status write as
+    // non-fatal (catch + warn) for exactly this reason.
+    try {
+      await db.query(
+        `INSERT INTO governance_audit_log (action, actor_did, details)
+         VALUES ('manual_cleanup_trigger', $1, $2)`,
+        [adminDid, JSON.stringify({ triggeredAt: new Date().toISOString(), result })]
+      );
+    } catch (err) {
+      logger.warn({ err }, 'Failed to write manual_cleanup_trigger audit log entry');
+    }
+
+    return reply.send({
+      success: result !== null,
+      result,
+    });
+  });
+}

--- a/src/admin/routes/index.ts
+++ b/src/admin/routes/index.ts
@@ -12,6 +12,7 @@ import { registerEpochRoutes } from './epochs.js';
 import { registerAnnouncementRoutes } from './announcements.js';
 import { registerFeedHealthRoutes } from './feed-health.js';
 import { registerAdminHealthRoutes } from './health.js';
+import { registerCleanupRoutes } from './cleanup.js';
 import { registerAuditLogRoutes } from './audit-log.js';
 import { registerAuditAnalysisRoutes } from './audit-analysis.js';
 import { registerSchedulerRoutes } from './scheduler.js';
@@ -35,6 +36,7 @@ export function registerAdminRoutes(app: FastifyInstance): void {
       registerAnnouncementRoutes(adminApp);
       registerFeedHealthRoutes(adminApp);
       registerAdminHealthRoutes(adminApp);
+      registerCleanupRoutes(adminApp);
       registerAuditLogRoutes(adminApp);
       registerAuditAnalysisRoutes(adminApp);
       registerSchedulerRoutes(adminApp);

--- a/src/admin/routes/vitals.ts
+++ b/src/admin/routes/vitals.ts
@@ -69,7 +69,7 @@ export function registerVitalsRoutes(app: FastifyInstance): void {
       redis.info('memory').catch(() => ''),
       safeQuery<{ key: string; value: Record<string, unknown>; updated_at: string }>(
         `SELECT key, value, updated_at::text FROM system_status
-         WHERE key IN ('current_scoring_run', 'last_cleanup_run', 'disk_status', 'last_emergency_vacuum', 'engagement_alert')`
+         WHERE key IN ('current_scoring_run', 'last_cleanup_run', 'disk_status', 'disk_emergency_alert', 'engagement_alert')`
       ),
       safeQuery<{ total: string; active_24h: string; active_7d: string }>(
         `SELECT
@@ -109,7 +109,7 @@ export function registerVitalsRoutes(app: FastifyInstance): void {
 
     const scoringRun = statusMap.get('current_scoring_run');
     const cleanupRun = statusMap.get('last_cleanup_run');
-    const emergencyVacuum = statusMap.get('last_emergency_vacuum');
+    const diskEmergencyAlert = statusMap.get('disk_emergency_alert');
     const engagementAlert = statusMap.get('engagement_alert');
 
     // Disk
@@ -143,7 +143,7 @@ export function registerVitalsRoutes(app: FastifyInstance): void {
             total_gb: diskStatus.total_gb,
             level: diskStatus.level,
             last_checked_at: diskStatus.last_checked_at,
-            last_emergency_vacuum: emergencyVacuum?.value ?? null,
+            emergency_alert: diskEmergencyAlert?.value ?? null,
           }
         : null,
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -184,6 +184,17 @@ export const ConfigSchema = z.object({
   DISK_CRITICAL_PERCENT: z.coerce.number().min(50).max(100).default(90),
   DISK_EMERGENCY_PERCENT: z.coerce.number().min(50).max(100).default(95),
 
+  // Partition retention (PROJ-917): src/maintenance/partition-manager.ts drops
+  // whole daily partitions once their upper bound falls this many days behind
+  // CURRENT_DATE. Must stay in sync with the window baked into migrations
+  // 026-029 (created_at index/partition rebuild) — those migrations create
+  // the initial partitions spanning [today - (retention + 2d), today + 2d];
+  // changing these values does not retroactively resize existing partitions.
+  /** Retention window (days) for raw event tables: likes, reposts, follows. */
+  RAW_EVENT_RETENTION_DAYS: z.coerce.number().int().min(1).default(14),
+  /** Retention window (days) for content+score tables: posts, post_scores, post_score_components. */
+  SCORED_DATA_RETENTION_DAYS: z.coerce.number().int().min(1).default(30),
+
   // Research export
   EXPORT_ANONYMIZATION_SALT: z.string().min(16).default(INSECURE_EXPORT_SALT_DEFAULT),
 }).superRefine((cfg, ctx) => {

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -19,3 +19,33 @@ db.on('error', (err) => {
 db.on('connect', () => {
   logger.debug('New PostgreSQL client connected');
 });
+
+/**
+ * Dedicated health-check pool (PROJ-917).
+ *
+ * Prod incident 2026-07-06: the health check's `SELECT 1` shared the main
+ * `db` pool above. When the main pool was exhausted (every connection
+ * checked out by real request/scoring traffic), the health query queued
+ * behind it, /health/ready started failing, and systemd's watchdog
+ * (src/lib/watchdog.ts, which gates its heartbeat on this same check)
+ * eventually SIGABRT-killed the service — the health check became a victim
+ * of the exact condition it exists to detect.
+ *
+ * This tiny, separate pool is used ONLY by checkDatabase() in
+ * src/lib/health.ts (and therefore by the watchdog heartbeat path that
+ * calls it). Kept intentionally small: a health probe never needs more
+ * than a couple of connections, and keeping it separate means main-pool
+ * exhaustion can no longer starve the one check whose entire job is to
+ * notice that.
+ */
+export const healthDb = new Pool({
+  connectionString: config.DATABASE_URL,
+  max: 2,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000,
+  statement_timeout: 5000,
+});
+
+healthDb.on('error', (err) => {
+  logger.error({ err }, 'Unexpected PostgreSQL health-pool error');
+});

--- a/src/db/migrations/025_raw_event_created_at_indexes.sql
+++ b/src/db/migrations/025_raw_event_created_at_indexes.sql
@@ -1,0 +1,40 @@
+-- migrate: no-transaction
+-- Migration 025: created_at indexes on raw event tables (retention root-cause fix)
+--
+-- The hourly retention cleanup (src/maintenance/cleanup.ts) deletes rows from
+-- likes/reposts/follows filtered by `created_at < NOW() - <window>`. Migration
+-- 001 created only subject_uri/author_did indexes on these tables, so every
+-- retention DELETE seq-scans the full table (likes ~48M rows) and hits the
+-- 120s statement_timeout (SQLSTATE 57014) before deleting a single row. In
+-- production this made retention a no-op on every run and let the tables grow
+-- unbounded until the root disk filled.
+--
+-- A plain b-tree on created_at lets the delete subqueries drain oldest-first via
+-- an index scan. The NOT EXISTS(post_scores) guard references another table, so
+-- a partial predicate index is not applicable; a plain index is correct here.
+-- Built concurrently on live production data, so this file opts out of the
+-- migration runner's transaction wrapper.
+--
+-- Rollback, if needed:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_likes_created;
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_reposts_created;
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_follows_created;
+
+-- Larger sort memory speeds the build; session-scoped, reverts on disconnect.
+SET maintenance_work_mem = '512MB';
+
+-- This file's own header notes the cleanup path hits a 120s statement_timeout
+-- on these same high-volume tables (likes ~48M rows). If that (or any)
+-- statement_timeout applies to the migration session, a CREATE INDEX
+-- CONCURRENTLY build that runs long can be canceled mid-build and leave an
+-- INVALID index behind (visible via pg_index.indisvalid = false) rather than
+-- rolling back cleanly, since CONCURRENTLY does not run inside a transaction.
+-- Disabling it for this session (scoped to this connection; reverts on
+-- disconnect, same as maintenance_work_mem above) lets all three builds run
+-- to completion regardless of how long they take.
+SET statement_timeout = 0;
+
+-- Build order smallest/fastest-growing first (follows deleter is unconditional).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_follows_created ON follows (created_at);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_reposts_created ON reposts (created_at);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_likes_created   ON likes (created_at);

--- a/src/db/migrations/026_partition_raw_events.sql
+++ b/src/db/migrations/026_partition_raw_events.sql
@@ -1,0 +1,184 @@
+-- Migration 026: Partition raw event tables (likes, reposts, follows)
+-- PROJ-917: native time-partitioned schema rebuild
+--
+-- ROOT CAUSE THIS FIXES: migration 025 added a plain b-tree on created_at so
+-- the hourly guarded-DELETE retention cleanup (src/maintenance/cleanup.ts)
+-- could at least find rows to delete without seq-scanning 48M rows. That
+-- band-aid still leaves retention as an indexed DELETE — bounded by
+-- statement_timeout, competing with autovacuum/bloat, and never truly
+-- instant. This migration replaces the unpartitioned tables with declarative
+-- RANGE partitioning on created_at, so retention becomes ALTER TABLE ...
+-- DETACH PARTITION + DROP TABLE (src/maintenance/partition-manager.ts) —
+-- a metadata-only operation independent of row count.
+--
+-- RETENTION WINDOW: 14 days (RAW_EVENT_RETENTION_DAYS in src/config.ts).
+-- Daily partitions are created spanning [today - 16d, today + 2d] (14d
+-- retention + 2d safety buffer on each side) so partition-manager.ts always
+-- has a couple of days of slack before it must create the next day's
+-- partition or drop the oldest one.
+--
+-- APPROACH: stop-the-line blocking rebuild (no real users yet — see PROJ-917
+-- packet). For each table: create a new RANGE-partitioned parent with the
+-- same columns (`LIKE <table> INCLUDING DEFAULTS`), widen the PK to include
+-- the partition key (required — see PG16 docs below), recreate the existing
+-- secondary indexes, copy rows inside the retention window from the old
+-- table, then rename-swap the old table out of the way (kept as `_legacy`,
+-- NOT dropped — see docs/PARTITION_REBUILD.md for the manual verify+drop
+-- step) and the new table into its place.
+--
+-- PG16 CONSTRAINT (cited): "To create a unique or primary key constraint on
+-- a partitioned table, ... the constraint's columns must include all of the
+-- partition key columns." — PostgreSQL 16 docs, "5.11.2.3. Limitations"
+-- (https://www.postgresql.org/docs/16/ddl-partitioning.html). This is why
+-- the PK below becomes (uri, created_at) instead of (uri) alone: a
+-- partitioned table cannot enforce global uniqueness on a column that isn't
+-- part of the partition key, because each partition only enforces
+-- uniqueness within itself.
+--
+-- CALLER IMPACT: every `ON CONFLICT (uri) DO NOTHING` against these three
+-- tables (like-handler.ts, repost-handler.ts, follow-handler.ts, and the A1
+-- simulation harness/stress seeders) must widen to
+-- `ON CONFLICT (uri, created_at) DO NOTHING` to keep matching a real unique
+-- constraint — done in the same PROJ-917 commit as this migration.
+--
+-- No FK changes needed here: likes/reposts/follows never had a foreign key
+-- to posts (see cleanup.ts's header comment — orphan cleanup already
+-- handles that gap), so nothing to re-point.
+
+-- Reusable helper: create one daily RANGE partition per day in [start_date,
+-- end_date] (inclusive) for a given partitioned parent. Shared by every
+-- PROJ-917 partitioning migration (026-029) and by
+-- src/maintenance/partition-manager.ts's "create tomorrow's partition"
+-- step, so the partition-naming convention (`<prefix>_p<YYYYMMDD>`) and
+-- creation DDL live in exactly one place.
+CREATE OR REPLACE FUNCTION create_daily_range_partitions(
+  parent_table text,
+  partition_prefix text,
+  start_date date,
+  end_date date
+) RETURNS void AS $$
+DECLARE
+  d date := start_date;
+  partition_name text;
+BEGIN
+  IF end_date < start_date THEN
+    RETURN;
+  END IF;
+
+  WHILE d <= end_date LOOP
+    partition_name := format('%s_p%s', partition_prefix, to_char(d, 'YYYYMMDD'));
+    EXECUTE format(
+      'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
+      partition_name, parent_table, d::text, (d + 1)::text
+    );
+    d := d + 1;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- likes
+-- ============================================================
+
+CREATE TABLE likes_new (
+  LIKE likes INCLUDING DEFAULTS,
+  PRIMARY KEY (uri, created_at)
+) PARTITION BY RANGE (created_at);
+
+CREATE INDEX idx_likes_subject_new ON likes_new(subject_uri);
+CREATE INDEX idx_likes_author_new ON likes_new(author_did);
+CREATE INDEX idx_likes_created_new ON likes_new(created_at);
+
+-- Default partition: safety net for any row whose created_at falls outside
+-- every explicit daily range (clock skew, backfill replay, a missed
+-- partition-manager run). Without one, an out-of-range INSERT hard-fails
+-- ("no partition of relation found for row"). partition-manager.ts sweeps
+-- this partition on its own retention cadence (see its header comment).
+CREATE TABLE likes_default PARTITION OF likes_new DEFAULT;
+
+SELECT create_daily_range_partitions(
+  'likes_new', 'likes',
+  (CURRENT_DATE - INTERVAL '16 days')::date,
+  (CURRENT_DATE + INTERVAL '2 days')::date
+);
+
+INSERT INTO likes_new
+SELECT * FROM likes
+WHERE created_at >= (CURRENT_DATE - INTERVAL '16 days');
+
+ALTER TABLE likes RENAME TO likes_legacy;
+ALTER INDEX idx_likes_subject RENAME TO idx_likes_subject_legacy;
+ALTER INDEX idx_likes_author RENAME TO idx_likes_author_legacy;
+ALTER INDEX idx_likes_created RENAME TO idx_likes_created_legacy;
+
+ALTER TABLE likes_new RENAME TO likes;
+ALTER INDEX idx_likes_subject_new RENAME TO idx_likes_subject;
+ALTER INDEX idx_likes_author_new RENAME TO idx_likes_author;
+ALTER INDEX idx_likes_created_new RENAME TO idx_likes_created;
+
+-- ============================================================
+-- reposts
+-- ============================================================
+
+CREATE TABLE reposts_new (
+  LIKE reposts INCLUDING DEFAULTS,
+  PRIMARY KEY (uri, created_at)
+) PARTITION BY RANGE (created_at);
+
+CREATE INDEX idx_reposts_subject_new ON reposts_new(subject_uri);
+CREATE INDEX idx_reposts_created_new ON reposts_new(created_at);
+
+CREATE TABLE reposts_default PARTITION OF reposts_new DEFAULT;
+
+SELECT create_daily_range_partitions(
+  'reposts_new', 'reposts',
+  (CURRENT_DATE - INTERVAL '16 days')::date,
+  (CURRENT_DATE + INTERVAL '2 days')::date
+);
+
+INSERT INTO reposts_new
+SELECT * FROM reposts
+WHERE created_at >= (CURRENT_DATE - INTERVAL '16 days');
+
+ALTER TABLE reposts RENAME TO reposts_legacy;
+ALTER INDEX idx_reposts_subject RENAME TO idx_reposts_subject_legacy;
+ALTER INDEX idx_reposts_created RENAME TO idx_reposts_created_legacy;
+
+ALTER TABLE reposts_new RENAME TO reposts;
+ALTER INDEX idx_reposts_subject_new RENAME TO idx_reposts_subject;
+ALTER INDEX idx_reposts_created_new RENAME TO idx_reposts_created;
+
+-- ============================================================
+-- follows
+-- ============================================================
+
+CREATE TABLE follows_new (
+  LIKE follows INCLUDING DEFAULTS,
+  PRIMARY KEY (uri, created_at)
+) PARTITION BY RANGE (created_at);
+
+CREATE INDEX idx_follows_author_new ON follows_new(author_did) WHERE deleted = FALSE;
+CREATE INDEX idx_follows_subject_new ON follows_new(subject_did) WHERE deleted = FALSE;
+CREATE INDEX idx_follows_created_new ON follows_new(created_at);
+
+CREATE TABLE follows_default PARTITION OF follows_new DEFAULT;
+
+SELECT create_daily_range_partitions(
+  'follows_new', 'follows',
+  (CURRENT_DATE - INTERVAL '16 days')::date,
+  (CURRENT_DATE + INTERVAL '2 days')::date
+);
+
+INSERT INTO follows_new
+SELECT * FROM follows
+WHERE created_at >= (CURRENT_DATE - INTERVAL '16 days');
+
+ALTER TABLE follows RENAME TO follows_legacy;
+ALTER INDEX idx_follows_author RENAME TO idx_follows_author_legacy;
+ALTER INDEX idx_follows_subject RENAME TO idx_follows_subject_legacy;
+ALTER INDEX idx_follows_created RENAME TO idx_follows_created_legacy;
+
+ALTER TABLE follows_new RENAME TO follows;
+ALTER INDEX idx_follows_author_new RENAME TO idx_follows_author;
+ALTER INDEX idx_follows_subject_new RENAME TO idx_follows_subject;
+ALTER INDEX idx_follows_created_new RENAME TO idx_follows_created;

--- a/src/db/migrations/027_partition_posts.sql
+++ b/src/db/migrations/027_partition_posts.sql
@@ -1,0 +1,127 @@
+-- Migration 027: Partition the posts table
+-- PROJ-917: native time-partitioned schema rebuild (see 026 for the raw-event
+-- half and full PROJ-917 rationale/PG16 citations).
+--
+-- RETENTION WINDOW: 30 days (SCORED_DATA_RETENTION_DAYS in src/config.ts).
+-- Daily partitions span [today - 32d, today + 2d] (30d retention + 2d
+-- safety buffer).
+--
+-- FOREIGN KEY FALLOUT (the "cross-partitioned-table FK" question the PROJ-917
+-- packet asks to resolve): post_engagement.post_uri, post_scores.post_uri,
+-- and post_score_components.post_uri all currently
+-- `REFERENCES posts(uri) ON DELETE CASCADE`. PG16 requires a partitioned
+-- table's PK/unique constraints to include the full partition key ("5.11.2.3.
+-- Limitations", https://www.postgresql.org/docs/16/ddl-partitioning.html) —
+-- so once posts' PK becomes (uri, created_at), `posts(uri)` alone is no
+-- longer backed by any unique constraint and can no longer be a valid FK
+-- target. Chosen approach: DROP these three FK constraints outright rather
+-- than widen every child to carry a denormalized created_at AND repoint the
+-- FK at the composite (uri, created_at) key. Rationale:
+--   1. Even a same-day-partition-aligned composite FK does not remove the
+--      operational problem this whole rebuild exists to solve: PG requires a
+--      SHARE lock against every table with an FK pointing at a partitioned
+--      table's partition before that partition can be detached (see
+--      "ALTER TABLE ... DETACH PARTITION",
+--      https://www.postgresql.org/docs/16/sql-altertable.html), which
+--      reintroduces cross-table coordination on every retention drop —
+--      exactly the kind of coupling instant-drop retention is meant to
+--      eliminate.
+--   2. Referential integrity is preserved by construction instead of by
+--      constraint: post_scores/post_score_components rows are only ever
+--      written by the scoring pipeline immediately after it reads the
+--      corresponding row from `posts` (src/scoring/pipeline.ts), and their
+--      retention windows are driven by the SAME 30-day config value and the
+--      same partition-manager job, so parent and child data age out
+--      together. post_engagement is handled by an explicit
+--      application-level cascade in partition-manager.ts's drop step (per
+--      this packet's instructions) plus an orphan-sweep in cleanup.ts,
+--      mirroring the pattern this codebase already uses for likes/reposts
+--      (which never had an FK to posts at all — see cleanup.ts's header
+--      comment).
+--
+-- Every `INSERT INTO posts ... ON CONFLICT (uri) DO NOTHING` call site
+-- widens to `ON CONFLICT (uri, created_at) DO NOTHING` in the same commit
+-- (post-handler.ts, the A1 harness seeders, the concurrent-writes stress
+-- scenario).
+
+-- Reusable helper: drop whichever FK constraint (if any) currently makes
+-- `child_table.<col>` reference `parent_table`, without hardcoding
+-- PostgreSQL's auto-generated constraint name (`<table>_<column>_fkey`) —
+-- looked up from pg_constraint instead so this is correct even if a
+-- constraint was given a custom name. Shared by every PROJ-917 migration
+-- that has to detach a table from the posts partitioning rebuild (027-029).
+CREATE OR REPLACE FUNCTION drop_fk_referencing(
+  child_table text,
+  parent_table text
+) RETURNS void AS $$
+DECLARE
+  fk_name text;
+BEGIN
+  SELECT conname INTO fk_name
+  FROM pg_constraint
+  WHERE conrelid = child_table::regclass
+    AND confrelid = parent_table::regclass
+    AND contype = 'f';
+
+  IF fk_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I', child_table, fk_name);
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT drop_fk_referencing('post_engagement', 'posts');
+SELECT drop_fk_referencing('post_scores', 'posts');
+SELECT drop_fk_referencing('post_score_components', 'posts');
+
+-- ============================================================
+-- posts
+-- ============================================================
+
+CREATE TABLE posts_new (
+  LIKE posts INCLUDING DEFAULTS,
+  PRIMARY KEY (uri, created_at)
+) PARTITION BY RANGE (created_at);
+
+CREATE INDEX idx_posts_author_new ON posts_new(author_did);
+CREATE INDEX idx_posts_created_new ON posts_new(created_at DESC);
+CREATE INDEX idx_posts_indexed_new ON posts_new(indexed_at DESC);
+CREATE INDEX idx_posts_reply_root_new ON posts_new(reply_root) WHERE reply_root IS NOT NULL;
+CREATE INDEX idx_posts_active_new ON posts_new(created_at DESC) WHERE deleted = FALSE;
+CREATE INDEX idx_posts_text_trgm_new ON posts_new USING gin (text gin_trgm_ops) WHERE deleted = FALSE;
+CREATE INDEX idx_posts_topic_vector_new ON posts_new USING GIN (topic_vector);
+CREATE INDEX idx_posts_classification_method_new ON posts_new(classification_method) WHERE classification_method IS NOT NULL;
+CREATE INDEX idx_posts_embed_url_new ON posts_new(embed_url) WHERE embed_url IS NOT NULL;
+
+CREATE TABLE posts_default PARTITION OF posts_new DEFAULT;
+
+SELECT create_daily_range_partitions(
+  'posts_new', 'posts',
+  (CURRENT_DATE - INTERVAL '32 days')::date,
+  (CURRENT_DATE + INTERVAL '2 days')::date
+);
+
+INSERT INTO posts_new
+SELECT * FROM posts
+WHERE created_at >= (CURRENT_DATE - INTERVAL '32 days');
+
+ALTER TABLE posts RENAME TO posts_legacy;
+ALTER INDEX idx_posts_author RENAME TO idx_posts_author_legacy;
+ALTER INDEX idx_posts_created RENAME TO idx_posts_created_legacy;
+ALTER INDEX idx_posts_indexed RENAME TO idx_posts_indexed_legacy;
+ALTER INDEX idx_posts_reply_root RENAME TO idx_posts_reply_root_legacy;
+ALTER INDEX idx_posts_active RENAME TO idx_posts_active_legacy;
+ALTER INDEX idx_posts_text_trgm RENAME TO idx_posts_text_trgm_legacy;
+ALTER INDEX idx_posts_topic_vector RENAME TO idx_posts_topic_vector_legacy;
+ALTER INDEX idx_posts_classification_method RENAME TO idx_posts_classification_method_legacy;
+ALTER INDEX idx_posts_embed_url RENAME TO idx_posts_embed_url_legacy;
+
+ALTER TABLE posts_new RENAME TO posts;
+ALTER INDEX idx_posts_author_new RENAME TO idx_posts_author;
+ALTER INDEX idx_posts_created_new RENAME TO idx_posts_created;
+ALTER INDEX idx_posts_indexed_new RENAME TO idx_posts_indexed;
+ALTER INDEX idx_posts_reply_root_new RENAME TO idx_posts_reply_root;
+ALTER INDEX idx_posts_active_new RENAME TO idx_posts_active;
+ALTER INDEX idx_posts_text_trgm_new RENAME TO idx_posts_text_trgm;
+ALTER INDEX idx_posts_topic_vector_new RENAME TO idx_posts_topic_vector;
+ALTER INDEX idx_posts_classification_method_new RENAME TO idx_posts_classification_method;
+ALTER INDEX idx_posts_embed_url_new RENAME TO idx_posts_embed_url;

--- a/src/db/migrations/028_partition_post_scores.sql
+++ b/src/db/migrations/028_partition_post_scores.sql
@@ -1,0 +1,112 @@
+-- Migration 028: Partition post_scores
+-- PROJ-917: native time-partitioned schema rebuild (see 026/027 for the raw
+-- events + posts halves, full rationale, and PG16 partitioning citations).
+--
+-- RETENTION WINDOW: 30 days (SCORED_DATA_RETENTION_DAYS), same window as
+-- posts (migration 027) — post_scores rows age out together with the post
+-- they score.
+--
+-- NEW COLUMN: post_scores gains a `created_at` column — a denormalized copy
+-- of the scored post's `posts.created_at` (NOT `scored_at`, which changes on
+-- every rescore). This is the partitioning key. Rationale for denormalizing
+-- rather than partitioning by `scored_at`: `scored_at` is bumped on every
+-- `ON CONFLICT ... DO UPDATE` rescore (src/scoring/pipeline.ts's storeScore,
+-- which runs every ~5 minutes per SCORING_INTERVAL_MS), and PostgreSQL moves
+-- a row to a different partition when an UPDATE changes its partition-key
+-- value — so partitioning by `scored_at` would make every incremental
+-- rescore a cross-partition row migration. Partitioning by the post's own
+-- (immutable) `created_at` instead means a row is written to its partition
+-- once and never moves.
+--
+-- WHY NOT A TRIGGER: a `BEFORE INSERT` trigger cannot populate `created_at`
+-- to drive partition routing — "`BEFORE ROW` triggers on `INSERT` cannot
+-- change which partition is the final destination for a new row." (PostgreSQL
+-- 16 docs, "5.11.2.3. Limitations",
+-- https://www.postgresql.org/docs/16/ddl-partitioning.html). `created_at`
+-- must instead be supplied directly in the INSERT's VALUES list — done via a
+-- `(SELECT created_at FROM posts WHERE uri = $1)` scalar subquery in
+-- src/scoring/pipeline.ts's storeScore(), which the query planner evaluates
+-- while constructing the row (before routing), and in
+-- scripts/backfill-score-components.ts's batch UNNEST insert via a JOIN.
+-- Both reuse the already-bound post_uri parameter, so no new bind parameter
+-- is introduced.
+--
+-- CONSTRAINT WIDENING: `unique_post_epoch UNIQUE(post_uri, epoch_id)` widens
+-- to `UNIQUE(post_uri, epoch_id, created_at)` because PG16 requires a
+-- partitioned table's unique constraints to include the full partition key
+-- (see 026/027 for the exact citation). `post_uri` determines `created_at`
+-- 1:1 in practice (a post's created_at never changes), so this widening adds
+-- no real ambiguity — it only satisfies PostgreSQL's per-partition
+-- enforcement mechanism. `storeScore()`'s `ON CONFLICT` target widens to
+-- match; `created_at` is never in the `DO UPDATE SET` list since it's
+-- immutable once written.
+--
+-- FK: post_scores.post_uri's FK to posts(uri) was already dropped in
+-- migration 027 (it has to be dropped before posts' PK changes shape).
+
+-- ============================================================
+-- post_scores
+-- ============================================================
+
+-- Constraint (and its backing index) named unique_post_epoch_new, not
+-- unique_post_epoch: the OLD post_scores table's own unique_post_epoch
+-- constraint still exists at this point (only renamed out of the way
+-- below, after this CREATE TABLE), and constraint/index names must be
+-- unique per schema — the same reason every index below is created with a
+-- _new suffix first.
+CREATE TABLE post_scores_new (
+  LIKE post_scores INCLUDING DEFAULTS,
+  created_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (id, created_at),
+  CONSTRAINT unique_post_epoch_new UNIQUE (post_uri, epoch_id, created_at)
+) PARTITION BY RANGE (created_at);
+
+CREATE INDEX idx_scores_epoch_total_new ON post_scores_new(epoch_id, total_score DESC);
+CREATE INDEX idx_scores_post_new ON post_scores_new(post_uri);
+CREATE INDEX idx_scores_scored_at_new ON post_scores_new(scored_at DESC);
+-- Mirrors migration 024's expression index (run-scoped transparency reads).
+CREATE INDEX idx_scores_epoch_run_total_new
+ON post_scores_new (epoch_id, (component_details->>'run_id'), total_score DESC)
+WHERE component_details ? 'run_id';
+
+CREATE TABLE post_scores_default PARTITION OF post_scores_new DEFAULT;
+
+SELECT create_daily_range_partitions(
+  'post_scores_new', 'post_scores',
+  (CURRENT_DATE - INTERVAL '32 days')::date,
+  (CURRENT_DATE + INTERVAL '2 days')::date
+);
+
+-- Copy step: JOIN against posts (already the new partitioned table as of
+-- migration 027) both to source the new created_at column AND to naturally
+-- scope the copy to scores whose post survived posts' own 30d-window copy —
+-- no separate age filter needed on post_scores itself.
+INSERT INTO post_scores_new (
+  id, post_uri, epoch_id,
+  recency_score, engagement_score, bridging_score, source_diversity_score, relevance_score,
+  recency_weight, engagement_weight, bridging_weight, source_diversity_weight, relevance_weight,
+  recency_weighted, engagement_weighted, bridging_weighted, source_diversity_weighted, relevance_weighted,
+  total_score, component_details, scored_at, classification_method, created_at
+)
+SELECT
+  s.id, s.post_uri, s.epoch_id,
+  s.recency_score, s.engagement_score, s.bridging_score, s.source_diversity_score, s.relevance_score,
+  s.recency_weight, s.engagement_weight, s.bridging_weight, s.source_diversity_weight, s.relevance_weight,
+  s.recency_weighted, s.engagement_weighted, s.bridging_weighted, s.source_diversity_weighted, s.relevance_weighted,
+  s.total_score, s.component_details, s.scored_at, s.classification_method, p.created_at
+FROM post_scores s
+JOIN posts p ON p.uri = s.post_uri;
+
+ALTER TABLE post_scores RENAME TO post_scores_legacy;
+ALTER INDEX idx_scores_epoch_total RENAME TO idx_scores_epoch_total_legacy;
+ALTER INDEX idx_scores_post RENAME TO idx_scores_post_legacy;
+ALTER INDEX idx_scores_scored_at RENAME TO idx_scores_scored_at_legacy;
+ALTER INDEX idx_scores_epoch_run_total RENAME TO idx_scores_epoch_run_total_legacy;
+ALTER TABLE post_scores_legacy RENAME CONSTRAINT unique_post_epoch TO unique_post_epoch_legacy;
+
+ALTER TABLE post_scores_new RENAME TO post_scores;
+ALTER INDEX idx_scores_epoch_total_new RENAME TO idx_scores_epoch_total;
+ALTER INDEX idx_scores_post_new RENAME TO idx_scores_post;
+ALTER INDEX idx_scores_scored_at_new RENAME TO idx_scores_scored_at;
+ALTER INDEX idx_scores_epoch_run_total_new RENAME TO idx_scores_epoch_run_total;
+ALTER TABLE post_scores RENAME CONSTRAINT unique_post_epoch_new TO unique_post_epoch;

--- a/src/db/migrations/029_partition_post_score_components.sql
+++ b/src/db/migrations/029_partition_post_score_components.sql
@@ -1,0 +1,66 @@
+-- Migration 029: Partition post_score_components
+-- PROJ-917: native time-partitioned schema rebuild (see 026/027/028 for the
+-- raw events, posts, and post_scores halves, full rationale, and PG16
+-- partitioning citations).
+--
+-- RETENTION WINDOW: 30 days (SCORED_DATA_RETENTION_DAYS), same window and
+-- same reasoning as post_scores (migration 028): a new `created_at` column
+-- denormalizes the scored post's `posts.created_at` (immutable) rather than
+-- reusing `scored_at` (bumped on every rescore, which would otherwise cause
+-- cross-partition row movement on every incremental scoring cycle).
+--
+-- `created_at` is populated the same way as post_scores: directly in the
+-- INSERT's VALUES/SELECT list (never via a BEFORE INSERT trigger — see
+-- migration 028's header for the PG16 citation on why triggers can't drive
+-- partition routing). src/scoring/pipeline.ts's storeScoreComponents() adds
+-- a `(SELECT created_at FROM posts WHERE uri = $N)` scalar subquery per
+-- component row, reusing the already-bound post_uri parameter for that row;
+-- scripts/backfill-score-components.ts's batch UNNEST insert instead JOINs
+-- against posts once for the whole batch.
+--
+-- PRIMARY KEY widens from (post_uri, epoch_id, component_key) to
+-- (post_uri, epoch_id, component_key, created_at) — required so the
+-- constraint includes the full partition key (PG16 docs, "5.11.2.3.
+-- Limitations", cited in 026/027). Every `ON CONFLICT (post_uri, epoch_id,
+-- component_key)` clause (src/scoring/pipeline.ts's storeScoreComponents,
+-- scripts/backfill-score-components.ts) widens to match in the same commit.
+--
+-- FK: post_score_components.post_uri's FK to posts(uri) was already dropped
+-- in migration 027.
+
+-- ============================================================
+-- post_score_components
+-- ============================================================
+
+CREATE TABLE post_score_components_new (
+  LIKE post_score_components INCLUDING DEFAULTS,
+  created_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (post_uri, epoch_id, component_key, created_at)
+) PARTITION BY RANGE (created_at);
+
+CREATE INDEX idx_psc_epoch_key_new ON post_score_components_new(epoch_id, component_key);
+
+CREATE TABLE post_score_components_default PARTITION OF post_score_components_new DEFAULT;
+
+SELECT create_daily_range_partitions(
+  'post_score_components_new', 'post_score_components',
+  (CURRENT_DATE - INTERVAL '32 days')::date,
+  (CURRENT_DATE + INTERVAL '2 days')::date
+);
+
+-- Copy step: JOIN against posts (already the new partitioned table) both to
+-- source created_at and to naturally scope the copy to components whose
+-- post survived posts' own 30d-window copy.
+INSERT INTO post_score_components_new (
+  post_uri, epoch_id, component_key, raw, weight, weighted, scored_at, created_at
+)
+SELECT
+  c.post_uri, c.epoch_id, c.component_key, c.raw, c.weight, c.weighted, c.scored_at, p.created_at
+FROM post_score_components c
+JOIN posts p ON p.uri = c.post_uri;
+
+ALTER TABLE post_score_components RENAME TO post_score_components_legacy;
+ALTER INDEX idx_psc_epoch_key RENAME TO idx_psc_epoch_key_legacy;
+
+ALTER TABLE post_score_components_new RENAME TO post_score_components;
+ALTER INDEX idx_psc_epoch_key_new RENAME TO idx_psc_epoch_key;

--- a/src/db/migrations/030_autovacuum_tuning.sql
+++ b/src/db/migrations/030_autovacuum_tuning.sql
@@ -1,0 +1,151 @@
+-- Migration 030: Per-table autovacuum tuning (PROJ-917 production hardening)
+--
+-- Lowers autovacuum_vacuum_scale_factor (the fraction of a table's rows that
+-- must be dead before autovacuum fires; PostgreSQL default is 0.2 = 20%) on
+-- the seven highest-churn tables in this system, so autovacuum runs much
+-- more often and keeps dead-tuple bloat down between runs, rather than
+-- letting 20% of a many-million-row table accumulate before it kicks in.
+-- Cited: https://www.postgresql.org/docs/16/runtime-config-autovacuum.html
+-- ("autovacuum_vacuum_scale_factor ... specifies a fraction of the table
+-- size to add to autovacuum_vacuum_threshold").
+--
+-- Values applied:
+--   - 0.02 (2%) on the six PROJ-917 partitioned tables (migrations 026-029):
+--     likes, reposts, follows, posts, post_scores, post_score_components.
+--   - 0.01 (1%, more aggressive) on post_engagement specifically: it is NOT
+--     partitioned (still a single ever-growing table) and therefore can't
+--     fall back on partition-manager.ts's instant DETACH+DROP retention the
+--     way the six tables above can — autovacuum is the only bloat control
+--     it has, so it gets the tighter number.
+--
+-- IMPORTANT CAVEAT (verified against the live PostgreSQL 16 docs, not
+-- assumed): storage parameters including autovacuum_vacuum_scale_factor
+-- CANNOT be set directly on a partitioned (parent) table — "Specifying
+-- these parameters for partitioned tables is not supported, but you may
+-- specify them for individual leaf partitions." (CREATE TABLE docs,
+-- "Storage Parameters", https://www.postgresql.org/docs/16/sql-createtable.html).
+-- A bare `ALTER TABLE posts SET (autovacuum_vacuum_scale_factor = 0.02)`
+-- would therefore fail outright against posts/post_scores/etc. (they are
+-- partitioned parents). This migration instead:
+--
+--   1. Updates the shared create_daily_range_partitions() helper (defined
+--      in migration 026, reused by every PROJ-917 partitioning migration
+--      AND by src/maintenance/partition-manager.ts's ongoing create-ahead
+--      job) so every NEWLY created daily leaf partition, from now on,
+--      is created WITH (autovacuum_vacuum_scale_factor = 0.02) directly —
+--      leaf partitions DO support storage parameters (same doc citation
+--      above: "... but you may specify them for individual leaf
+--      partitions").
+--   2. Walks pg_inherits for each of the six parent tables and applies the
+--      same setting to every EXISTING leaf partition (including each
+--      table's DEFAULT partition), since those were created before this
+--      migration existed and won't pick up the function change
+--      retroactively.
+--
+-- post_engagement is a plain (non-partitioned) table, so it takes the
+-- ALTER TABLE directly with no such restriction.
+--
+-- Rollback, if needed:
+--   ALTER TABLE post_engagement RESET (autovacuum_vacuum_scale_factor);
+--   -- plus a DO block mirroring the one below, calling RESET instead of
+--   -- SET, for each existing leaf partition of the six tables; and
+--   -- re-running CREATE OR REPLACE FUNCTION create_daily_range_partitions
+--   -- with the WITH clause removed (see migration 026 for the prior body).
+
+-- ── 1. Future leaf partitions: bake the setting into the creation helper ──
+
+CREATE OR REPLACE FUNCTION create_daily_range_partitions(
+  parent_table text,
+  partition_prefix text,
+  start_date date,
+  end_date date
+) RETURNS void AS $$
+DECLARE
+  d date := start_date;
+  partition_name text;
+  default_name text := format('%s_default', partition_prefix);
+BEGIN
+  -- Bound every lock this function waits on (the default-partition EXCLUSIVE
+  -- lock and the ATTACH's ACCESS EXCLUSIVE on the parent). If a concurrent
+  -- long-running writer holds a conflicting lock, fail fast with a lock_timeout
+  -- error instead of hanging indefinitely — partition-manager catches it per
+  -- table and retries on the next run rather than silently stalling partition
+  -- creation. Scoped to this transaction; reverts on commit.
+  SET LOCAL lock_timeout = '5s';
+
+  IF end_date < start_date THEN
+    RETURN;
+  END IF;
+
+  WHILE d <= end_date LOOP
+    partition_name := format('%s_p%s', partition_prefix, to_char(d, 'YYYYMMDD'));
+
+    -- Skip if it already exists (idempotent, like the prior CREATE ... IF NOT
+    -- EXISTS). Otherwise create the leaf as a STANDALONE table, drain any rows
+    -- the DEFAULT partition already holds for this day, then ATTACH it.
+    --
+    -- Why not a plain `CREATE TABLE ... PARTITION OF`: ATTACH (and the implicit
+    -- attach that PARTITION OF performs) fails if the default partition
+    -- contains rows that fall in the new partition's range — which is exactly
+    -- what happens when a partition-manager create-ahead run is missed and live
+    -- inserts fall through to the default. Draining those rows into the new
+    -- leaf first makes the attach valid. On a fresh table (initial migration)
+    -- the default is empty, so the drain is a no-op and this reduces to
+    -- create + attach.
+    IF to_regclass(partition_name) IS NULL THEN
+      EXECUTE format(
+        'CREATE TABLE %I (LIKE %I INCLUDING DEFAULTS) WITH (autovacuum_vacuum_scale_factor = 0.02)',
+        partition_name, parent_table
+      );
+
+      IF to_regclass(default_name) IS NOT NULL THEN
+        -- Block concurrent inserts into the default partition for the rest of
+        -- this transaction, so no new row can land in [d, d+1) between the drain
+        -- below and the ATTACH — which would otherwise make the attach abort on
+        -- the missed-run path. EXCLUSIVE mode conflicts with the ROW EXCLUSIVE
+        -- lock INSERT takes (blocks writes) while still allowing reads; it
+        -- releases when the surrounding transaction (the migration, or
+        -- partition-manager's SELECT create_daily_range_partitions(...)) commits.
+        EXECUTE format('LOCK TABLE %I IN EXCLUSIVE MODE', default_name);
+        EXECUTE format(
+          'WITH moved AS (DELETE FROM %I WHERE created_at >= %L AND created_at < %L RETURNING *) '
+          'INSERT INTO %I SELECT * FROM moved',
+          default_name, d::text, (d + 1)::text, partition_name
+        );
+      END IF;
+
+      EXECUTE format(
+        'ALTER TABLE %I ATTACH PARTITION %I FOR VALUES FROM (%L) TO (%L)',
+        parent_table, partition_name, d::text, (d + 1)::text
+      );
+    END IF;
+
+    d := d + 1;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── 2. Existing leaf partitions: apply the same setting retroactively ──
+
+DO $$
+DECLARE
+  parent_name text;
+  leaf record;
+BEGIN
+  FOREACH parent_name IN ARRAY ARRAY['likes', 'reposts', 'follows', 'posts', 'post_scores', 'post_score_components']
+  LOOP
+    FOR leaf IN
+      SELECT c.relname AS partition_name
+      FROM pg_inherits i
+      JOIN pg_class c ON c.oid = i.inhrelid
+      WHERE i.inhparent = parent_name::regclass
+    LOOP
+      EXECUTE format('ALTER TABLE %I SET (autovacuum_vacuum_scale_factor = 0.02)', leaf.partition_name);
+    END LOOP;
+  END LOOP;
+END;
+$$;
+
+-- ── 3. post_engagement: plain table, more aggressive factor ──
+
+ALTER TABLE post_engagement SET (autovacuum_vacuum_scale_factor = 0.01);

--- a/src/harness/baseline-comparison.ts
+++ b/src/harness/baseline-comparison.ts
@@ -230,9 +230,11 @@ async function seedCorpus(db: QueryableDb, population: Population): Promise<void
   }));
 
   await insertBatched(db, population.posts, (batch) => ({
+    // PROJ-917: posts' PK widened to (uri, created_at) — partitioned tables
+    // require the partition key in every unique constraint.
     text: `INSERT INTO posts (uri, cid, author_did, text, created_at, has_media, embed_url, topic_vector)
            VALUES ${valuesClause(batch.length, 8)}
-           ON CONFLICT (uri) DO NOTHING`,
+           ON CONFLICT (uri, created_at) DO NOTHING`,
     params: batch.flatMap((post) => [
       post.uri,
       post.cid,

--- a/src/harness/simulation.ts
+++ b/src/harness/simulation.ts
@@ -657,9 +657,11 @@ export class Simulation {
     );
 
     await insertBatched(db, population.posts, (batch, offset) => ({
+      // PROJ-917: posts' PK widened to (uri, created_at) — partitioned
+      // tables require the partition key in every unique constraint.
       text: `INSERT INTO posts (uri, cid, author_did, text, created_at, has_media, embed_url, topic_vector)
              VALUES ${valuesClause(batch.length, 8, offset)}
-             ON CONFLICT (uri) DO NOTHING`,
+             ON CONFLICT (uri, created_at) DO NOTHING`,
       params: batch.flatMap((post) => [
         post.uri,
         post.cid,

--- a/src/ingestion/handlers/follow-handler.ts
+++ b/src/ingestion/handlers/follow-handler.ts
@@ -8,6 +8,7 @@
 import { db } from '../../db/client.js';
 import { logger } from '../../lib/logger.js';
 import type { IngestionEventOutcome } from '../outcomes.js';
+import { normalizeCreatedAt } from '../normalize-timestamp.js';
 
 interface FollowRecord {
   subject?: string; // The DID being followed
@@ -27,14 +28,16 @@ export async function handleFollow(
     return 'follow-missing-subject';
   }
 
-  const createdAt = followRecord.createdAt ?? new Date().toISOString();
+  const createdAt = normalizeCreatedAt(followRecord.createdAt, uri);
 
   try {
     // UPSERT follow relationship
     const result = await db.query(
       `INSERT INTO follows (uri, author_did, subject_did, created_at)
        VALUES ($1, $2, $3, $4)
-       ON CONFLICT (uri) DO NOTHING
+       -- PROJ-917: follows' PK widened to (uri, created_at) — partitioned
+       -- tables require the partition key in every unique constraint.
+       ON CONFLICT (uri, created_at) DO NOTHING
        RETURNING uri`,
       [uri, authorDid, subjectDid, createdAt]
     );

--- a/src/ingestion/handlers/like-handler.ts
+++ b/src/ingestion/handlers/like-handler.ts
@@ -8,6 +8,7 @@
 import { db } from '../../db/client.js';
 import { logger } from '../../lib/logger.js';
 import type { IngestionEventOutcome } from '../outcomes.js';
+import { normalizeCreatedAt } from '../normalize-timestamp.js';
 
 interface LikeRecord {
   subject?: {
@@ -35,7 +36,7 @@ export async function handleLike(
     return 'like-missing-subject';
   }
 
-  const createdAt = likeRecord.createdAt ?? new Date().toISOString();
+  const createdAt = normalizeCreatedAt(likeRecord.createdAt, uri);
 
   try {
     // Insert like only if the referenced post exists in our system.
@@ -48,7 +49,9 @@ export async function handleLike(
          INSERT INTO likes (uri, author_did, subject_uri, created_at)
          SELECT $1, $2, $3, $4
          FROM subject
-         ON CONFLICT (uri) DO NOTHING
+         -- PROJ-917: likes' PK widened to (uri, created_at) — partitioned
+         -- tables require the partition key in every unique constraint.
+         ON CONFLICT (uri, created_at) DO NOTHING
          RETURNING uri
        )
        SELECT

--- a/src/ingestion/handlers/post-handler.ts
+++ b/src/ingestion/handlers/post-handler.ts
@@ -15,6 +15,7 @@ import { checkGovernanceGate, isGovernanceGateReady } from '../governance-gate.j
 import { classifyPostByEmbedding } from '../embedding-gate.js';
 import { isEmbedderReady } from '../../scoring/topics/embedder.js';
 import type { IngestionEventOutcome } from '../outcomes.js';
+import { normalizeCreatedAt } from '../normalize-timestamp.js';
 
 /** AT Protocol content labels that indicate NSFW content. */
 const NSFW_LABELS = new Set(['porn', 'sexual', 'graphic-media', 'nudity']);
@@ -64,7 +65,7 @@ export async function handlePost(
 
   const text = postRecord.text ?? null;
   const langs = postRecord.langs ?? [];
-  const createdAt = postRecord.createdAt ?? new Date().toISOString();
+  const createdAt = normalizeCreatedAt(postRecord.createdAt, uri);
 
   // Extract reply info
   const replyRoot = postRecord.reply?.root?.uri ?? null;
@@ -192,7 +193,9 @@ export async function handlePost(
     const postResult = await db.query(
       `INSERT INTO posts (uri, cid, author_did, text, reply_root, reply_parent, langs, has_media, created_at, topic_vector, embed_url, classification_method)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-       ON CONFLICT (uri) DO NOTHING
+       -- PROJ-917: posts' PK widened to (uri, created_at) — partitioned
+       -- tables require the partition key in every unique constraint.
+       ON CONFLICT (uri, created_at) DO NOTHING
        RETURNING uri`,
       [uri, cid, authorDid, text, replyRoot, replyParent, langs, hasMedia, createdAt, JSON.stringify(topicVector), embedUrl, classificationMethod]
     );

--- a/src/ingestion/handlers/repost-handler.ts
+++ b/src/ingestion/handlers/repost-handler.ts
@@ -8,6 +8,7 @@
 import { db } from '../../db/client.js';
 import { logger } from '../../lib/logger.js';
 import type { IngestionEventOutcome } from '../outcomes.js';
+import { normalizeCreatedAt } from '../normalize-timestamp.js';
 
 interface RepostRecord {
   subject?: {
@@ -35,7 +36,7 @@ export async function handleRepost(
     return 'repost-missing-subject';
   }
 
-  const createdAt = repostRecord.createdAt ?? new Date().toISOString();
+  const createdAt = normalizeCreatedAt(repostRecord.createdAt, uri);
 
   try {
     // Insert repost only if the referenced post exists in our system.
@@ -48,7 +49,9 @@ export async function handleRepost(
          INSERT INTO reposts (uri, author_did, subject_uri, created_at)
          SELECT $1, $2, $3, $4
          FROM subject
-         ON CONFLICT (uri) DO NOTHING
+         -- PROJ-917: reposts' PK widened to (uri, created_at) — partitioned
+         -- tables require the partition key in every unique constraint.
+         ON CONFLICT (uri, created_at) DO NOTHING
          RETURNING uri
        )
        SELECT

--- a/src/ingestion/normalize-timestamp.ts
+++ b/src/ingestion/normalize-timestamp.ts
@@ -1,0 +1,93 @@
+/**
+ * Normalize a client-supplied AT Protocol `createdAt` into a trustworthy,
+ * STABLE timestamp for storage.
+ *
+ * Two constraints, both load-bearing after the PROJ-917 partitioning rebuild:
+ *
+ *   1. **Stability / dedup.** likes/reposts/follows/posts are now keyed on
+ *      `(uri, created_at)` and writers use `ON CONFLICT (uri, created_at)`.
+ *      A Jetstream redelivery of the *same* record must therefore produce the
+ *      *same* `created_at`, or the conflict misses and a duplicate row is
+ *      inserted (double-counting engagement). So the returned value must be a
+ *      pure function of the record — never `Date.now()`, which differs per
+ *      delivery.
+ *   2. **Sane partition routing / ranking.** Records carry a client-set
+ *      `createdAt` that cannot be trusted (prod has values dated 2030/2038/
+ *      2056). A far-future value would land in the DEFAULT partition and never
+ *      age out (retention only drops `created_at < cutoff`), and would max the
+ *      recency score, letting a client pin a post to the top of the feed.
+ *
+ * Resolution order (all deterministic given the record):
+ *   a. The client `createdAt`, iff present, parseable, and not in the future —
+ *      the normal case, stable across redelivery.
+ *   b. Otherwise the timestamp encoded in the record key (rkey): AT Protocol
+ *      rkeys are TIDs, which embed the record's real creation time. This is
+ *      immutable per-URI, so it satisfies both constraints — and it recovers a
+ *      real time for future-dated / missing / garbage `createdAt` records.
+ *   c. Last resort (rkey is not a TID and `createdAt` is unusable — very rare):
+ *      the Unix epoch, a fixed deterministic sentinel that ages out on the next
+ *      retention pass rather than churning like `Date.now()`.
+ */
+
+// crockford-ish base32-sortable alphabet used by AT Protocol TIDs.
+const TID_ALPHABET = '234567abcdefghijklmnopqrstuvwxyz';
+
+/** Decode an AT Protocol TID rkey to epoch milliseconds, or null if it is not a
+ *  well-formed 13-char TID. A TID is a 64-bit int `(micros << 10) | clockid`. */
+function tidToMillis(rkey: string): number | null {
+  if (rkey.length !== 13) return null;
+  let value = 0n;
+  for (const ch of rkey) {
+    const idx = TID_ALPHABET.indexOf(ch);
+    if (idx === -1) return null;
+    value = value * 32n + BigInt(idx);
+  }
+  const micros = value >> 10n;
+  const millis = Number(micros / 1000n);
+  if (!Number.isFinite(millis) || millis <= 0) return null;
+  return millis;
+}
+
+/** The record key is the final path segment of an `at://did/collection/rkey` URI. */
+function rkeyFromUri(uri: string | undefined | null): string | null {
+  if (!uri) return null;
+  const idx = uri.lastIndexOf('/');
+  if (idx === -1 || idx === uri.length - 1) return null;
+  return uri.slice(idx + 1);
+}
+
+/** Whether a raw timestamp resolves to the same instant regardless of the
+ *  parsing host's timezone. `Date.parse` reads a date-only string as UTC, but a
+ *  datetime WITHOUT an explicit zone as *local* time — so a zone-less datetime
+ *  would normalize the same record to different instants across workers and
+ *  break `ON CONFLICT (uri, created_at)` dedup. Trust only date-only values and
+ *  datetimes that carry `Z` or an explicit ±HH[:MM] offset. */
+function isDeterministicTimestamp(raw: string): boolean {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return true;
+  return /[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$/.test(raw);
+}
+
+export function normalizeCreatedAt(
+  raw: string | undefined | null,
+  uri: string | undefined | null,
+  nowMs: number = Date.now()
+): string {
+  // (a) trust a present, parseable, non-future client timestamp — but only if
+  // it is timezone-unambiguous (see isDeterministicTimestamp); a zone-less
+  // datetime parses as local time and would break cross-worker dedup.
+  if (raw && isDeterministicTimestamp(raw)) {
+    const parsed = Date.parse(raw);
+    if (!Number.isNaN(parsed) && parsed <= nowMs) {
+      return new Date(parsed).toISOString();
+    }
+  }
+
+  // (b) fall back to the record key's embedded creation time (stable per-URI).
+  const tidMillis = tidToMillis(rkeyFromUri(uri) ?? '');
+  if (tidMillis !== null && tidMillis <= nowMs) {
+    return new Date(tidMillis).toISOString();
+  }
+
+  // (c) deterministic sentinel — stable, and old enough to age out immediately.
+  return new Date(0).toISOString();
+}

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -10,7 +10,7 @@
  * Returns structured health status for monitoring and k8s probes.
  */
 
-import { db } from '../db/client.js';
+import { db, healthDb } from '../db/client.js';
 import { redis } from '../db/redis.js';
 import { logger } from './logger.js';
 import type { DiskStatus } from '../maintenance/disk-monitor.js';
@@ -98,6 +98,12 @@ export function registerDiskHealth(fn: () => DiskStatus | null): void {
 
 /**
  * Check PostgreSQL health with timeout.
+ *
+ * Uses the dedicated `healthDb` pool (PROJ-917), not the main `db` pool —
+ * see src/db/client.ts's healthDb comment for the 2026-07-06 incident this
+ * fixes (main-pool exhaustion starved this check, which then failed
+ * readiness and got the service SIGABRT-killed by the systemd watchdog
+ * that gates its heartbeat on isReady() -> this function).
  */
 async function checkDatabase(): Promise<ComponentHealth> {
   const start = Date.now();
@@ -107,7 +113,7 @@ async function checkDatabase(): Promise<ComponentHealth> {
       setTimeout(() => reject(new Error('Database health check timed out')), HEALTH_CHECK_TIMEOUT);
     });
 
-    const queryPromise = db.query('SELECT 1');
+    const queryPromise = healthDb.query('SELECT 1');
     await Promise.race([queryPromise, timeoutPromise]);
 
     return {

--- a/src/lib/shutdown.ts
+++ b/src/lib/shutdown.ts
@@ -2,12 +2,12 @@
  * Graceful Shutdown Module
  *
  * Handles clean shutdown of all system components with a timeout.
- * Order: Watchdog → HTTP server → Scoring → Jetstream → Epoch Scheduler → Maintenance Worker Supervisor → Cleanup → Interaction Logger → Interaction Aggregator → Database → Redis
+ * Order: Watchdog → HTTP server → Scoring → Jetstream → Epoch Scheduler → Maintenance Worker Supervisor → Cleanup → Interaction Logger → Interaction Aggregator → Database (main + health-check pools) → Redis
  */
 
 import type { FastifyInstance } from 'fastify';
 import { logger } from './logger.js';
-import { db } from '../db/client.js';
+import { db, healthDb } from '../db/client.js';
 import { redis } from '../db/redis.js';
 
 // Maximum time to wait for graceful shutdown before forcing exit
@@ -101,10 +101,14 @@ export async function gracefulShutdown(deps: ShutdownDependencies): Promise<void
       }
     }
 
-    // 4. Close database pool
+    // 4. Close database pools (main + the dedicated health-check pool)
     logger.info('Closing PostgreSQL connection pool...');
     await db.end();
     logger.info('PostgreSQL closed');
+
+    logger.info('Closing health-check PostgreSQL pool...');
+    await healthDb.end();
+    logger.info('Health-check PostgreSQL pool closed');
 
     // 5. Close Redis connection
     logger.info('Closing Redis connection...');

--- a/src/maintenance/cleanup.ts
+++ b/src/maintenance/cleanup.ts
@@ -7,13 +7,25 @@
  * What gets deleted:
  * - Posts with indexed_at > 72 hours ago that have no post_scores rows
  *   and are not in the Redis feed:current sorted set
- * - Orphaned likes/reposts whose subject_uri no longer exists in posts
- *   (these have no FK, so CASCADE doesn't help)
+ * - Orphaned likes/reposts/post_engagement rows whose post no longer
+ *   exists in posts (none of these have an FK to posts, so CASCADE never
+ *   helps — see below)
  * - Likes/reposts older than 7 days for posts that are not scored
  * - Follows older than 7 days
  *
- * post_engagement and post_scores have ON DELETE CASCADE from posts,
- * so they are cleaned up automatically.
+ * PROJ-917: posts/post_scores/post_score_components are now declaratively
+ * RANGE-partitioned by created_at (migrations 026-029), and bulk 30-day-old
+ * retention is handled by src/maintenance/partition-manager.ts via instant
+ * partition DROP, not by this hourly job. That rebuild also DROPPED
+ * post_engagement's `ON DELETE CASCADE` FK to posts — a partitioned table's
+ * unique constraints must include the full partition key (PG16), so
+ * `posts(uri)` alone can no longer back an FK once posts' PK becomes
+ * (uri, created_at). So post_engagement joins likes/reposts in never having
+ * CASCADE cleanup: batchDeleteOrphanedEngagement() below mirrors the
+ * existing orphaned-likes/orphaned-reposts pattern (partition-manager.ts
+ * separately cascades post_engagement for the bulk 30-day-partition-drop
+ * case; this function is the finer-grained sweep for the 72h-unscored-post
+ * path in batchDeleteOldPosts above).
  *
  * VACUUM runs after large deletes to reclaim disk space.
  */
@@ -26,6 +38,7 @@ export interface CleanupResult {
   postsDeleted: number;
   orphanedLikesDeleted: number;
   orphanedRepostsDeleted: number;
+  orphanedEngagementDeleted: number;
   staleLikesDeleted: number;
   staleRepostsDeleted: number;
   oldFollowsDeleted: number;
@@ -176,6 +189,15 @@ async function runCleanupInternal(): Promise<CleanupResult> {
     logger.error({ err }, 'Failed to delete orphaned reposts');
   }
 
+  // PROJ-917: post_engagement lost its ON DELETE CASCADE from posts (see
+  // this file's header comment) — sweep the same way as orphaned likes/reposts.
+  let orphanedEngagementDeleted = 0;
+  try {
+    orphanedEngagementDeleted = await batchDeleteOrphanedEngagement();
+  } catch (err) {
+    logger.error({ err }, 'Failed to delete orphaned post_engagement rows');
+  }
+
   // 4. Delete old likes/reposts not associated with scored posts, and old follows.
   let staleLikesDeleted = 0;
   try {
@@ -202,6 +224,7 @@ async function runCleanupInternal(): Promise<CleanupResult> {
     postsDeleted +
     orphanedLikesDeleted +
     orphanedRepostsDeleted +
+    orphanedEngagementDeleted +
     staleLikesDeleted +
     staleRepostsDeleted +
     oldFollowsDeleted;
@@ -216,6 +239,7 @@ async function runCleanupInternal(): Promise<CleanupResult> {
     postsDeleted,
     orphanedLikesDeleted,
     orphanedRepostsDeleted,
+    orphanedEngagementDeleted,
     staleLikesDeleted,
     staleRepostsDeleted,
     oldFollowsDeleted,
@@ -358,6 +382,55 @@ async function batchDeleteOrphanedReposts(): Promise<number> {
   return totalDeleted;
 }
 
+/**
+ * PROJ-917: post_engagement.post_uri lost its `ON DELETE CASCADE` FK to
+ * posts when posts was partitioned (migration 027 — a partitioned table's
+ * unique constraints must include the full partition key, so `posts(uri)`
+ * alone can no longer back an FK). This mirrors batchDeleteOrphanedLikes/
+ * batchDeleteOrphanedReposts above (which never had CASCADE either, for the
+ * same "no FK" reason) rather than an age filter: post_engagement has no
+ * created_at column of its own, and a row is only ever orphaned by its post
+ * being hard-deleted, not by aging — so "post no longer exists" is the
+ * complete condition.
+ */
+async function batchDeleteOrphanedEngagement(): Promise<number> {
+  let totalDeleted = 0;
+  const client = await db.connect();
+
+  try {
+    await client.query("SET statement_timeout = '120s'");
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (isShuttingDown) break;
+
+      const result = await client.query(
+        `DELETE FROM post_engagement
+         WHERE post_uri IN (
+           SELECT pe.post_uri FROM post_engagement pe
+           WHERE NOT EXISTS (SELECT 1 FROM posts p WHERE p.uri = pe.post_uri)
+           LIMIT $1
+         )`,
+        [BATCH_SIZE]
+      );
+
+      const deleted = result.rowCount ?? 0;
+      totalDeleted += deleted;
+
+      if (deleted > 0) {
+        logger.debug({ deleted, totalDeleted }, 'Cleanup batch: orphaned post_engagement deleted');
+      }
+
+      if (deleted < BATCH_SIZE) break;
+    }
+  } finally {
+    await client.query("SET statement_timeout = '10s'").catch(() => {});
+    client.release();
+  }
+
+  return totalDeleted;
+}
+
 async function batchDeleteStaleLikes(): Promise<number> {
   let totalDeleted = 0;
   const client = await db.connect();
@@ -480,11 +553,15 @@ async function runVacuum(): Promise<boolean> {
     client = await db.connect();
     await client.query("SET statement_timeout = '300s'");
 
-    logger.info('Running VACUUM ANALYZE on posts, likes, reposts, follows');
+    logger.info('Running VACUUM ANALYZE on posts, likes, reposts, follows, post_engagement');
     await client.query('VACUUM (ANALYZE) posts');
     await client.query('VACUUM (ANALYZE) likes');
     await client.query('VACUUM (ANALYZE) reposts');
     await client.query('VACUUM (ANALYZE) follows');
+    // PROJ-917: post_engagement now receives real deletes from
+    // batchDeleteOrphanedEngagement() above (no more FK CASCADE), so it
+    // needs the same VACUUM treatment as the other actively-pruned tables.
+    await client.query('VACUUM (ANALYZE) post_engagement');
 
     logger.info('VACUUM complete');
     return true;

--- a/src/maintenance/disk-monitor.ts
+++ b/src/maintenance/disk-monitor.ts
@@ -6,7 +6,11 @@
  *
  * - WARNING (80%):  Log warning, store alert in system_status
  * - CRITICAL (90%): Trigger immediate cleanup, truncate journald
- * - EMERGENCY (95%): Run VACUUM FULL, CHECKPOINT to reclaim space
+ * - EMERGENCY (95%): Free-space-safe recovery — force an immediate
+ *   partition-manager drop pass, cleanup's orphan sweeps, journald
+ *   truncation, a WAL checkpoint, and a plain VACUUM (never FULL) — plus
+ *   an escalating system_status alert. See runEmergencyDiskFreeingActions()
+ *   for why VACUUM FULL was removed (PROJ-917).
  *
  * Runs every 5 minutes. Uses fs.statfs() (no shell exec).
  * Follows the same start/stop/isRunning pattern as cleanup.ts.
@@ -18,6 +22,7 @@ import { db } from '../db/client.js';
 import { logger } from '../lib/logger.js';
 import { config } from '../config.js';
 import { triggerManualCleanup } from './cleanup.js';
+import { runPartitionMaintenanceNow } from './partition-manager.js';
 
 const CHECK_INTERVAL_MS = 5 * 60_000; // 5 minutes
 
@@ -35,7 +40,7 @@ let isShuttingDown = false;
 let isChecking = false;
 let lastStatus: DiskStatus | null = null;
 let consecutiveCriticalChecks = 0;
-let isVacuumRunning = false;
+let isEmergencyActionRunning = false;
 
 /**
  * Get current disk status using fs.statfs (no shell needed).
@@ -92,65 +97,183 @@ async function truncateJournald(): Promise<void> {
   });
 }
 
+/** Tables targeted by the emergency plain-VACUUM pass (same targets the old
+ *  VACUUM FULL used to hit — follows/reposts/likes are the highest-churn raw
+ *  event tables, posts is the largest content table). All four are now
+ *  RANGE-partitioned (migrations 026-029); running VACUUM on a partitioned
+ *  parent recurses into every leaf partition (PostgreSQL 16 docs,
+ *  "VACUUM Parameters": "If a partitioned table is specified, all its leaf
+ *  partitions will be vacuumed."), so this still covers the same data. */
+const EMERGENCY_VACUUM_TABLES = ['follows', 'reposts', 'likes', 'posts'];
+
 /**
- * Run VACUUM FULL on tables to return space to the OS.
- * This takes ACCESS EXCLUSIVE locks — only runs at emergency threshold.
- * Guarded to prevent concurrent runs with cleanup.ts VACUUM.
+ * Run a plain VACUUM (NEVER FULL) on the emergency-tier tables.
+ *
+ * PROJ-917 postmortem: the previous emergency action ran `VACUUM FULL`,
+ * which rewrites the entire table into a new file and therefore needs
+ * roughly as much free disk space as the table itself to complete. On a
+ * disk that is already at 95%+, that space is exactly what's missing — in
+ * production this failed with ENOSPC 3 times in a row against the 21GB
+ * `likes` table, and each attempt held an ACCESS EXCLUSIVE lock on the
+ * table for its full (failed) duration, starving the connection pool of
+ * every other query that touched `likes`.
+ *
+ * Plain VACUUM only needs a SHARE UPDATE EXCLUSIVE lock (does not block
+ * reads/writes) and, critically, can still return space to the OS: when it
+ * finds entirely-empty pages at the physical end of a table/partition it
+ * truncates the file (unless `vacuum_truncate` is disabled), which is
+ * exactly the space this monitor is trying to free. It just can't compact
+ * fragmented pages in the middle of the table the way VACUUM FULL can —
+ * that's an acceptable trade during an active emergency; a full compaction
+ * can be scheduled later, off the emergency path, during a maintenance
+ * window when disk headroom is no longer contested.
  */
-async function runEmergencyVacuumFull(): Promise<void> {
-  if (isVacuumRunning) {
-    logger.warn('Emergency VACUUM FULL skipped — already running');
-    return;
-  }
-  isVacuumRunning = true;
-  const tables = ['follows', 'reposts', 'likes', 'posts'];
+async function runEmergencyPlainVacuum(): Promise<void> {
   let client;
 
   try {
     client = await db.connect();
     await client.query("SET statement_timeout = '600s'");
 
-    for (const table of tables) {
-      const before = await client.query(
-        `SELECT pg_total_relation_size($1) as size_bytes`,
-        [table]
-      );
-      const sizeMb = Math.round(Number(before.rows[0].size_bytes) / (1024 * 1024));
-      logger.info({ table, size_mb: sizeMb }, 'Running VACUUM FULL');
+    for (const table of EMERGENCY_VACUUM_TABLES) {
+      // Per-table try/catch: a failure on one table (lock contention, a
+      // canceled statement, etc.) must not abort the whole emergency pass —
+      // the remaining tables still need their space reclaimed. Without this,
+      // a single failing VACUUM would silently skip every table after it.
+      try {
+        const before = await client.query(
+          `SELECT pg_total_relation_size($1) as size_bytes`,
+          [table]
+        );
+        const sizeMb = Math.round(Number(before.rows[0].size_bytes) / (1024 * 1024));
+        logger.info({ table, size_mb: sizeMb }, 'Running emergency VACUUM (not FULL)');
 
-      await client.query(`VACUUM FULL ${table}`);
+        // NEVER VACUUM FULL here — see function header. Table names come from
+        // the hardcoded EMERGENCY_VACUUM_TABLES list above, not user input.
+        await client.query(`VACUUM ${table}`);
 
-      const after = await client.query(
-        `SELECT pg_total_relation_size($1) as size_bytes`,
-        [table]
-      );
-      const afterMb = Math.round(Number(after.rows[0].size_bytes) / (1024 * 1024));
-      logger.info(
-        { table, before_mb: sizeMb, after_mb: afterMb, freed_mb: sizeMb - afterMb },
-        'VACUUM FULL complete'
-      );
+        const after = await client.query(
+          `SELECT pg_total_relation_size($1) as size_bytes`,
+          [table]
+        );
+        const afterMb = Math.round(Number(after.rows[0].size_bytes) / (1024 * 1024));
+        logger.info(
+          { table, before_mb: sizeMb, after_mb: afterMb, freed_mb: sizeMb - afterMb },
+          'Emergency VACUUM complete'
+        );
+      } catch (err) {
+        logger.error({ err, table }, 'Emergency VACUUM failed for table; continuing with remaining tables');
+      }
     }
-
-    // Run CHECKPOINT to flush WAL
-    await client.query('CHECKPOINT');
-    logger.info('CHECKPOINT complete');
-
-    // Store result
-    await client.query(
-      `INSERT INTO system_status (key, value, updated_at)
-       VALUES ('last_emergency_vacuum', $1::jsonb, NOW())
-       ON CONFLICT (key) DO UPDATE SET value = $1::jsonb, updated_at = NOW()`,
-      [JSON.stringify({ timestamp: new Date().toISOString(), tables })]
-    );
   } catch (err) {
-    logger.error({ err }, 'Emergency VACUUM FULL failed');
+    logger.error({ err }, 'Emergency VACUUM failed');
   } finally {
-    isVacuumRunning = false;
     if (client) {
       await client.query("SET statement_timeout = '10s'").catch(() => {});
       client.release();
     }
   }
+}
+
+/**
+ * Free-space-safe emergency recovery, run at the 95% (emergency) threshold.
+ * Every action here is safe to run while the disk is nearly full — none of
+ * them require the 2x-table-size scratch space that VACUUM FULL needed.
+ * Guarded against overlapping runs (a 5-minute check interval could
+ * otherwise start a second pass before a slow first pass finishes).
+ */
+// Exported (only) so tests can exercise the isEmergencyActionRunning guard
+// directly — runDiskCheck()'s own isChecking flag already fully serializes
+// this on the normal scheduled path, so there is no way to reach a second,
+// overlapping invocation through startDiskMonitor()/stopDiskMonitor() alone.
+export async function runEmergencyDiskFreeingActions(): Promise<void> {
+  if (isEmergencyActionRunning) {
+    logger.warn('Emergency disk-freeing actions skipped — already running');
+    return;
+  }
+  isEmergencyActionRunning = true;
+
+  try {
+    // 1. Partition-manager's drop pass is normally once-per-calendar-day;
+    // force it now so any partition that has aged past retention is
+    // DETACHed + DROPped immediately (metadata-only, instant reclaim) —
+    // then cleanup's guarded orphan/stale-row sweeps.
+    try {
+      await runPartitionMaintenanceNow();
+    } catch (err) {
+      logger.error({ err }, 'Emergency partition-manager drop failed');
+    }
+
+    try {
+      await triggerManualCleanup();
+    } catch (err) {
+      logger.error({ err }, 'Emergency cleanup sweep failed');
+    }
+
+    // 2. Reclaim journald disk usage.
+    await truncateJournald();
+
+    // 3. CHECKPOINT + WAL-size check (flushes WAL if the on-disk WAL
+    // directory has grown past checkWalSize()'s own threshold).
+    await checkWalSize();
+
+    // 4. Plain VACUUM (never FULL) — see runEmergencyPlainVacuum() header.
+    await runEmergencyPlainVacuum();
+  } finally {
+    isEmergencyActionRunning = false;
+  }
+}
+
+/**
+ * Store an escalating alert in system_status and log at error level.
+ * Severity escalates with consecutive emergency-level checks so an operator
+ * scanning logs/vitals can tell "just tipped over" apart from "still stuck
+ * at 95%+ after repeated recovery passes".
+ */
+async function recordEmergencyAlert(status: DiskStatus, consecutiveChecks: number): Promise<void> {
+  const severity = consecutiveChecks >= 3 ? 'critical' : consecutiveChecks >= 2 ? 'high' : 'elevated';
+  const alert = {
+    severity,
+    used_percent: status.used_percent,
+    available_gb: status.available_gb,
+    consecutive_checks: consecutiveChecks,
+    detected_at: new Date().toISOString(),
+  };
+
+  logger.error(
+    alert,
+    `EMERGENCY disk alert (severity=${severity}): disk-freeing actions ran, usage still at ${status.used_percent}%`
+  );
+
+  try {
+    await db.query(
+      `INSERT INTO system_status (key, value, updated_at)
+       VALUES ('disk_emergency_alert', $1::jsonb, NOW())
+       ON CONFLICT (key) DO UPDATE SET value = $1::jsonb, updated_at = NOW()`,
+      [JSON.stringify(alert)]
+    );
+  } catch (err) {
+    logger.warn({ err }, 'Failed to store disk emergency alert in system_status');
+  }
+}
+
+/**
+ * Clear the emergency alert once disk usage drops back out of the
+ * emergency tier, so vitals/dashboards don't keep showing a stale critical
+ * banner after the incident has resolved.
+ *
+ * Deliberately unconditional (no in-memory "was an alert active" guard):
+ * system_status is tiny and a keyed DELETE on a row that doesn't exist is a
+ * cheap no-op, whereas an in-memory flag would desync from the database
+ * across a process restart — e.g. the service crashes while
+ * 'disk_emergency_alert' is set, restarts with the flag defaulted back to
+ * false, and a stale critical alert would then linger forever because the
+ * guard thinks there's nothing to clear.
+ */
+async function clearEmergencyAlert(): Promise<void> {
+  await db.query(`DELETE FROM system_status WHERE key = 'disk_emergency_alert'`).catch((err: unknown) => {
+    logger.warn({ err }, 'Failed to clear disk emergency alert from system_status');
+  });
 }
 
 /**
@@ -209,15 +332,11 @@ async function runDiskCheck(): Promise<void> {
       consecutiveCriticalChecks++;
       logger.error(
         { used_percent: lastStatus.used_percent, available_gb: lastStatus.available_gb, consecutive: consecutiveCriticalChecks },
-        'EMERGENCY: Disk usage critical — running cleanup then VACUUM FULL'
+        'EMERGENCY: Disk usage critical — running free-space-safe recovery actions'
       );
 
-      // Run cleanup first and wait for it to finish (frees rows for VACUUM FULL)
-      await triggerManualCleanup();
-      // Small delay to let cleanup's VACUUM ANALYZE finish before we take exclusive locks
-      await new Promise((resolve) => setTimeout(resolve, 5000));
-      await truncateJournald();
-      await runEmergencyVacuumFull();
+      await runEmergencyDiskFreeingActions();
+      await recordEmergencyAlert(lastStatus, consecutiveCriticalChecks);
     } else if (lastStatus.level === 'critical') {
       consecutiveCriticalChecks++;
       logger.warn(
@@ -228,6 +347,7 @@ async function runDiskCheck(): Promise<void> {
       await triggerManualCleanup();
       await truncateJournald();
       await checkWalSize();
+      await clearEmergencyAlert();
     } else if (lastStatus.level === 'warning') {
       consecutiveCriticalChecks = 0;
       logger.warn(
@@ -235,8 +355,10 @@ async function runDiskCheck(): Promise<void> {
         'WARNING: Disk usage approaching critical'
       );
       await checkWalSize();
+      await clearEmergencyAlert();
     } else {
       consecutiveCriticalChecks = 0;
+      await clearEmergencyAlert();
     }
   } catch (err) {
     logger.error({ err }, 'Disk check failed');

--- a/src/maintenance/partition-manager.ts
+++ b/src/maintenance/partition-manager.ts
@@ -1,0 +1,516 @@
+/**
+ * Partition Manager — Background Job (PROJ-917)
+ *
+ * Migrations 026-029 rebuilt likes/reposts/follows/posts/post_scores/
+ * post_score_components as declaratively RANGE-partitioned-by-created_at
+ * tables (daily partitions). This module is the runtime half of that
+ * rebuild: retention is now "DETACH + DROP a whole day's partition"
+ * (metadata-only, independent of row count) instead of the guarded
+ * `DELETE ... WHERE created_at < NOW() - window` queries in cleanup.ts,
+ * which — even indexed (migration 025) — still scan and delete row by row
+ * and compete with autovacuum/bloat at 48M-row scale.
+ *
+ * Two jobs, run once per calendar day (mirrors interaction-aggregator.ts's
+ * "hourly tick, daily-guarded work" pattern):
+ *
+ * 1. Create-ahead: ensure partitions exist for [today, today+2] on every
+ *    partitioned table. Idempotent (CREATE TABLE IF NOT EXISTS under the
+ *    hood via create_daily_range_partitions(), added in migration 026) —
+ *    safe to call even if today's/tomorrow's partition already exists.
+ *
+ * 2. Drop-old: for every partitioned table, DETACH + DROP any daily
+ *    partition whose upper bound has aged past that table's retention
+ *    window (RAW_EVENT_RETENTION_DAYS=14 for likes/reposts/follows,
+ *    SCORED_DATA_RETENTION_DAYS=30 for posts/post_scores/
+ *    post_score_components — src/config.ts). For `posts` specifically, this
+ *    also deletes the matching post_engagement rows FIRST — the
+ *    application-level cascade PROJ-917 substitutes for the FK CASCADE that
+ *    used to exist (see migration 027's header for why the FK had to be
+ *    dropped: PG16 requires a partitioned table's unique constraints to
+ *    include the full partition key, so `posts(uri)` alone can no longer be
+ *    an FK target once the PK becomes (uri, created_at)).
+ *
+ * A small DEFAULT partition per table (created in migrations 026-029) is the
+ * safety net for any row whose created_at falls outside every explicit daily
+ * range (clock skew, a missed maintenance run, backfill replay) — without
+ * one, an out-of-range INSERT hard-fails. This job also purges
+ * default-partition rows once they age past retention, using the same
+ * cutoff. Known limitation: a row with a *future*-dated created_at that
+ * lands in the default partition never migrates into its "real" partition
+ * once that day arrives — Postgres does not rebalance existing rows across
+ * partitions. This is expected to be rare (client clock skew) and is not
+ * swept by anything; it only ages out once past retention like any other
+ * default-partition row.
+ *
+ * Follows the same start/stop/guard pattern as cleanup.ts and
+ * interaction-aggregator.ts.
+ */
+
+import { db } from '../db/client.js';
+import { logger } from '../lib/logger.js';
+import { config } from '../config.js';
+
+const MAINTENANCE_INTERVAL_MS = 60 * 60 * 1000; // hourly tick; actual work is daily-guarded
+const BATCH_SIZE = 5000;
+/** How many days beyond a table's own retention window to keep checking for
+ *  undropped partitions. Covers a maintenance-job outage of many days
+ *  without needing operator intervention to "catch up". */
+const DROP_LOOKBACK_BUFFER_DAYS = 90;
+/** How many days ahead of today to guarantee a partition exists. */
+const CREATE_AHEAD_DAYS = 2;
+
+const IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+interface PartitionedTableSpec {
+  /** Live table name (also used as the partition-name prefix). */
+  name: string;
+  retentionDays: number;
+}
+
+function getPartitionedTables(): PartitionedTableSpec[] {
+  return [
+    { name: 'likes', retentionDays: config.RAW_EVENT_RETENTION_DAYS },
+    { name: 'reposts', retentionDays: config.RAW_EVENT_RETENTION_DAYS },
+    { name: 'follows', retentionDays: config.RAW_EVENT_RETENTION_DAYS },
+    { name: 'posts', retentionDays: config.SCORED_DATA_RETENTION_DAYS },
+    { name: 'post_scores', retentionDays: config.SCORED_DATA_RETENTION_DAYS },
+    { name: 'post_score_components', retentionDays: config.SCORED_DATA_RETENTION_DAYS },
+  ];
+}
+
+export interface PartitionMaintenanceResult {
+  partitionsCreated: string[];
+  partitionsDropped: string[];
+  defaultPartitionRowsPurged: number;
+  engagementRowsCascaded: number;
+  durationMs: number;
+  errors: string[];
+}
+
+let isRunning = false;
+let isMaintaining = false;
+let intervalId: NodeJS.Timeout | null = null;
+let isShuttingDown = false;
+let lastMaintenanceDate: string | null = null;
+
+/**
+ * Start the partition maintenance scheduler. Runs immediately, then checks
+ * hourly whether today's maintenance has already run (only actually does
+ * the create-ahead/drop-old work once per calendar day).
+ */
+export async function startPartitionManager(): Promise<void> {
+  if (isRunning) {
+    logger.warn('Partition manager already running');
+    return;
+  }
+
+  isRunning = true;
+  isShuttingDown = false;
+
+  logger.info(
+    {
+      rawEventRetentionDays: config.RAW_EVENT_RETENTION_DAYS,
+      scoredDataRetentionDays: config.SCORED_DATA_RETENTION_DAYS,
+    },
+    'Starting partition manager'
+  );
+
+  await runWithGuard();
+
+  intervalId = setInterval(runWithGuard, MAINTENANCE_INTERVAL_MS);
+
+  logger.info('Partition manager started');
+}
+
+export async function stopPartitionManager(): Promise<void> {
+  if (!isRunning) {
+    return;
+  }
+
+  logger.info('Stopping partition manager...');
+  isShuttingDown = true;
+
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+
+  while (isMaintaining) {
+    logger.info('Waiting for partition maintenance run to complete...');
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  isRunning = false;
+  logger.info('Partition manager stopped');
+}
+
+export function isPartitionManagerRunning(): boolean {
+  return isRunning;
+}
+
+async function runWithGuard(): Promise<void> {
+  if (isShuttingDown) return;
+
+  const today = await getServerToday();
+  if (lastMaintenanceDate === today) {
+    return;
+  }
+
+  try {
+    // runPartitionMaintenanceNow owns the concurrency guard (shared with the
+    // disk-monitor emergency path). Only advance the once-per-day marker if the
+    // run actually executed — null means another run already held the guard.
+    const result = await runPartitionMaintenanceNow();
+    if (result !== null) {
+      lastMaintenanceDate = today;
+    }
+  } catch (err) {
+    logger.error({ err }, 'Partition maintenance run failed');
+  }
+}
+
+/**
+ * Run partition maintenance immediately (bypasses the once-per-day date guard,
+ * but NOT the concurrency guard). Exported for manual triggers, the
+ * disk-monitor emergency recovery path, and the Testcontainers suite.
+ *
+ * Acquires the shared `isMaintaining` mutex so a direct call — e.g. an
+ * emergency disk-pressure run from disk-monitor.ts — cannot execute
+ * concurrently with the scheduled hourly run and race to DETACH/DROP the same
+ * partition (the loser's DETACH would fail noisily on an already-gone
+ * partition). Returns null if a run is already in progress.
+ */
+export async function runPartitionMaintenanceNow(): Promise<PartitionMaintenanceResult | null> {
+  if (isMaintaining) {
+    logger.warn('Partition maintenance already in progress - skipping concurrent invocation');
+    return null;
+  }
+  isMaintaining = true;
+  try {
+    return await doPartitionMaintenance();
+  } finally {
+    isMaintaining = false;
+  }
+}
+
+async function doPartitionMaintenance(): Promise<PartitionMaintenanceResult> {
+  const startTime = Date.now();
+  const errors: string[] = [];
+  const partitionsCreated: string[] = [];
+  const partitionsDropped: string[] = [];
+  let defaultPartitionRowsPurged = 0;
+  let engagementRowsCascaded = 0;
+
+  const today = await getServerTodayAsDate();
+  const tables = getPartitionedTables();
+
+  for (const table of tables) {
+    try {
+      const created = await createAheadPartitions(table, today);
+      partitionsCreated.push(...created);
+    } catch (err) {
+      const message = `create-ahead failed for ${table.name}: ${String(err instanceof Error ? err.message : err)}`;
+      logger.error({ err, table: table.name }, 'Partition create-ahead failed');
+      errors.push(message);
+    }
+  }
+
+  for (const table of tables) {
+    try {
+      const { dropped, engagementCascaded } = await dropOldPartitions(table, today);
+      partitionsDropped.push(...dropped);
+      engagementRowsCascaded += engagementCascaded;
+    } catch (err) {
+      const message = `drop-old failed for ${table.name}: ${String(err instanceof Error ? err.message : err)}`;
+      logger.error({ err, table: table.name }, 'Partition drop-old failed');
+      errors.push(message);
+    }
+  }
+
+  for (const table of tables) {
+    try {
+      defaultPartitionRowsPurged += await purgeDefaultPartition(table, today);
+    } catch (err) {
+      const message = `default-partition purge failed for ${table.name}: ${String(err instanceof Error ? err.message : err)}`;
+      logger.error({ err, table: table.name }, 'Default partition purge failed');
+      errors.push(message);
+    }
+  }
+
+  const result: PartitionMaintenanceResult = {
+    partitionsCreated,
+    partitionsDropped,
+    defaultPartitionRowsPurged,
+    engagementRowsCascaded,
+    durationMs: Date.now() - startTime,
+    errors,
+  };
+
+  logger.info(result, 'Partition maintenance run complete');
+
+  try {
+    await db.query(
+      `INSERT INTO system_status (key, value, updated_at)
+       VALUES ('last_partition_maintenance_run', $1, NOW())
+       ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
+      [JSON.stringify(result)]
+    );
+  } catch (err) {
+    logger.warn({ err }, 'Failed to store partition maintenance result in system_status');
+  }
+
+  return result;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** `YYYY-MM-DD` string for today, per PostgreSQL's own clock/timezone —
+ *  deliberately asked of the DB rather than computed from Node's `Date`, so
+ *  partition boundaries always agree with the `CURRENT_DATE` the migrations
+ *  used to create them, regardless of the app server's local timezone. */
+async function getServerToday(): Promise<string> {
+  const result = await db.query<{ today: string }>(`SELECT CURRENT_DATE::text AS today`);
+  return result.rows[0].today;
+}
+
+async function getServerTodayAsDate(): Promise<Date> {
+  const today = await getServerToday();
+  return parseDateOnly(today);
+}
+
+/** Parse a `YYYY-MM-DD` string as a UTC midnight Date (avoids local-timezone
+ *  drift when doing day-granularity arithmetic in JS). */
+function parseDateOnly(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map((part) => parseInt(part, 10));
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function formatDateOnly(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date.getTime());
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+function assertSafeIdentifier(name: string): void {
+  if (!IDENTIFIER_PATTERN.test(name)) {
+    throw new Error(`Refusing to use unsafe SQL identifier: ${JSON.stringify(name)}`);
+  }
+}
+
+function quoteIdent(name: string): string {
+  assertSafeIdentifier(name);
+  return `"${name}"`;
+}
+
+function partitionName(table: string, date: Date): string {
+  return `${table}_p${formatDateOnly(date).replace(/-/g, '')}`;
+}
+
+async function partitionExists(name: string): Promise<boolean> {
+  assertSafeIdentifier(name);
+  const result = await db.query<{ exists: boolean }>(
+    `SELECT to_regclass('public.' || $1) IS NOT NULL AS exists`,
+    [name]
+  );
+  return result.rows[0]?.exists === true;
+}
+
+/**
+ * Ensure a partition exists for every day in [today, today + CREATE_AHEAD_DAYS].
+ * Delegates the actual DDL to create_daily_range_partitions() (migration
+ * 026), which is idempotent (`CREATE TABLE IF NOT EXISTS`), so calling this
+ * daily even when partitions already exist is a cheap no-op.
+ */
+async function createAheadPartitions(table: PartitionedTableSpec, today: Date): Promise<string[]> {
+  assertSafeIdentifier(table.name);
+  const endDate = addDays(today, CREATE_AHEAD_DAYS);
+
+  const beforeNames: string[] = [];
+  for (let d = today; d <= endDate; d = addDays(d, 1)) {
+    beforeNames.push(partitionName(table.name, d));
+  }
+
+  // Only report names that didn't already exist, so callers/tests can
+  // distinguish "created this run" from "already there".
+  const existedBefore = new Set<string>();
+  for (const name of beforeNames) {
+    if (await partitionExists(name)) {
+      existedBefore.add(name);
+    }
+  }
+
+  await db.query(`SELECT create_daily_range_partitions($1, $2, $3, $4)`, [
+    table.name,
+    table.name,
+    formatDateOnly(today),
+    formatDateOnly(endDate),
+  ]);
+
+  return beforeNames.filter((name) => !existedBefore.has(name));
+}
+
+/**
+ * DETACH + DROP every daily partition of `table` whose upper bound (i.e. the
+ * day after the partition's date) is at or before `today - retentionDays`.
+ * Scans up to DROP_LOOKBACK_BUFFER_DAYS beyond the cutoff so a maintenance
+ * outage still drains the backlog on the next successful run, using cheap
+ * to_regclass() existence checks rather than introspecting pg_inherits.
+ */
+async function dropOldPartitions(
+  table: PartitionedTableSpec,
+  today: Date
+): Promise<{ dropped: string[]; engagementCascaded: number }> {
+  assertSafeIdentifier(table.name);
+  const cutoff = addDays(today, -table.retentionDays);
+  const scanStart = addDays(cutoff, -DROP_LOOKBACK_BUFFER_DAYS);
+
+  const dropped: string[] = [];
+  let engagementCascaded = 0;
+
+  // Partition for date `d` covers [d, d+1) — drop it once d+1 <= cutoff.
+  for (let d = scanStart; d < cutoff; d = addDays(d, 1)) {
+    const name = partitionName(table.name, d);
+    if (!(await partitionExists(name))) {
+      continue;
+    }
+
+    if (table.name === 'posts') {
+      engagementCascaded += await cascadeDeletePostEngagement(name);
+    }
+
+    await detachAndDropPartition(table.name, name);
+    dropped.push(name);
+    logger.info({ table: table.name, partition: name }, 'Dropped expired partition');
+  }
+
+  return { dropped, engagementCascaded };
+}
+
+/**
+ * Application-level cascade substituting for the FK CASCADE that used to
+ * exist on post_engagement.post_uri before migration 027 dropped it (a
+ * partitioned table's PK/unique constraints must include the full partition
+ * key, so `posts(uri)` alone could no longer back that FK). Deletes
+ * post_engagement rows for every post in the specific posts partition about
+ * to be dropped — bounded by that one day's post volume, not a full-table
+ * scan.
+ */
+async function cascadeDeletePostEngagement(postsPartitionName: string): Promise<number> {
+  assertSafeIdentifier(postsPartitionName);
+  let totalDeleted = 0;
+
+  // Batch over post_engagement itself (the table being modified), not over the
+  // static posts partition — selecting `SELECT uri FROM <partition> LIMIT n`
+  // returns the SAME n rows every iteration (nothing is removed from the
+  // partition), so once those n engagement rows are gone the count drops below
+  // BATCH_SIZE and the loop exits, orphaning every post beyond the first n.
+  // Keying the LIMIT off post_engagement.ctid makes each batch delete a fresh
+  // set and self-advance (same pattern purgeDefaultPartition's posts branch uses).
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await db.query(
+      `DELETE FROM post_engagement
+       WHERE ctid IN (
+         SELECT pe.ctid FROM post_engagement pe
+         WHERE pe.post_uri IN (SELECT uri FROM ${quoteIdent(postsPartitionName)})
+         LIMIT $1
+       )`,
+      [BATCH_SIZE]
+    );
+    const deleted = result.rowCount ?? 0;
+    totalDeleted += deleted;
+    if (deleted < BATCH_SIZE) break;
+  }
+
+  return totalDeleted;
+}
+
+async function detachAndDropPartition(parentTable: string, partitionTable: string): Promise<void> {
+  assertSafeIdentifier(parentTable);
+  assertSafeIdentifier(partitionTable);
+
+  // DETACH PARTITION takes an ACCESS EXCLUSIVE lock on the parent; CONCURRENTLY
+  // is unavailable because these tables keep a DEFAULT partition. This path is
+  // also reachable from disk-monitor's emergency recovery, so bound the lock
+  // wait: fail fast rather than stall reads/writes during disk pressure. A
+  // timeout throws, is recorded in the run's `errors`, and the partition is
+  // retried on the next run (the drop-lookback buffer drains any backlog).
+  // DETACH + DROP run in one transaction so the drop can't leave a detached
+  // orphan table behind.
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query("SET LOCAL lock_timeout = '5s'");
+    await client.query(`ALTER TABLE ${quoteIdent(parentTable)} DETACH PARTITION ${quoteIdent(partitionTable)}`);
+    await client.query(`DROP TABLE ${quoteIdent(partitionTable)}`);
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Sweep the DEFAULT partition (the out-of-range safety net created in
+ * migrations 026-029) for rows that have aged past retention, same cutoff as
+ * dropOldPartitions. Bounded/batched like cleanup.ts's guarded deletes — the
+ * default partition is expected to stay small (only clock-skew/backfill
+ * stragglers land there), so this is not the 48M-row full-scan pattern
+ * migration 025 fixed.
+ */
+async function purgeDefaultPartition(table: PartitionedTableSpec, today: Date): Promise<number> {
+  assertSafeIdentifier(table.name);
+  const defaultTable = `${table.name}_default`;
+  if (!(await partitionExists(defaultTable))) {
+    return 0;
+  }
+
+  const cutoff = addDays(today, -table.retentionDays);
+  let totalDeleted = 0;
+
+  if (table.name === 'posts') {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = await db.query<{ uri: string }>(
+        `DELETE FROM ${quoteIdent(defaultTable)}
+         WHERE uri IN (
+           SELECT uri FROM ${quoteIdent(defaultTable)} WHERE created_at < $1 LIMIT $2
+         )
+         RETURNING uri`,
+        [formatDateOnly(cutoff), BATCH_SIZE]
+      );
+      const uris = result.rows.map((r) => r.uri);
+      if (uris.length > 0) {
+        await db.query(`DELETE FROM post_engagement WHERE post_uri = ANY($1::text[])`, [uris]);
+      }
+      totalDeleted += uris.length;
+      if (uris.length < BATCH_SIZE) break;
+    }
+    return totalDeleted;
+  }
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // ctid (physical row id) works generically regardless of each table's PK
+    // shape, so this one query body covers likes/reposts/follows/post_scores/
+    // post_score_components default partitions alike.
+    const result = await db.query(
+      `DELETE FROM ${quoteIdent(defaultTable)}
+       WHERE ctid IN (
+         SELECT ctid FROM ${quoteIdent(defaultTable)} WHERE created_at < $1 LIMIT $2
+       )`,
+      [formatDateOnly(cutoff), BATCH_SIZE]
+    );
+    const deleted = result.rowCount ?? 0;
+    totalDeleted += deleted;
+    if (deleted < BATCH_SIZE) break;
+  }
+
+  return totalDeleted;
+}

--- a/src/maintenance/worker-supervisor.ts
+++ b/src/maintenance/worker-supervisor.ts
@@ -15,6 +15,11 @@ import {
   stopDiskMonitor,
   isDiskMonitorRunning,
 } from './disk-monitor.js';
+import {
+  startPartitionManager,
+  stopPartitionManager,
+  isPartitionManagerRunning,
+} from './partition-manager.js';
 
 const START_RETRY_ATTEMPTS = 3;
 const START_RETRY_DELAY_MS = 5_000;
@@ -69,6 +74,12 @@ const defaultWorkers: ManagedWorker[] = [
     start: startDiskMonitor,
     stop: stopDiskMonitor,
     isRunning: isDiskMonitorRunning,
+  },
+  {
+    name: 'partition-manager',
+    start: startPartitionManager,
+    stop: stopPartitionManager,
+    isRunning: isPartitionManagerRunning,
   },
 ];
 

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -600,6 +600,7 @@ async function scorePost(
   return {
     uri: post.uri,
     authorDid: post.authorDid,
+    createdAt: post.createdAt,
     score: { raw, weights, weighted, total },
   };
 }
@@ -630,9 +631,21 @@ async function storeScore(
   runId: string,
   classificationMethod: 'keyword' | 'embedding' = 'keyword'
 ): Promise<void> {
-  const { uri } = scoredPost;
+  const { uri, createdAt } = scoredPost;
   const { raw, weights, weighted, total } = scoredPost.score;
 
+  // PROJ-917: post_scores is RANGE-partitioned by a denormalized, immutable
+  // copy of the scored post's own posts.created_at (NOT scored_at, which
+  // changes on every rescore and would move the row across partitions). It's
+  // bound directly from the scored post ($21) — the post row was already read
+  // to compute this score, so its created_at is in hand. (A prior version
+  // re-looked it up with `(SELECT created_at FROM posts WHERE uri = $1)`, but
+  // uri is no longer unique on its own after the PK widened to
+  // (uri, created_at), so that scalar subquery could match multiple rows /
+  // error, and its NOW() fallback could route a rescore to a different
+  // partition than the original write.) unique_post_epoch widened to
+  // (post_uri, epoch_id, created_at); created_at is immutable once written, so
+  // it is never part of the DO UPDATE SET list.
   await db.query(
     `INSERT INTO post_scores (
       post_uri, epoch_id,
@@ -642,9 +655,9 @@ async function storeScore(
       source_diversity_weight, relevance_weight,
       recency_weighted, engagement_weighted, bridging_weighted,
       source_diversity_weighted, relevance_weighted,
-      total_score, component_details, classification_method
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
-    ON CONFLICT (post_uri, epoch_id) DO UPDATE SET
+      total_score, component_details, classification_method, created_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+    ON CONFLICT (post_uri, epoch_id, created_at) DO UPDATE SET
       recency_score = $3, engagement_score = $4, bridging_score = $5,
       source_diversity_score = $6, relevance_score = $7,
       recency_weight = $8, engagement_weight = $9, bridging_weight = $10,
@@ -674,11 +687,12 @@ async function storeScore(
       total,
       JSON.stringify({ run_id: runId, classification_method: classificationMethod }),
       classificationMethod,
+      createdAt,
     ]
   );
 
   if (config.SCORE_LONGTABLE_DUALWRITE_ENABLED) {
-    await storeScoreComponents(uri, epoch.id, raw, weights, weighted);
+    await storeScoreComponents(uri, epoch.id, createdAt, raw, weights, weighted);
   }
 }
 
@@ -692,6 +706,7 @@ async function storeScore(
 async function storeScoreComponents(
   postUri: string,
   epochId: number,
+  createdAt: Date,
   raw: ScoreComponents,
   weights: ScoreComponents,
   weighted: ScoreComponents
@@ -708,17 +723,24 @@ async function storeScoreComponents(
   const placeholders: string[] = [];
   for (const key of keys) {
     const offset = params.length;
-    params.push(postUri, epochId, key, raw[key], weights[key], weighted[key]);
+    params.push(postUri, epochId, key, raw[key], weights[key], weighted[key], createdAt);
+    // PROJ-917: post_score_components is RANGE-partitioned by created_at
+    // (migration 029), denormalized from posts.created_at exactly like
+    // post_scores. Bound directly from the scored post ($offset+7), same as
+    // storeScore() — see its comment for why the old
+    // `(SELECT created_at FROM posts WHERE uri = ...)` lookup was unsafe once
+    // uri stopped being unique on its own. PRIMARY KEY widened to
+    // (post_uri, epoch_id, component_key, created_at) in the same migration.
     placeholders.push(
-      `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6})`
+      `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7})`
     );
   }
 
   await db.query(
     `INSERT INTO post_score_components
-       (post_uri, epoch_id, component_key, raw, weight, weighted)
+       (post_uri, epoch_id, component_key, raw, weight, weighted, created_at)
      VALUES ${placeholders.join(', ')}
-     ON CONFLICT (post_uri, epoch_id, component_key) DO UPDATE SET
+     ON CONFLICT (post_uri, epoch_id, component_key, created_at) DO UPDATE SET
        raw = EXCLUDED.raw,
        weight = EXCLUDED.weight,
        weighted = EXCLUDED.weighted,

--- a/src/scoring/score.types.ts
+++ b/src/scoring/score.types.ts
@@ -39,6 +39,10 @@ export interface WeightedScore {
 export interface ScoredPost {
   uri: string;
   authorDid: string;
+  /** The scored post's own posts.created_at — carried through so score writes
+   *  bind the partition key directly instead of re-looking it up by uri
+   *  (which is no longer unique on its own after the PROJ-917 rebuild). */
+  createdAt: Date;
   score: WeightedScore;
 }
 

--- a/tests/admin-cleanup-route.test.ts
+++ b/tests/admin-cleanup-route.test.ts
@@ -1,0 +1,173 @@
+/**
+ * PROJ-917: POST /api/admin/trigger-cleanup used to 404 (ops/health-watchdog
+ * called a route that didn't exist, hidden by `|| true`). This proves the
+ * route now exists, delegates to triggerManualCleanup(), writes an audit
+ * log entry, and reports success:false (not an error) when a cleanup run
+ * was already in progress.
+ */
+
+import Fastify from 'fastify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbQueryMock, triggerManualCleanupMock } = vi.hoisted(() => ({
+  dbQueryMock: vi.fn(),
+  triggerManualCleanupMock: vi.fn(),
+}));
+
+vi.mock('../src/db/client.js', () => ({
+  db: {
+    query: dbQueryMock,
+  },
+}));
+
+vi.mock('../src/maintenance/cleanup.js', () => ({
+  triggerManualCleanup: triggerManualCleanupMock,
+}));
+
+vi.mock('../src/auth/admin.js', () => ({
+  getAdminDid: () => 'did:plc:admin',
+}));
+
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { registerCleanupRoutes } from '../src/admin/routes/cleanup.js';
+
+describe('admin trigger-cleanup route', () => {
+  beforeEach(() => {
+    dbQueryMock.mockReset().mockResolvedValue({ rows: [] });
+    triggerManualCleanupMock.mockReset();
+  });
+
+  it('triggers cleanup, returns the result, and writes an audit log entry', async () => {
+    const cleanupResult = {
+      postsDeleted: 42,
+      orphanedLikesDeleted: 3,
+      orphanedRepostsDeleted: 1,
+      orphanedEngagementDeleted: 0,
+      staleLikesDeleted: 0,
+      staleRepostsDeleted: 0,
+      oldFollowsDeleted: 5,
+      vacuumRan: true,
+      durationMs: 1234,
+    };
+    triggerManualCleanupMock.mockResolvedValue(cleanupResult);
+
+    const app = Fastify();
+    registerCleanupRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/trigger-cleanup',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      success: true,
+      result: cleanupResult,
+    });
+    expect(triggerManualCleanupMock).toHaveBeenCalledTimes(1);
+
+    const auditCall = dbQueryMock.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('INSERT INTO governance_audit_log')
+    );
+    expect(auditCall).toBeDefined();
+    expect(auditCall![1]).toEqual(['did:plc:admin', expect.any(String)]);
+    expect(JSON.parse((auditCall![1] as string[])[1]).result).toEqual(cleanupResult);
+
+    await app.close();
+  });
+
+  it('reports success:false with a null result when a cleanup run is already in progress', async () => {
+    triggerManualCleanupMock.mockResolvedValue(null);
+
+    const app = Fastify();
+    registerCleanupRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/trigger-cleanup',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      success: false,
+      result: null,
+    });
+
+    await app.close();
+  });
+
+  // Thread 7 / 17: the audit-log write happens after triggerManualCleanup()
+  // already ran (and may have mutated a lot of state) — a failure there must
+  // not discard the cleanup result via a 500, mirroring how
+  // src/maintenance/cleanup.ts treats its own system_status write as
+  // non-fatal.
+  it('still returns 200 with the cleanup result when the audit-log INSERT rejects', async () => {
+    const cleanupResult = {
+      postsDeleted: 10,
+      orphanedLikesDeleted: 0,
+      orphanedRepostsDeleted: 0,
+      orphanedEngagementDeleted: 0,
+      staleLikesDeleted: 0,
+      staleRepostsDeleted: 0,
+      oldFollowsDeleted: 0,
+      vacuumRan: false,
+      durationMs: 5,
+    };
+    triggerManualCleanupMock.mockResolvedValue(cleanupResult);
+    dbQueryMock.mockImplementation(async (sql: unknown) => {
+      if (typeof sql === 'string' && sql.includes('INSERT INTO governance_audit_log')) {
+        throw new Error('simulated audit-log write failure');
+      }
+      return { rows: [] };
+    });
+
+    const app = Fastify();
+    registerCleanupRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/trigger-cleanup',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      success: true,
+      result: cleanupResult,
+    });
+
+    await app.close();
+  });
+
+  // Thread 17's second ask: a triggerManualCleanup() rejection must surface
+  // as a proper error response, not an unhandled rejection that crashes the
+  // process. Fastify's default async-handler error handling already covers
+  // this (no route change needed) — this pins that behavior down.
+  it('surfaces a 500 error response, not an unhandled rejection, when triggerManualCleanup rejects', async () => {
+    triggerManualCleanupMock.mockRejectedValue(new Error('simulated cleanup failure'));
+
+    const app = Fastify();
+    registerCleanupRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/trigger-cleanup',
+    });
+
+    expect(response.statusCode).toBe(500);
+
+    const auditCall = dbQueryMock.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('INSERT INTO governance_audit_log')
+    );
+    expect(auditCall).toBeUndefined();
+
+    await app.close();
+  });
+});

--- a/tests/backfill-score-components-cli.test.ts
+++ b/tests/backfill-score-components-cli.test.ts
@@ -14,10 +14,38 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { projectWideRows } from '../scripts/backfill-score-components.ts';
 
 const SCRIPT = path.resolve('scripts', 'backfill-score-components.ts');
 const TSX_LOADER = path.resolve('node_modules', 'tsx', 'dist', 'loader.mjs');
 const SENTINEL = 'postgresql://sentinel-user:sentinel-pass@sentinel-host:6543/sentinel-db';
+
+/** Minimal well-formed WideRow fixture (the shape of a post_scores row this
+ * script selects), overridable per-field for individual test cases. */
+function buildWideScoreRow(overrides: Partial<Parameters<typeof projectWideRows>[0][number]> = {}) {
+  return {
+    post_uri: 'at://did:plc:test/app.bsky.feed.post/backfill-1',
+    epoch_id: 1,
+    recency_score: 0.5,
+    engagement_score: 0.5,
+    bridging_score: 0.5,
+    source_diversity_score: 0.5,
+    relevance_score: 0.5,
+    recency_weight: 0.2,
+    engagement_weight: 0.2,
+    bridging_weight: 0.2,
+    source_diversity_weight: 0.2,
+    relevance_weight: 0.2,
+    recency_weighted: 0.1,
+    engagement_weighted: 0.1,
+    bridging_weighted: 0.1,
+    source_diversity_weighted: 0.1,
+    relevance_weighted: 0.1,
+    scored_at: '2026-07-01T00:00:00.000Z',
+    created_at: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 const UNSAFE_INTEGER = '9007199254740993';
 
 /**
@@ -149,5 +177,61 @@ describe('backfill-score-components CLI: argument validation', () => {
     assertSpawnCompleted(result);
     expect(result.status).toBe(2);
     expect(result.stderr).toMatch(/Unknown argument/);
+  });
+});
+
+describe('backfill-score-components: projectWideRows (PROJ-917 created_at sourcing)', () => {
+  it('projects a single wide row into one component row per registered component', () => {
+    const row = buildWideScoreRow();
+    const projected = projectWideRows([row]);
+
+    expect(projected).toHaveLength(5);
+    expect(new Set(projected.map((p) => p.component_key))).toEqual(
+      new Set(['recency', 'engagement', 'bridging', 'sourceDiversity', 'relevance'])
+    );
+    for (const component of projected) {
+      expect(component.post_uri).toBe(row.post_uri);
+      expect(component.created_at).toBe(row.created_at);
+    }
+  });
+
+  it('keeps each row created_at independent for duplicate post_uri across different created_at (dry-run backfill case)', () => {
+    // This is the scenario the posts-JOIN + COALESCE approach could mis-key:
+    // two post_scores rows sharing a post_uri (e.g. the same URI replayed
+    // into two partitions with different created_at, per the migration
+    // 026/027 uniqueness review threads) must each keep their OWN
+    // created_at on every projected component — never collapsed onto one
+    // value or cross-attributed to the other row.
+    const older = buildWideScoreRow({
+      post_uri: 'at://did:plc:test/app.bsky.feed.post/dup-uri',
+      created_at: '2026-05-01T00:00:00.000Z',
+      recency_score: 0.1,
+    });
+    const newer = buildWideScoreRow({
+      post_uri: 'at://did:plc:test/app.bsky.feed.post/dup-uri',
+      created_at: '2026-06-15T00:00:00.000Z',
+      recency_score: 0.9,
+    });
+
+    const projected = projectWideRows([older, newer]);
+
+    // No fan-out / no dropped rows: 2 wide rows × 5 components = 10.
+    expect(projected).toHaveLength(10);
+
+    const olderComponents = projected.filter((p) => p.created_at === older.created_at);
+    const newerComponents = projected.filter((p) => p.created_at === newer.created_at);
+    expect(olderComponents).toHaveLength(5);
+    expect(newerComponents).toHaveLength(5);
+
+    // Each group's raw values must trace back to its own source row, not the
+    // other row's — this is exactly what a mis-keyed JOIN could scramble.
+    const olderRecency = olderComponents.find((p) => p.component_key === 'recency');
+    const newerRecency = newerComponents.find((p) => p.component_key === 'recency');
+    expect(olderRecency?.raw).toBe(0.1);
+    expect(newerRecency?.raw).toBe(0.9);
+  });
+
+  it('returns an empty array for an empty input batch', () => {
+    expect(projectWideRows([])).toEqual([]);
   });
 });

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -157,9 +157,123 @@ describe('cleanup job', () => {
     expect(result!.postsDeleted).toBe(50);
     expect(result!.orphanedLikesDeleted).toBe(12);
     expect(result!.orphanedRepostsDeleted).toBe(5);
+    expect(result!.orphanedEngagementDeleted).toBe(0);
     expect(result!.staleLikesDeleted).toBe(0);
     expect(result!.staleRepostsDeleted).toBe(0);
     expect(result!.oldFollowsDeleted).toBe(0);
+  });
+
+  // PROJ-917: post_engagement.post_uri lost its ON DELETE CASCADE FK to posts
+  // when posts was partitioned (a partitioned table's unique constraints must
+  // include the full partition key, so posts(uri) alone can no longer back
+  // an FK — see migration 027 and this file's header comment). This sweep
+  // mirrors the existing orphaned-likes/orphaned-reposts pattern above.
+  it('cleans orphaned post_engagement rows (no more FK CASCADE from posts)', async () => {
+    let orphanEngagementBatch = 0;
+
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('SET statement_timeout')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM posts')) {
+        return { rowCount: 0, rows: [] };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM likes')) {
+        return { rowCount: 0, rows: [] };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM reposts')) {
+        return { rowCount: 0, rows: [] };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM follows')) {
+        return { rowCount: 0, rows: [] };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM post_engagement')) {
+        orphanEngagementBatch++;
+        if (orphanEngagementBatch === 1) return { rowCount: 9, rows: Array(9).fill({}) };
+        return { rowCount: 0, rows: [] };
+      }
+      return { rowCount: 0, rows: [] };
+    });
+
+    const result = await triggerManualCleanup();
+
+    expect(result).not.toBeNull();
+    expect(result!.orphanedEngagementDeleted).toBe(9);
+
+    const engagementCall = clientQueryMock.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === 'string' && (call[0] as string).includes('DELETE FROM post_engagement')
+    );
+    expect(engagementCall).toBeDefined();
+    expect(engagementCall![0]).toContain('NOT EXISTS');
+    expect(engagementCall![0]).toContain('FROM posts p');
+  });
+
+  // Thread 18: only the single-batch happy path was covered above. A batch
+  // returning exactly BATCH_SIZE (5000) rows must not be treated as "done" --
+  // the loop should keep going until a batch comes back smaller than
+  // BATCH_SIZE, and the total must sum correctly across iterations.
+  it('continues the orphaned post_engagement sweep across multiple batches', async () => {
+    let orphanEngagementBatch = 0;
+
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('SET statement_timeout')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM posts')) {
+        return { rowCount: 0, rows: [] };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM likes')) {
+        return { rowCount: 0, rows: [] };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM reposts')) {
+        return { rowCount: 0, rows: [] };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM follows')) {
+        return { rowCount: 0, rows: [] };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM post_engagement')) {
+        orphanEngagementBatch++;
+        // First batch is a full BATCH_SIZE (5000) page -- the loop must not
+        // stop here. Second batch is a smaller, final page.
+        if (orphanEngagementBatch === 1) return { rowCount: 5000, rows: Array(5000).fill({}) };
+        if (orphanEngagementBatch === 2) return { rowCount: 137, rows: Array(137).fill({}) };
+        return { rowCount: 0, rows: [] };
+      }
+      return { rowCount: 0, rows: [] };
+    });
+
+    const result = await triggerManualCleanup();
+
+    expect(result).not.toBeNull();
+    expect(result!.orphanedEngagementDeleted).toBe(5137);
+    // Full BATCH_SIZE batch, then a smaller batch that ends the loop
+    // (deleted < BATCH_SIZE) -- no third round-trip needed.
+    expect(orphanEngagementBatch).toBe(2);
+  });
+
+  // Thread 18: a failure specific to the post_engagement DELETE must not take
+  // down the rest of the cleanup run -- triggerManualCleanup's own try/catch
+  // around batchDeleteOrphanedEngagement() should leave
+  // orphanedEngagementDeleted at 0 and still return a result.
+  it('completes the cleanup run with orphanedEngagementDeleted: 0 when the post_engagement DELETE rejects', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('SET statement_timeout')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (typeof sql === 'string' && sql.includes('DELETE FROM post_engagement')) {
+        throw new Error('simulated post_engagement DELETE failure');
+      }
+      return { rowCount: 0, rows: [] };
+    });
+
+    const result = await triggerManualCleanup();
+
+    expect(result).not.toBeNull();
+    expect(result!.orphanedEngagementDeleted).toBe(0);
+    // The rest of the job still ran and produced a well-formed result.
+    expect(result!.postsDeleted).toBe(0);
+    expect(result!.durationMs).toBeGreaterThanOrEqual(0);
   });
 
   it('runs VACUUM only when threshold exceeded', async () => {

--- a/tests/disk-monitor.test.ts
+++ b/tests/disk-monitor.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Tests for the disk monitor's escalating disk-freeing actions (PROJ-917).
+ *
+ * Focus: the emergency tier must NEVER run VACUUM FULL (prod postmortem —
+ * it failed ENOSPC 3x against the 21GB `likes` table and starved the pool
+ * with an ACCESS EXCLUSIVE lock) and must instead run the free-space-safe
+ * action set: partition-manager's drop pass, cleanup's orphan sweeps,
+ * journald truncation, CHECKPOINT/WAL check, and a plain VACUUM — plus an
+ * escalating system_status alert.
+ *
+ * Follows the interaction-aggregator.test.ts pattern: start/stop the
+ * monitor to exercise the private runDiskCheck() loop, since it isn't
+ * exported directly.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  statfsMock,
+  dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  clientReleaseMock,
+  execFileMock,
+  triggerManualCleanupMock,
+  runPartitionMaintenanceNowMock,
+  loggerWarnMock,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  statfsMock: vi.fn(),
+  dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
+  execFileMock: vi.fn((_cmd: string, _args: string[], cb?: (err?: Error | null) => void) => cb?.(null)),
+  triggerManualCleanupMock: vi.fn(),
+  runPartitionMaintenanceNowMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  statfs: statfsMock,
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+vi.mock('../src/db/client.js', () => ({
+  db: {
+    query: dbQueryMock,
+    connect: dbConnectMock,
+  },
+}));
+
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: loggerWarnMock,
+    error: loggerErrorMock,
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    DISK_WARNING_PERCENT: 80,
+    DISK_CRITICAL_PERCENT: 90,
+    DISK_EMERGENCY_PERCENT: 95,
+  },
+}));
+
+vi.mock('../src/maintenance/cleanup.js', () => ({
+  triggerManualCleanup: triggerManualCleanupMock,
+}));
+
+vi.mock('../src/maintenance/partition-manager.js', () => ({
+  runPartitionMaintenanceNow: runPartitionMaintenanceNowMock,
+}));
+
+import {
+  startDiskMonitor,
+  stopDiskMonitor,
+  getDiskStatus,
+  runEmergencyDiskFreeingActions,
+} from '../src/maintenance/disk-monitor.js';
+
+/** Build a fake fs.statfs() result that resolves to the given used_percent
+ *  (bsize=1 keeps the arithmetic trivial: blocks=100 == 100% of "capacity"). */
+function mockStatfsPercent(usedPercent: number): void {
+  const bavail = 100 - usedPercent;
+  statfsMock.mockImplementation(
+    (_path: string, cb: (err: Error | null, stats?: { blocks: number; bsize: number; bavail: number }) => void) => {
+      cb(null, { blocks: 100, bsize: 1, bavail });
+    }
+  );
+}
+
+describe('disk monitor emergency actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    dbConnectMock.mockResolvedValue({
+      query: clientQueryMock,
+      release: clientReleaseMock,
+    });
+    dbQueryMock.mockResolvedValue({ rows: [], rowCount: 0 });
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('pg_total_relation_size')) {
+        return { rows: [{ size_bytes: '1000000' }] };
+      }
+      if (typeof sql === 'string' && sql.includes('pg_ls_waldir')) {
+        return { rows: [{ wal_bytes: '0' }] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    triggerManualCleanupMock.mockResolvedValue({ postsDeleted: 0 });
+    runPartitionMaintenanceNowMock.mockResolvedValue({ partitionsDropped: [] });
+  });
+
+  afterEach(async () => {
+    await stopDiskMonitor();
+  });
+
+  it('takes no action below the warning threshold', async () => {
+    mockStatfsPercent(50);
+
+    await startDiskMonitor();
+
+    expect(getDiskStatus()?.level).toBe('ok');
+    expect(triggerManualCleanupMock).not.toHaveBeenCalled();
+    expect(runPartitionMaintenanceNowMock).not.toHaveBeenCalled();
+    expect(clientQueryMock).not.toHaveBeenCalledWith(expect.stringContaining('VACUUM'));
+  });
+
+  it('runs cleanup + journald truncation + WAL check at the critical tier (but not partition drop or VACUUM)', async () => {
+    mockStatfsPercent(92);
+
+    await startDiskMonitor();
+
+    expect(getDiskStatus()?.level).toBe('critical');
+    expect(triggerManualCleanupMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledWith('journalctl', ['--vacuum-size=500M'], expect.any(Function));
+    expect(runPartitionMaintenanceNowMock).not.toHaveBeenCalled();
+
+    const vacuumCalls = clientQueryMock.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).startsWith('VACUUM')
+    );
+    expect(vacuumCalls).toHaveLength(0);
+  });
+
+  it('never runs VACUUM FULL at the emergency tier, and runs the full free-space-safe action set', async () => {
+    mockStatfsPercent(97);
+
+    await startDiskMonitor();
+
+    expect(getDiskStatus()?.level).toBe('emergency');
+
+    // 1. partition-manager drop + cleanup orphan sweeps
+    expect(runPartitionMaintenanceNowMock).toHaveBeenCalledTimes(1);
+    expect(triggerManualCleanupMock).toHaveBeenCalledTimes(1);
+
+    // 2. journald truncation
+    expect(execFileMock).toHaveBeenCalledWith('journalctl', ['--vacuum-size=500M'], expect.any(Function));
+
+    // 4. plain VACUUM per emergency table, NEVER VACUUM FULL
+    const allSql = clientQueryMock.mock.calls.map((call: unknown[]) => call[0] as string);
+    const fullVacuumCalls = allSql.filter((sql) => /VACUUM\s+FULL/i.test(sql));
+    expect(fullVacuumCalls).toHaveLength(0);
+
+    for (const table of ['follows', 'reposts', 'likes', 'posts']) {
+      expect(allSql).toContain(`VACUUM ${table}`);
+    }
+
+    // 5. escalating alert stored in system_status + error-logged
+    const alertCall = dbQueryMock.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes("'disk_emergency_alert'")
+    );
+    expect(alertCall).toBeDefined();
+    const alertParams = (alertCall as unknown[])[1] as string[];
+    const alertPayload = JSON.parse(alertParams[0]);
+    expect(alertPayload.severity).toBe('elevated');
+    expect(alertPayload.consecutive_checks).toBe(1);
+  });
+
+  it('escalates alert severity on repeated consecutive emergency checks within one monitor lifetime', async () => {
+    vi.useFakeTimers();
+    mockStatfsPercent(97);
+
+    await startDiskMonitor(); // 1st check: consecutive=1 => elevated
+    await vi.advanceTimersByTimeAsync(5 * 60_000); // 2nd check: consecutive=2 => high
+    await vi.advanceTimersByTimeAsync(5 * 60_000); // 3rd check: consecutive=3 => critical
+
+    const alertCalls = dbQueryMock.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes("'disk_emergency_alert'")
+    );
+    expect(alertCalls.length).toBeGreaterThanOrEqual(3);
+
+    const severities = alertCalls.map((call: unknown[]) => JSON.parse((call[1] as string[])[0]).severity);
+    expect(severities.slice(0, 3)).toEqual(['elevated', 'high', 'critical']);
+
+    vi.useRealTimers();
+  });
+
+  it('clears the emergency alert key once usage drops back to ok', async () => {
+    mockStatfsPercent(50);
+    await startDiskMonitor();
+
+    const deleteCall = dbQueryMock.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('DELETE FROM system_status') &&
+        (call[0] as string).includes("'disk_emergency_alert'")
+    );
+    expect(deleteCall).toBeDefined();
+  });
+
+  it('clears the emergency alert key at the warning tier', async () => {
+    mockStatfsPercent(85); // warning: 80-90%
+    await startDiskMonitor();
+
+    const deleteCall = dbQueryMock.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('DELETE FROM system_status') &&
+        (call[0] as string).includes("'disk_emergency_alert'")
+    );
+    expect(deleteCall).toBeDefined();
+  });
+
+  // Thread 20: the old version of this test was titled "...at the warning
+  // and critical tiers too" but only ever exercised 85% (warning). This
+  // exercises 92%, which is specifically the critical tier (90-95%), and
+  // pins down that clearEmergencyAlert() fires there too (runDiskCheck's
+  // critical branch calls it after triggerManualCleanup/truncateJournald/
+  // checkWalSize).
+  it('clears the emergency alert key at the critical tier', async () => {
+    mockStatfsPercent(92); // critical: 90-95%
+    await startDiskMonitor();
+
+    expect(getDiskStatus()?.level).toBe('critical');
+
+    const deleteCall = dbQueryMock.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('DELETE FROM system_status') &&
+        (call[0] as string).includes("'disk_emergency_alert'")
+    );
+    expect(deleteCall).toBeDefined();
+  });
+
+  // Thread 19 (1/3): isEmergencyActionRunning is the guard added specifically
+  // to prevent a second emergency pass from starting mid-flight. Under the
+  // normal scheduled path, runDiskCheck()'s own isChecking flag already fully
+  // serializes checks (startDiskMonitor() awaits the first check before ever
+  // registering the interval), so there is no way to reach a genuinely
+  // overlapping call through the public start/stop API. Exercise the guard
+  // directly against the (now-exported) function instead.
+  it('runEmergencyDiskFreeingActions skips a second overlapping invocation instead of running twice', async () => {
+    let resolvePartitionMaintenance: (() => void) | undefined;
+    runPartitionMaintenanceNowMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePartitionMaintenance = () => resolve({ partitionsDropped: [] });
+        })
+    );
+
+    // Both calls are issued before either awaits anything: the first call's
+    // synchronous prefix (the isEmergencyActionRunning check-and-set) runs to
+    // completion before control returns to this test, so the second call
+    // deterministically observes the guard already engaged.
+    const firstCall = runEmergencyDiskFreeingActions();
+    const secondCall = runEmergencyDiskFreeingActions();
+
+    await secondCall;
+
+    expect(runPartitionMaintenanceNowMock).toHaveBeenCalledTimes(1);
+    expect(triggerManualCleanupMock).not.toHaveBeenCalled(); // still blocked behind the pending partition-maintenance call
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining('already running')
+    );
+
+    // Unblock the first call so it completes and doesn't leak a pending
+    // promise/timer into the next test.
+    resolvePartitionMaintenance?.();
+    await firstCall;
+
+    expect(runPartitionMaintenanceNowMock).toHaveBeenCalledTimes(1);
+    expect(triggerManualCleanupMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Thread 19 (2/3): a failure on one table's VACUUM must not abort the rest
+  // of the emergency pass -- this also regression-tests the per-table
+  // try/catch fix in runEmergencyPlainVacuum (previously a single outer
+  // try/catch meant one failing table silently skipped every table after it).
+  it('continues vacuuming the remaining tables when one VACUUM call fails at the emergency tier', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('pg_total_relation_size')) {
+        return { rows: [{ size_bytes: '1000000' }] };
+      }
+      if (typeof sql === 'string' && sql.includes('pg_ls_waldir')) {
+        return { rows: [{ wal_bytes: '0' }] };
+      }
+      if (typeof sql === 'string' && sql === 'VACUUM likes') {
+        throw new Error('simulated VACUUM failure');
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    mockStatfsPercent(97);
+    await startDiskMonitor();
+
+    const vacuumCalls = clientQueryMock.mock.calls
+      .map((call: unknown[]) => call[0] as string)
+      .filter((sql) => /^VACUUM\s+\w+$/.test(sql));
+
+    // All four tables were still attempted, including the ones after the
+    // failing "likes" table in EMERGENCY_VACUUM_TABLES (follows, reposts,
+    // likes, posts) -- "posts" specifically proves the loop didn't stop.
+    for (const table of ['follows', 'reposts', 'likes', 'posts']) {
+      expect(vacuumCalls).toContain(`VACUUM ${table}`);
+    }
+  });
+
+  // Thread 19 (3/3): execFileMock always calls back with success in every
+  // other test; nothing exercises the err branch that logs a warning and
+  // continues (truncateJournald must not throw / abort the check).
+  it('logs a warning and continues when journald truncation fails', async () => {
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], cb?: (err?: Error | null) => void) =>
+        cb?.(new Error('journalctl: permission denied'))
+    );
+
+    mockStatfsPercent(92); // critical tier also runs truncateJournald()
+
+    await expect(startDiskMonitor()).resolves.toBeUndefined();
+
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      expect.stringContaining('Failed to truncate journald')
+    );
+    expect(getDiskStatus()?.level).toBe('critical');
+  });
+});

--- a/tests/harness/partition-lifecycle.sim.ts
+++ b/tests/harness/partition-lifecycle.sim.ts
@@ -1,0 +1,409 @@
+/**
+ * PROJ-917: partition lifecycle integration suite.
+ *
+ * Proves, against a real postgres:16 Testcontainer running the REAL
+ * migration runner (migrations 026-029 — see tests/harness/global-setup.ts),
+ * that the native time-partitioned schema rebuild actually works:
+ *
+ *  (a) migrations build the partitioned schema (likes/reposts/follows/posts/
+ *      post_scores/post_score_components are declaratively RANGE-partitioned
+ *      by created_at, with today's daily partition already present).
+ *  (b) inserts route to the correct daily partition.
+ *  (c) src/maintenance/partition-manager.ts creates partitions ahead of time
+ *      and DETACHes+DROPs partitions past their retention window — a
+ *      dropped partition's rows vanish instantly (row count AND
+ *      pg_total_relation_size, not a DELETE that leaves dead tuples for
+ *      autovacuum), and the posts-drop path cascades to post_engagement
+ *      (the FK CASCADE that migration 027 had to drop).
+ *  (d) representative reads — a 72h scoring-window join of posts+post_scores
+ *      (the shape of src/scoring/pipeline.ts's writeToRedisFromDb query),
+ *      and the real scoreBridging() component reading likes/reposts/follows
+ *      — still return correct results against the partitioned tables.
+ *
+ * Uses direct SQL for seeding (not the A1 population/scenario harness):
+ * this suite needs exact, individually-controlled `created_at` values to
+ * pin rows to specific day partitions (including partitions well outside
+ * the default retention window, to exercise dropOldPartitions), which the
+ * scenario-generator seeders aren't built for. tests/harness/helpers.ts's
+ * resetHarnessData/insertActiveEpoch are reused where they fit directly.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { db } from '../../src/db/client.js';
+import { scoreBridging } from '../../src/scoring/components/bridging.js';
+import { runPartitionMaintenanceNow } from '../../src/maintenance/partition-manager.js';
+import { config } from '../../src/config.js';
+import { resetHarnessData, insertActiveEpoch } from './helpers.js';
+
+const PARTITIONED_TABLES = [
+  'likes',
+  'reposts',
+  'follows',
+  'posts',
+  'post_scores',
+  'post_score_components',
+] as const;
+
+async function getServerToday(): Promise<Date> {
+  const result = await db.query<{ today: string }>(`SELECT CURRENT_DATE::text AS today`);
+  const [year, month, day] = result.rows[0].today.split('-').map((p) => parseInt(p, 10));
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date.getTime());
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+function dateSuffix(date: Date): string {
+  return date.toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+function partitionName(table: string, date: Date): string {
+  return `${table}_p${dateSuffix(date)}`;
+}
+
+async function regclassExists(name: string): Promise<boolean> {
+  const result = await db.query<{ exists: boolean }>(
+    `SELECT to_regclass('public.' || $1) IS NOT NULL AS exists`,
+    [name]
+  );
+  return result.rows[0]?.exists === true;
+}
+
+async function relkind(table: string): Promise<string | null> {
+  const result = await db.query<{ relkind: string }>(
+    `SELECT relkind FROM pg_class WHERE relname = $1 AND relnamespace = 'public'::regnamespace`,
+    [table]
+  );
+  return result.rows[0]?.relkind ?? null;
+}
+
+describe('partition lifecycle (PROJ-917)', () => {
+  let today: Date;
+
+  beforeAll(async () => {
+    today = await getServerToday();
+  });
+
+  afterEach(async () => {
+    await resetHarnessData();
+  });
+
+  // ── (a) migrations build the partitioned schema ──────────────────
+
+  it('migrations 026-029 rebuilt all six tables as declaratively RANGE-partitioned', async () => {
+    for (const table of PARTITIONED_TABLES) {
+      expect(await relkind(table), `${table} should be relkind 'p' (partitioned table)`).toBe('p');
+    }
+  });
+
+  it("today's daily partition already exists for every partitioned table (created by the migrations' initial window)", async () => {
+    for (const table of PARTITIONED_TABLES) {
+      const name = partitionName(table, today);
+      expect(await regclassExists(name), `${name} should exist`).toBe(true);
+    }
+  });
+
+  it('each table also has a DEFAULT partition as an out-of-range safety net', async () => {
+    for (const table of PARTITIONED_TABLES) {
+      expect(await regclassExists(`${table}_default`)).toBe(true);
+    }
+  });
+
+  // ── (b) inserts route to the correct daily partition ─────────────
+
+  it('a like inserted for "today" is physically stored in the corresponding daily partition', async () => {
+    const uri = 'at://did:plc:partition-test/app.bsky.feed.like/routing-1';
+    await db.query(
+      `INSERT INTO likes (uri, author_did, subject_uri, created_at)
+       VALUES ($1, $2, $3, NOW())
+       ON CONFLICT (uri, created_at) DO NOTHING`,
+      [uri, 'did:plc:partition-test-liker', 'at://did:plc:partition-test/app.bsky.feed.post/subject']
+    );
+
+    const result = await db.query<{ partition: string }>(
+      `SELECT tableoid::regclass::text AS partition FROM likes WHERE uri = $1`,
+      [uri]
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].partition).toBe(partitionName('likes', today));
+  });
+
+  it('a post inserted for "today" is physically stored in the corresponding daily partition', async () => {
+    const uri = 'at://did:plc:partition-test/app.bsky.feed.post/routing-2';
+    await db.query(
+      `INSERT INTO posts (uri, cid, author_did, created_at)
+       VALUES ($1, 'cid-routing-2', 'did:plc:partition-test-author', NOW())
+       ON CONFLICT (uri, created_at) DO NOTHING`,
+      [uri]
+    );
+
+    const result = await db.query<{ partition: string }>(
+      `SELECT tableoid::regclass::text AS partition FROM posts WHERE uri = $1`,
+      [uri]
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].partition).toBe(partitionName('posts', today));
+  });
+
+  // ── (c) partition-manager: create-ahead + drop-old + cascade + instant vanish ──
+
+  it('runPartitionMaintenanceNow() re-creates a missing "create-ahead" partition', async () => {
+    const aheadDate = addDays(today, 2);
+    const aheadName = partitionName('likes', aheadDate);
+
+    // The initial migration window already created this partition ([today,
+    // today+2]) — drop it so we can prove partition-manager creates it back.
+    expect(await regclassExists(aheadName)).toBe(true);
+    await db.query(`ALTER TABLE likes DETACH PARTITION ${aheadName}`);
+    await db.query(`DROP TABLE ${aheadName}`);
+    expect(await regclassExists(aheadName)).toBe(false);
+
+    const result = await runPartitionMaintenanceNow();
+    if (result === null) throw new Error('partition maintenance unexpectedly skipped');
+
+    expect(await regclassExists(aheadName)).toBe(true);
+    expect(result.partitionsCreated).toContain(aheadName);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('runPartitionMaintenanceNow() drops a partition past its retention window — rows and disk space vanish instantly', async () => {
+    // Well beyond RAW_EVENT_RETENTION_DAYS (default 14) and outside the
+    // migrations' initial window ([today-16d, today+2d]), so this partition
+    // does not already exist and must be created here for the test.
+    const oldDate = addDays(today, -(config.RAW_EVENT_RETENTION_DAYS + 6));
+    const oldName = partitionName('likes', oldDate);
+
+    await db.query(`SELECT create_daily_range_partitions('likes', 'likes', $1::date, $1::date)`, [
+      oldDate.toISOString().slice(0, 10),
+    ]);
+    expect(await regclassExists(oldName)).toBe(true);
+
+    // Seed enough rows that the partition has a real, non-trivial disk
+    // footprint — a meaningful contrast against a plain DELETE, which would
+    // leave that same footprint behind as dead tuples until VACUUM.
+    const rowCount = 300;
+    const values: string[] = [];
+    const params: unknown[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const base = i * 4;
+      values.push(`($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4})`);
+      params.push(
+        `at://did:plc:partition-test/app.bsky.feed.like/old-${i}`,
+        `did:plc:partition-test-old-liker-${i}`,
+        'at://did:plc:partition-test/app.bsky.feed.post/old-subject',
+        new Date(oldDate.getTime() + i * 60_000).toISOString()
+      );
+    }
+    await db.query(
+      `INSERT INTO likes (uri, author_did, subject_uri, created_at) VALUES ${values.join(', ')}`,
+      params
+    );
+
+    const countBefore = await db.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM ${oldName}`
+    );
+    expect(parseInt(countBefore.rows[0].count, 10)).toBe(rowCount);
+
+    const sizeBefore = await db.query<{ size: string }>(
+      `SELECT pg_total_relation_size(to_regclass('public.' || $1))::text AS size`,
+      [oldName]
+    );
+    expect(parseInt(sizeBefore.rows[0].size, 10)).toBeGreaterThan(0);
+
+    const result = await runPartitionMaintenanceNow();
+    if (result === null) throw new Error('partition maintenance unexpectedly skipped');
+
+    expect(result.partitionsDropped).toContain(oldName);
+    expect(result.errors).toEqual([]);
+
+    // The partition relation itself is gone — not just empty. DROP TABLE
+    // unlinks the file immediately; a DELETE of the same rows would leave
+    // this same disk footprint present (as dead tuples) until VACUUM.
+    expect(await regclassExists(oldName)).toBe(false);
+
+    // Rows are gone from the parent's point of view too, instantly.
+    const liveCount = await db.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM likes
+       WHERE subject_uri = 'at://did:plc:partition-test/app.bsky.feed.post/old-subject'`
+    );
+    expect(parseInt(liveCount.rows[0].count, 10)).toBe(0);
+
+    // A live, in-retention partition (today's) must survive the same run.
+    expect(await regclassExists(partitionName('likes', today))).toBe(true);
+  });
+
+  it('dropping an old posts partition cascades to post_engagement (the FK CASCADE dropped in migration 027)', async () => {
+    const oldDate = addDays(today, -(config.SCORED_DATA_RETENTION_DAYS + 5));
+    const oldName = partitionName('posts', oldDate);
+
+    await db.query(`SELECT create_daily_range_partitions('posts', 'posts', $1::date, $1::date)`, [
+      oldDate.toISOString().slice(0, 10),
+    ]);
+
+    const postUri = 'at://did:plc:partition-test/app.bsky.feed.post/engagement-cascade';
+    await db.query(
+      `INSERT INTO posts (uri, cid, author_did, created_at) VALUES ($1, 'cid-cascade', 'did:plc:partition-test-author', $2)`,
+      [postUri, oldDate.toISOString()]
+    );
+    await db.query(
+      `INSERT INTO post_engagement (post_uri, like_count, repost_count, reply_count) VALUES ($1, 3, 1, 0)`,
+      [postUri]
+    );
+
+    const engagementBefore = await db.query(`SELECT 1 FROM post_engagement WHERE post_uri = $1`, [postUri]);
+    expect(engagementBefore.rows).toHaveLength(1);
+
+    const result = await runPartitionMaintenanceNow();
+    if (result === null) throw new Error('partition maintenance unexpectedly skipped');
+
+    expect(result.partitionsDropped).toContain(oldName);
+    expect(result.engagementRowsCascaded).toBeGreaterThanOrEqual(1);
+
+    const engagementAfter = await db.query(`SELECT 1 FROM post_engagement WHERE post_uri = $1`, [postUri]);
+    expect(engagementAfter.rows).toHaveLength(0);
+  });
+
+  it('cascade deletes ALL post_engagement rows when the dropped posts partition exceeds BATCH_SIZE (regression for the self-advancing batch loop)', async () => {
+    const oldDate = addDays(today, -(config.SCORED_DATA_RETENTION_DAYS + 7));
+    const oldName = partitionName('posts', oldDate);
+    await db.query(`SELECT create_daily_range_partitions('posts', 'posts', $1::date, $1::date)`, [
+      oldDate.toISOString().slice(0, 10),
+    ]);
+
+    // > BATCH_SIZE (5000). The prior cascade re-selected the same static 5000
+    // URIs from the posts partition every iteration, so once their engagement
+    // rows were gone the loop exited and orphaned everything past the first
+    // batch. This seeds 5200 to prove the fix drains the whole partition.
+    const rowCount = 5200;
+    await db.query(
+      `INSERT INTO posts (uri, cid, author_did, created_at)
+       SELECT 'at://did:plc:cascade-vol/app.bsky.feed.post/' || g, 'cid', 'did:plc:cascade-vol', $1::timestamptz
+       FROM generate_series(1, $2) g`,
+      [oldDate.toISOString(), rowCount]
+    );
+    await db.query(
+      `INSERT INTO post_engagement (post_uri, like_count, repost_count, reply_count)
+       SELECT uri, 1, 0, 0 FROM ${oldName}`
+    );
+    const before = await db.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM post_engagement WHERE post_uri LIKE 'at://did:plc:cascade-vol/%'`
+    );
+    expect(parseInt(before.rows[0].count, 10)).toBe(rowCount);
+
+    const result = await runPartitionMaintenanceNow();
+    if (result === null) throw new Error('partition maintenance unexpectedly skipped');
+
+    expect(result.partitionsDropped).toContain(oldName);
+    expect(result.engagementRowsCascaded).toBeGreaterThanOrEqual(rowCount);
+
+    // No orphans: every engagement row for the dropped partition's posts is gone.
+    const after = await db.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM post_engagement WHERE post_uri LIKE 'at://did:plc:cascade-vol/%'`
+    );
+    expect(parseInt(after.rows[0].count, 10)).toBe(0);
+  });
+
+  // ── (d) representative reads still return correct results ────────
+
+  it('a 72h scoring-window read joining posts+post_scores returns only in-window rows, correctly ranked', async () => {
+    const epochId = await insertActiveEpoch('partition-lifecycle scoring window test');
+
+    const inWindowUri = 'at://did:plc:partition-test/app.bsky.feed.post/in-window';
+    const outOfWindowUri = 'at://did:plc:partition-test/app.bsky.feed.post/out-of-window';
+    const inWindowCreatedAt = new Date(Date.now() - 1 * 60 * 60 * 1000); // 1h ago
+    const outOfWindowCreatedAt = new Date(Date.now() - 100 * 60 * 60 * 1000); // 100h ago
+
+    for (const [uri, createdAt] of [
+      [inWindowUri, inWindowCreatedAt],
+      [outOfWindowUri, outOfWindowCreatedAt],
+    ] as const) {
+      await db.query(
+        `INSERT INTO posts (uri, cid, author_did, created_at) VALUES ($1, 'cid', 'did:plc:partition-test-author', $2)`,
+        [uri, createdAt.toISOString()]
+      );
+
+      // Mirrors src/scoring/pipeline.ts's storeScore(): created_at is
+      // resolved via a subquery against posts (immutable partition key),
+      // not supplied as a literal — proving that exact construct works
+      // against the real partitioned schema.
+      await db.query(
+        `INSERT INTO post_scores (
+          post_uri, epoch_id,
+          recency_score, engagement_score, bridging_score, source_diversity_score, relevance_score,
+          recency_weight, engagement_weight, bridging_weight, source_diversity_weight, relevance_weight,
+          recency_weighted, engagement_weighted, bridging_weighted, source_diversity_weighted, relevance_weighted,
+          total_score, created_at
+        ) VALUES ($1, $2, 0.5, 0.5, 0.5, 0.5, 0.5, 0.2, 0.2, 0.2, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1,
+          ${uri === inWindowUri ? '0.9' : '0.1'},
+          COALESCE((SELECT created_at FROM posts WHERE uri = $1), NOW()))
+        ON CONFLICT (post_uri, epoch_id, created_at) DO UPDATE SET total_score = EXCLUDED.total_score`,
+        [uri, epochId]
+      );
+    }
+
+    const cutoff = new Date(Date.now() - 72 * 60 * 60 * 1000);
+    const result = await db.query<{ post_uri: string; total_score: number }>(
+      `SELECT ps.post_uri, ps.total_score
+       FROM post_scores ps
+       JOIN posts p ON p.uri = ps.post_uri
+       WHERE ps.epoch_id = $1
+         AND p.deleted = FALSE
+         AND p.created_at > $2
+         AND p.created_at <= NOW()
+       ORDER BY ps.total_score DESC`,
+      [epochId, cutoff.toISOString()]
+    );
+
+    expect(result.rows.map((r) => r.post_uri)).toEqual([inWindowUri]);
+    expect(result.rows[0].total_score).toBeCloseTo(0.9, 5);
+  });
+
+  it('scoreBridging() (real production component) still distinguishes disjoint vs. overlapping engager networks across partitioned likes/reposts/follows', async () => {
+    // Case A: two engagers whose follow sets are completely disjoint -> high bridging.
+    const disjointSubject = 'at://did:plc:partition-test/app.bsky.feed.post/bridging-disjoint';
+    await seedLike(disjointSubject, 'did:plc:bridge-engager-a1');
+    await seedLike(disjointSubject, 'did:plc:bridge-engager-a2');
+    await seedFollow('did:plc:bridge-engager-a1', 'did:plc:bridge-followee-1');
+    await seedFollow('did:plc:bridge-engager-a1', 'did:plc:bridge-followee-2');
+    await seedFollow('did:plc:bridge-engager-a2', 'did:plc:bridge-followee-3');
+    await seedFollow('did:plc:bridge-engager-a2', 'did:plc:bridge-followee-4');
+
+    const disjointScore = await scoreBridging(disjointSubject, 'did:plc:partition-test-author');
+    expect(disjointScore).toBeCloseTo(1.0, 5);
+
+    // Case B: two engagers with identical follow sets -> low bridging.
+    const overlappingSubject = 'at://did:plc:partition-test/app.bsky.feed.post/bridging-overlap';
+    await seedLike(overlappingSubject, 'did:plc:bridge-engager-b1');
+    await seedLike(overlappingSubject, 'did:plc:bridge-engager-b2');
+    await seedFollow('did:plc:bridge-engager-b1', 'did:plc:bridge-followee-x');
+    await seedFollow('did:plc:bridge-engager-b1', 'did:plc:bridge-followee-y');
+    await seedFollow('did:plc:bridge-engager-b2', 'did:plc:bridge-followee-x');
+    await seedFollow('did:plc:bridge-engager-b2', 'did:plc:bridge-followee-y');
+
+    const overlappingScore = await scoreBridging(overlappingSubject, 'did:plc:partition-test-author');
+    expect(overlappingScore).toBeCloseTo(0.0, 5);
+  });
+});
+
+async function seedLike(subjectUri: string, authorDid: string): Promise<void> {
+  await db.query(
+    `INSERT INTO likes (uri, author_did, subject_uri, created_at)
+     VALUES ($1, $2, $3, NOW())
+     ON CONFLICT (uri, created_at) DO NOTHING`,
+    [`${subjectUri}-like-by-${authorDid}`, authorDid, subjectUri]
+  );
+}
+
+async function seedFollow(authorDid: string, subjectDid: string): Promise<void> {
+  await db.query(
+    `INSERT INTO follows (uri, author_did, subject_did, created_at)
+     VALUES ($1, $2, $3, NOW())
+     ON CONFLICT (uri, created_at) DO NOTHING`,
+    [`at://${authorDid}/app.bsky.graph.follow/${subjectDid.replace(/[^a-zA-Z0-9]/g, '')}`, authorDid, subjectDid]
+  );
+}

--- a/tests/health-db-pool.test.ts
+++ b/tests/health-db-pool.test.ts
@@ -1,0 +1,110 @@
+/**
+ * PROJ-917: proves the health check's `SELECT 1` runs against the
+ * dedicated healthDb pool (src/db/client.ts), not the shared main `db`
+ * pool. Prod incident 2026-07-06: the check previously shared the main
+ * 50-conn pool; main-pool exhaustion starved it, readiness failed, and
+ * systemd's watchdog SIGABRT-killed the service. Splitting the pool means
+ * main-pool exhaustion can no longer take down the one check whose job is
+ * to detect exactly that condition.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbQueryMock, healthDbQueryMock } = vi.hoisted(() => ({
+  dbQueryMock: vi.fn(),
+  healthDbQueryMock: vi.fn(),
+}));
+
+vi.mock('../src/db/client.js', () => ({
+  db: {
+    query: dbQueryMock,
+  },
+  healthDb: {
+    query: healthDbQueryMock,
+  },
+}));
+
+vi.mock('../src/db/redis.js', () => ({
+  redis: {
+    ping: vi.fn().mockResolvedValue('PONG'),
+    zcard: vi.fn().mockResolvedValue(0),
+    get: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { getHealthStatus } from '../src/lib/health.js';
+
+describe('health check dedicated pool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Main pool: only ever hit by checkFeedFreshness's scoring-age lookup
+    // in this suite — keep it healthy/empty so it can't influence the
+    // database component's status.
+    dbQueryMock.mockResolvedValue({ rows: [] });
+  });
+
+  it('queries healthDb (not the main db pool) for the database component', async () => {
+    healthDbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+
+    const status = await getHealthStatus();
+
+    expect(status.components.database.status).toBe('healthy');
+    expect(healthDbQueryMock).toHaveBeenCalledWith('SELECT 1');
+    // The main pool must never see the health probe's own query.
+    expect(dbQueryMock).not.toHaveBeenCalledWith('SELECT 1');
+  });
+
+  it('reports the database component unhealthy when only healthDb fails, even if the main pool is fine', async () => {
+    healthDbQueryMock.mockRejectedValue(new Error('connection timeout exceeded'));
+    dbQueryMock.mockResolvedValue({ rows: [] });
+
+    const status = await getHealthStatus();
+
+    expect(status.components.database.status).toBe('unhealthy');
+    expect(status.components.database.error).toBe('connection timeout exceeded');
+  });
+
+  it('reports the database component healthy when healthDb succeeds, even if a hypothetical main-pool query would have failed', async () => {
+    healthDbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    dbQueryMock.mockRejectedValue(new Error('main pool exhausted'));
+
+    const status = await getHealthStatus();
+
+    // Proves database health is decided entirely by healthDb: main-pool
+    // exhaustion (simulated here by a rejecting dbQueryMock) does not
+    // propagate into the database component at all, since checkFeedFreshness's
+    // internal db.query failure is caught and does not affect this component.
+    expect(status.components.database.status).toBe('healthy');
+  });
+
+  // Thread 22: checkDatabase() races healthDb.query('SELECT 1') against a
+  // 2000ms timeout (src/lib/health.ts HEALTH_CHECK_TIMEOUT) specifically so a
+  // hung/exhausted pool can't wedge readiness forever -- that race is the
+  // whole point of splitting this pool out (see this file's header comment),
+  // so a hang that never resolves or rejects must still trip the timeout.
+  it('reports the database component unhealthy when healthDb hangs past the 2000ms timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      // Never resolves or rejects -- simulates a hung/exhausted pool.
+      healthDbQueryMock.mockImplementation(() => new Promise(() => {}));
+
+      const statusPromise = getHealthStatus();
+      await vi.advanceTimersByTimeAsync(2000);
+      const status = await statusPromise;
+
+      expect(status.components.database.status).toBe('unhealthy');
+      expect(status.components.database.error).toBe('Database health check timed out');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/health-redaction.test.ts
+++ b/tests/health-redaction.test.ts
@@ -1,14 +1,23 @@
 import Fastify from 'fastify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { dbQueryMock, redisPingMock } = vi.hoisted(() => ({
-  dbQueryMock: vi.fn(),
+const { dbQueryMock, healthDbQueryMock, redisPingMock } = vi.hoisted(() => ({
+  dbQueryMock: vi.fn().mockResolvedValue({ rows: [] }),
+  healthDbQueryMock: vi.fn(),
   redisPingMock: vi.fn(),
 }));
 
+// PROJ-917: checkDatabase() in src/lib/health.ts now queries the dedicated
+// healthDb pool (src/db/client.ts), not the shared `db` pool — the "database
+// down/up" scenarios below drive healthDbQueryMock. `dbQueryMock` remains
+// wired to the main pool for the other query checkFeedFreshness makes
+// (current_scoring_run), which this suite doesn't otherwise exercise.
 vi.mock('../src/db/client.js', () => ({
   db: {
     query: dbQueryMock,
+  },
+  healthDb: {
+    query: healthDbQueryMock,
   },
 }));
 
@@ -50,7 +59,7 @@ describe('health response redaction', () => {
   });
 
   it('returns only redacted status for public health when database is down', async () => {
-    dbQueryMock.mockRejectedValue(new Error('db down'));
+    healthDbQueryMock.mockRejectedValue(new Error('db down'));
     redisPingMock.mockResolvedValue('PONG');
 
     const status = await getPublicHealthStatus();
@@ -61,7 +70,7 @@ describe('health response redaction', () => {
   });
 
   it('returns only redacted status for public health when jetstream provider throws', async () => {
-    dbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    healthDbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
     redisPingMock.mockResolvedValue('PONG');
     registerJetstreamHealth(() => {
       throw new Error('jetstream probe failed');
@@ -79,7 +88,7 @@ describe('health response redaction', () => {
   });
 
   it('returns detailed diagnostics for admin health', async () => {
-    dbQueryMock.mockRejectedValue(new Error('db down'));
+    healthDbQueryMock.mockRejectedValue(new Error('db down'));
     redisPingMock.mockResolvedValue('PONG');
 
     const app = Fastify();
@@ -109,7 +118,7 @@ describe('health response redaction', () => {
   });
 
   it('returns degraded admin health when only jetstream is unhealthy', async () => {
-    dbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    healthDbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
     redisPingMock.mockResolvedValue('PONG');
     registerJetstreamHealth(() => ({
       status: 'unhealthy',
@@ -143,7 +152,7 @@ describe('health response redaction', () => {
   });
 
   it('returns unhealthy admin health when database and jetstream are both unhealthy', async () => {
-    dbQueryMock.mockRejectedValue(new Error('db down'));
+    healthDbQueryMock.mockRejectedValue(new Error('db down'));
     redisPingMock.mockResolvedValue('PONG');
     registerJetstreamHealth(() => ({
       status: 'unhealthy',
@@ -182,7 +191,7 @@ describe('health response redaction', () => {
   });
 
   it('returns degraded admin health when jetstream provider throws and critical components are healthy', async () => {
-    dbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    healthDbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
     redisPingMock.mockResolvedValue('PONG');
     registerJetstreamHealth(() => {
       throw new Error('jetstream probe failed');
@@ -225,7 +234,7 @@ describe('health response redaction', () => {
     const { registerScoringHealth: registerScoringHealthFresh } = await import('../src/lib/health.js');
     const { registerAdminHealthRoutes: registerAdminHealthRoutesFresh } = await import('../src/admin/routes/health.js');
 
-    dbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    healthDbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
     redisPingMock.mockResolvedValue('PONG');
     registerScoringHealthFresh(() => ({
       status: 'healthy',
@@ -264,7 +273,7 @@ describe('health response redaction', () => {
       registerScoringHealth: registerScoringHealthFresh,
     } = await import('../src/lib/health.js');
 
-    dbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    healthDbQueryMock.mockResolvedValue({ rows: [{ '?column?': 1 }] });
     redisPingMock.mockResolvedValue('PONG');
     registerScoringHealthFresh(() => ({
       status: 'healthy',

--- a/tests/migrate-bootstrap.test.ts
+++ b/tests/migrate-bootstrap.test.ts
@@ -5,6 +5,7 @@ import {
   bootstrapLegacyMigrations,
   MigrationVerificationError,
   shouldRunMigrationInTransaction,
+  splitSqlStatements,
   verifyRequiredMigrationSideEffects,
 } from '../scripts/migrate.ts';
 
@@ -40,6 +41,66 @@ describe('migration bootstrap for legacy schemas', () => {
       'public',
       'idx_scores_epoch_run_total',
     ]);
+  });
+
+  // PROJ-917 thread 8: migration 025 builds three CREATE INDEX CONCURRENTLY
+  // indexes; verify all three get checked for indisvalid=true, not just one.
+  it('verifies all three created_at indexes for migration 025', async () => {
+    const checkedIndexNames: unknown[] = [];
+    const queryMock = vi.fn(async (_sql: unknown, params?: unknown[]) => {
+      checkedIndexNames.push(params?.[2]);
+      return { rows: [{ index_exists: true, index_is_valid: true }] };
+    });
+
+    await expect(
+      verifyRequiredMigrationSideEffects(
+        asClient(queryMock as Client['query']),
+        '025_raw_event_created_at_indexes.sql'
+      )
+    ).resolves.toBeUndefined();
+
+    expect(checkedIndexNames).toEqual([
+      'idx_follows_created',
+      'idx_reposts_created',
+      'idx_likes_created',
+    ]);
+  });
+
+  it('refuses to mark migration 025 applied when any one of the three indexes is invalid', async () => {
+    const queryMock = vi.fn(async (_sql: unknown, params?: unknown[]) => {
+      const indexName = params?.[2];
+      if (indexName === 'idx_likes_created') {
+        return { rows: [{ index_exists: true, index_is_valid: false }] };
+      }
+      return { rows: [{ index_exists: true, index_is_valid: true }] };
+    });
+
+    await expect(
+      verifyRequiredMigrationSideEffects(
+        asClient(queryMock as Client['query']),
+        '025_raw_event_created_at_indexes.sql'
+      )
+    ).rejects.toThrow(MigrationVerificationError);
+  });
+
+  it('refuses to mark migration 025 applied when an index is missing (to_regclass null)', async () => {
+    // The other failure branch: CREATE INDEX CONCURRENTLY never ran or was
+    // rolled back, so the index does not exist at all (distinct from existing-
+    // but-invalid).
+    const queryMock = vi.fn(async (_sql: unknown, params?: unknown[]) => {
+      const indexName = params?.[2];
+      if (indexName === 'idx_reposts_created') {
+        return { rows: [{ index_exists: false, index_is_valid: false }] };
+      }
+      return { rows: [{ index_exists: true, index_is_valid: true }] };
+    });
+
+    await expect(
+      verifyRequiredMigrationSideEffects(
+        asClient(queryMock as Client['query']),
+        '025_raw_event_created_at_indexes.sql'
+      )
+    ).rejects.toThrow(MigrationVerificationError);
   });
 
   it('refuses to mark migration 024 applied when the concurrent index is invalid', async () => {
@@ -106,6 +167,20 @@ describe('migration bootstrap for legacy schemas', () => {
     expect(applied.has('001_initial_schema.sql')).toBe(true);
     expect(applied.has('002_scoring_tables.sql')).toBe(false);
     expect(inserted).toEqual(['001_initial_schema.sql']);
+  });
+
+  // PROJ-917 / thread 6: the dollar-quote tag regex previously only allowed
+  // `[a-zA-Z_]*` (no digits), so a tag like `$tag1$` was not recognized as a
+  // dollar-quote delimiter at all, and a `;` inside that block would be
+  // mis-split as a statement boundary.
+  it('does not split on a semicolon inside a $tag1$ ... $tag1$ dollar-quoted block', () => {
+    const sql = `DO $tag1$ BEGIN RAISE NOTICE 'a;b'; END $tag1$;`;
+    expect(splitSqlStatements(sql)).toEqual([sql.replace(/;$/, '')]);
+  });
+
+  it('does not split on a semicolon inside a $$ ... $$ dollar-quoted block', () => {
+    const sql = `DO $$ BEGIN RAISE NOTICE 'a;b'; END $$;`;
+    expect(splitSqlStatements(sql)).toEqual([sql.replace(/;$/, '')]);
   });
 
   it('does not bootstrap on fresh schema without sentinel tables', async () => {

--- a/tests/normalize-timestamp.test.ts
+++ b/tests/normalize-timestamp.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCreatedAt } from '../src/ingestion/normalize-timestamp.js';
+
+const NOW = Date.parse('2026-07-08T00:00:00.000Z');
+
+// Encode epoch-ms into a valid AT Protocol TID rkey (inverse of the decoder),
+// so tests can exercise the rkey-fallback path with a real TID.
+const TID_ALPHABET = '234567abcdefghijklmnopqrstuvwxyz';
+function millisToTid(ms: number): string {
+  let value = (BigInt(ms) * 1000n) << 10n; // micros << 10, clockid 0
+  let s = '';
+  for (let i = 0; i < 13; i++) {
+    s = TID_ALPHABET[Number(value % 32n)] + s;
+    value /= 32n;
+  }
+  return s;
+}
+const TID_MS = Date.parse('2026-06-20T12:00:00.000Z');
+const uriWithTid = (ms: number) => `at://did:plc:abc/app.bsky.feed.like/${millisToTid(ms)}`;
+
+describe('normalizeCreatedAt', () => {
+  it('passes through a valid past client timestamp (canonical ISO)', () => {
+    expect(normalizeCreatedAt('2026-07-01T12:00:00.000Z', uriWithTid(TID_MS), NOW)).toBe(
+      '2026-07-01T12:00:00.000Z'
+    );
+  });
+
+  it('normalizes a non-canonical but valid past date to canonical ISO', () => {
+    expect(normalizeCreatedAt('2026-07-01', uriWithTid(TID_MS), NOW)).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('does NOT trust a timezone-less datetime (Date.parse reads it as local time) — falls back to the rkey', () => {
+    // "2026-07-05T12:00:00" has no Z/offset, so different workers/timezones
+    // would resolve it to different instants and miss ON CONFLICT dedup. Must
+    // resolve deterministically from the record key instead.
+    expect(normalizeCreatedAt('2026-07-05T12:00:00', uriWithTid(TID_MS), NOW)).toBe(
+      new Date(TID_MS).toISOString()
+    );
+  });
+
+  it('falls back to the record-key TID for a far-future createdAt (2056)', () => {
+    // Not the 2056 value, not now — the record key's real creation time.
+    expect(normalizeCreatedAt('2056-01-01T00:00:00.000Z', uriWithTid(TID_MS), NOW)).toBe(
+      new Date(TID_MS).toISOString()
+    );
+  });
+
+  it('falls back to the record-key TID for a missing createdAt', () => {
+    expect(normalizeCreatedAt(undefined, uriWithTid(TID_MS), NOW)).toBe(new Date(TID_MS).toISOString());
+  });
+
+  it('is STABLE across redelivery — same (raw, uri) yields the same value regardless of now', () => {
+    // The dedup-safety property: ON CONFLICT (uri, created_at) only works if a
+    // redelivered event resolves to the identical created_at each time.
+    const later = NOW + 5 * 60_000;
+    const uri = uriWithTid(TID_MS);
+    expect(normalizeCreatedAt('2056-01-01T00:00:00.000Z', uri, NOW)).toBe(
+      normalizeCreatedAt('2056-01-01T00:00:00.000Z', uri, later)
+    );
+    expect(normalizeCreatedAt(undefined, uri, NOW)).toBe(normalizeCreatedAt(undefined, uri, later));
+  });
+
+  it('uses a deterministic epoch sentinel when both createdAt and rkey are unusable', () => {
+    const uri = 'at://did:plc:abc/app.bsky.feed.like/self'; // rkey is not a TID
+    expect(normalizeCreatedAt(undefined, uri, NOW)).toBe('1970-01-01T00:00:00.000Z');
+    expect(normalizeCreatedAt('not-a-date', uri, NOW)).toBe('1970-01-01T00:00:00.000Z');
+  });
+
+  it('keeps a genuinely old client timestamp (retention ages it out, not the clamp)', () => {
+    expect(normalizeCreatedAt('2013-01-01T00:00:00.000Z', uriWithTid(TID_MS), NOW)).toBe(
+      '2013-01-01T00:00:00.000Z'
+    );
+  });
+});

--- a/tests/scoring-longtable-dualwrite.test.ts
+++ b/tests/scoring-longtable-dualwrite.test.ts
@@ -153,13 +153,14 @@ describe('scoring pipeline long-table dual-write (PROJ-814)', () => {
     const longCall = findCall('INSERT INTO post_score_components');
     expect(longCall).toBeDefined();
 
-    // Params layout: 6 columns × N components. Default registry → 5 components → 30 params.
+    // Params layout: 7 columns × N components (PROJ-917 added created_at, the
+    // partition key, bound per row). Default registry → 5 components → 35 params.
     const params = longCall![1] as unknown[];
-    expect(params.length).toBe(5 * 6);
+    expect(params.length).toBe(5 * 7);
 
-    // Verify the component_key column is the 3rd of each 6-tuple and matches the
+    // Verify the component_key column is the 3rd of each 7-tuple and matches the
     // registry order in DEFAULT_COMPONENTS.
-    const componentKeys = [params[2], params[8], params[14], params[20], params[26]];
+    const componentKeys = [params[2], params[9], params[16], params[23], params[30]];
     expect(componentKeys).toEqual([
       'recency',
       'engagement',
@@ -167,6 +168,15 @@ describe('scoring pipeline long-table dual-write (PROJ-814)', () => {
       'sourceDiversity',
       'relevance',
     ]);
+
+    // created_at (7th of each tuple) is bound directly from the scored post, not
+    // re-looked-up via `(SELECT created_at FROM posts WHERE uri = ...)` — that
+    // subquery is unsafe once uri stops being unique on its own.
+    const sql = String(longCall![0]);
+    expect(sql).not.toMatch(/SELECT created_at FROM posts/);
+    for (const idx of [6, 13, 20, 27, 34]) {
+      expect(params[idx]).toBeInstanceOf(Date);
+    }
   });
 
   it('skips the long-table write when flag is off', async () => {
@@ -205,8 +215,10 @@ describe('scoring pipeline long-table dual-write (PROJ-814)', () => {
     expect(longCall).toBeDefined();
 
     const sql = String(longCall![0]);
+    // PROJ-917: post_score_components' PK widened to include created_at
+    // (the partition key) — see migration 029.
     expect(sql).toMatch(
-      /ON CONFLICT \(post_uri, epoch_id, component_key\) DO UPDATE SET/
+      /ON CONFLICT \(post_uri, epoch_id, component_key, created_at\) DO UPDATE SET/
     );
     // Update clause must refresh all three numeric columns plus scored_at.
     expect(sql).toMatch(/raw = EXCLUDED\.raw/);

--- a/tests/stress/concurrent-writes.stress.ts
+++ b/tests/stress/concurrent-writes.stress.ts
@@ -24,9 +24,11 @@ export async function runConcurrentWritesStress(): Promise<ScenarioResult> {
     await db.query('TRUNCATE TABLE likes, post_engagement, posts, engagement_attributions RESTART IDENTITY CASCADE');
 
     await db.query(
+      // PROJ-917: posts' PK widened to (uri, created_at) — partitioned
+      // tables require the partition key in every unique constraint.
       `INSERT INTO posts (uri, cid, author_did, text, created_at, indexed_at, deleted)
        VALUES ($1, $2, $3, $4, NOW(), NOW(), FALSE)
-       ON CONFLICT (uri) DO NOTHING`,
+       ON CONFLICT (uri, created_at) DO NOTHING`,
       [postUri, 'cid-concurrent', 'did:plc:concurrent-author', 'concurrent write stress target']
     );
 


### PR DESCRIPTION
## Why

Production was on a verified path to disk exhaustion (root disk hit 100% during this work; growth ~2.3 GiB/day). Root cause: the app ingests the Bluesky firehose into permanent, unpartitioned tables, while the existing guarded-DELETE retention (`cleanup.ts`) **silently failed on every run** — the six event tables had no `created_at` index, so each retention DELETE seq-scanned tens of millions of rows and hit the 120s statement timeout (SQLSTATE 57014), deleting nothing. Even after adding the indexes, the `NOT EXISTS post_scores` anti-join provably cannot use them at 48M-row scale (confirmed on prod with EXPLAIN across default / ORDER BY / hashjoin-off plans — all seq-scan or time out).

## What

A **stop-the-line rebuild** (appropriate for the current no-real-users phase) to native declarative **RANGE-partitioning by `created_at`** on `likes`, `reposts`, `follows`, `posts`, `post_scores`, `post_score_components`. Retention becomes an instant `DETACH PARTITION` + `DROP` (metadata-only, independent of row count) via `src/maintenance/partition-manager.ts` — 14d for raw events, 30d for content/scores. Governance tables are untouched.

Key design decisions (see migration headers for full PG16 doc citations):
- PKs widen to include `created_at` (PG16 requires the partition key in every unique constraint).
- `post_scores`/`post_score_components` gain a **denormalized immutable `created_at`** (= the post's, not `scored_at`, which changes on every rescore and would trigger cross-partition row migration).
- The three `... -> posts(uri)` FKs are dropped (can't reference a partitioned PK; keeping them would force a lock on every partition drop). Integrity is preserved by construction + an app-level cascade in the partition-manager + orphan sweeps in `cleanup.ts`.

Also in this PR:
- **Guardrails**: the harmful emergency `VACUUM FULL` (which ENOSPC'd on prod and starved the pool) replaced with a free-space-safe recovery set; a **dedicated health-check DB pool** (removes the pool-exhaustion path that SIGABRT-killed the service); the phantom `POST /api/admin/trigger-cleanup` implemented (the watchdog no longer calls it blind).
- **Postgres tuning** (`docker-compose.prod.yml` + migration 030): shared_buffers 4GB, work_mem 32MB, maintenance_work_mem 512MB, per-partition autovacuum (baked into the partition-creation helper — storage params can't be set on partitioned parents), images digest-pinned.
- **Timestamp clamp** (`normalizeCreatedAt`): client-supplied `createdAt` is clamped to now (prod has 2030/2056 values that would leak into the DEFAULT partition forever and max the recency score).
- **pgBackRest** config + runbook + restore-drill (`ops/pgbackrest/`) — local repo + DO Spaces offsite, PITR. Artifacts only; not live-tested (needs creds + running PG).

## Validation

- Unit suite **926 passing**; Testcontainers harness suite **196 passing** on real postgres:16 (includes a dedicated `partition-lifecycle.sim.ts` proving create-ahead, instant partition-drop, the app-level cascade, and scoring-query correctness against the partitioned schema).
- Prod schema audit: only the 3 expected FKs; no views/triggers/sequences/checks/generated-columns.
- Scale rehearsal (20M-row throwaway PG): the 14d windowed copy = 9.3M rows in ~2 min (full cutover ~10-15 min); partition pruning confirmed (13 subplans removed).

## Cutover

This is not applied by CI — it runs in a maintenance window per `docs/PARTITION_REBUILD.md` (resize droplet to 200GB **first**, deploy code, migrate, verify, drop legacy). Full backup + snapshot taken before.

## For reviewers / open questions

- `cleanup.ts` retains its fine-grained deleters (72h-unscored-posts, orphan sweeps) alongside partition-drop. They're correct and harmless, but their role in the partitioned model is worth a deliberate look — happy to trim to just the orphan sweeps if preferred.
- Apply-time items handled by the operator, not this PR: DO Spaces credentials, pgBackRest install path (README documents container-vs-sidecar), and the maintenance-window schedule.