### PR TITLE
[PROJ-917] Prune cross-partition score reads by created_at; harden retention

### DIFF
--- a/src/admin/routes/audit-analysis.ts
+++ b/src/admin/routes/audit-analysis.ts
@@ -461,9 +461,12 @@ export function registerAuditAnalysisRoutes(app: FastifyInstance): void {
            MAX(psc.raw) FILTER (WHERE psc.component_key = 'sourceDiversity') AS source_diversity_score,
            MAX(psc.raw) FILTER (WHERE psc.component_key = 'relevance') AS relevance_score
          FROM post_scores ps
-         LEFT JOIN posts p ON p.uri = ps.post_uri
+         -- created_at equality is the shared partition key (posts / post_scores
+         -- / post_score_components are all RANGE-partitioned by the post's
+         -- immutable created_at) — prunes each probe to one partition (PROJ-917).
+         LEFT JOIN posts p ON p.uri = ps.post_uri AND p.created_at = ps.created_at
          LEFT JOIN post_score_components psc
-           ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id
+           ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id AND psc.created_at = ps.created_at
          WHERE ps.epoch_id = $1
            AND ps.post_uri = ANY($2::text[])
            ${runScopeClause}
@@ -478,7 +481,9 @@ export function registerAuditAnalysisRoutes(app: FastifyInstance): void {
            ps.source_diversity_score,
            ps.relevance_score
          FROM post_scores ps
-         LEFT JOIN posts p ON p.uri = ps.post_uri
+         -- p.created_at = ps.created_at: shared partition key, prunes the posts
+         -- probe to one partition per score row (PROJ-917).
+         LEFT JOIN posts p ON p.uri = ps.post_uri AND p.created_at = ps.created_at
          WHERE ps.epoch_id = $1
            AND ps.post_uri = ANY($2::text[])
            ${runScopeClause}`;

--- a/src/admin/routes/export.ts
+++ b/src/admin/routes/export.ts
@@ -86,7 +86,10 @@ const SCORE_EXPORT_SQL_WIDE_BASE = `
          ps.source_diversity_weighted, ps.relevance_weighted,
          ps.total_score, p.topic_vector, ps.classification_method, ps.scored_at
   FROM post_scores ps
-  LEFT JOIN posts p ON ps.post_uri = p.uri
+  -- p.created_at = ps.created_at is the shared partition key (both RANGE-
+  -- partitioned by the post's immutable created_at); prunes the posts probe to
+  -- one partition per score row instead of all ~36 (PROJ-917).
+  LEFT JOIN posts p ON ps.post_uri = p.uri AND p.created_at = ps.created_at
   WHERE ps.epoch_id = $1
   ORDER BY ps.total_score DESC
 `;
@@ -110,9 +113,11 @@ const SCORE_EXPORT_SQL_LONG_BASE = `
          MAX(psc.weighted) FILTER (WHERE psc.component_key = 'relevance') AS relevance_weighted,
          ps.total_score, p.topic_vector, ps.classification_method, ps.scored_at
   FROM post_scores ps
-  LEFT JOIN posts p ON ps.post_uri = p.uri
+  -- created_at equality on both JOINs is the shared partition key (PROJ-917) —
+  -- prunes each probe to one partition per score row instead of all ~36.
+  LEFT JOIN posts p ON ps.post_uri = p.uri AND p.created_at = ps.created_at
   LEFT JOIN post_score_components psc
-    ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id
+    ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id AND psc.created_at = ps.created_at
   WHERE ps.epoch_id = $1
   GROUP BY ps.post_uri, ps.epoch_id, ps.total_score, p.topic_vector, ps.classification_method, ps.scored_at
   ORDER BY ps.total_score DESC

--- a/src/admin/routes/vitals.ts
+++ b/src/admin/routes/vitals.ts
@@ -84,14 +84,18 @@ export function registerVitalsRoutes(app: FastifyInstance): void {
       ),
       safeQuery<{ dead_count: string; total_scored: string }>(
         `SELECT
-           COUNT(*) FILTER (WHERE ps.final_score IS NOT NULL AND NOT EXISTS (
+           COUNT(*) FILTER (WHERE ps.total_score IS NOT NULL AND NOT EXISTS (
              SELECT 1 FROM likes l WHERE l.subject_uri = p.uri
            ) AND NOT EXISTS (
              SELECT 1 FROM reposts r WHERE r.subject_uri = p.uri
            )) as dead_count,
            COUNT(*) as total_scored
          FROM posts p
-         JOIN post_scores ps ON ps.uri = p.uri
+         -- Join column is ps.post_uri (post_scores has no plain uri column), plus
+         -- the created_at partition-key predicate: post_scores is RANGE-partitioned
+         -- by created_at (denormalized 1:1 from posts.created_at), so this prunes
+         -- the probe to one partition per post instead of all ~36 (PROJ-917).
+         JOIN post_scores ps ON ps.post_uri = p.uri AND ps.created_at = p.created_at
          WHERE p.indexed_at > NOW() - INTERVAL '24 hours' AND p.deleted = FALSE`
       ),
     ]);

--- a/src/maintenance/partition-manager.ts
+++ b/src/maintenance/partition-manager.ts
@@ -463,6 +463,11 @@ async function detachAndDropPartition(parentTable: string, partitionTable: strin
   let lastErr: unknown;
   for (let attempt = 1; attempt <= DETACH_RETRY_ATTEMPTS; attempt++) {
     const client = await db.connect();
+    // If ROLLBACK itself fails, the connection's transaction state is unknown;
+    // pass that error to release() so pg-pool DESTROYS the connection instead of
+    // returning a possibly-broken one to the pool. A clean rollback leaves this
+    // undefined and the connection is reused normally.
+    let releaseError: Error | undefined;
     try {
       await client.query('BEGIN');
       await client.query("SET LOCAL lock_timeout = '5s'");
@@ -471,8 +476,10 @@ async function detachAndDropPartition(parentTable: string, partitionTable: strin
       await client.query('COMMIT');
       return;
     } catch (err) {
-      await client.query('ROLLBACK').catch(() => {});
       lastErr = err;
+      await client.query('ROLLBACK').catch((rollbackErr) => {
+        releaseError = rollbackErr instanceof Error ? rollbackErr : new Error(String(rollbackErr));
+      });
       if (attempt < DETACH_RETRY_ATTEMPTS) {
         logger.warn(
           { parentTable, partitionTable, attempt, err },
@@ -481,7 +488,7 @@ async function detachAndDropPartition(parentTable: string, partitionTable: strin
         await sleep(DETACH_RETRY_BACKOFF_MS);
       }
     } finally {
-      client.release();
+      client.release(releaseError);
     }
   }
   throw lastErr;

--- a/src/maintenance/partition-manager.ts
+++ b/src/maintenance/partition-manager.ts
@@ -58,8 +58,19 @@ const BATCH_SIZE = 5000;
 const DROP_LOOKBACK_BUFFER_DAYS = 90;
 /** How many days ahead of today to guarantee a partition exists. */
 const CREATE_AHEAD_DAYS = 2;
+/** DETACH PARTITION needs a brief ACCESS EXCLUSIVE lock the constantly-written
+ *  posts/post_scores tables rarely grant on the first try; retry a few times
+ *  within the run (each attempt keeps the short 5s lock_timeout) to catch a
+ *  quieter moment before deferring the partition to the next daily run. */
+const DETACH_RETRY_ATTEMPTS = 3;
+const DETACH_RETRY_BACKOFF_MS = 3000;
 
 const IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/** Resolve after `ms` milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 interface PartitionedTableSpec {
   /** Live table name (also used as the partition-name prefix). */
@@ -441,19 +452,39 @@ async function detachAndDropPartition(parentTable: string, partitionTable: strin
   // retried on the next run (the drop-lookback buffer drains any backlog).
   // DETACH + DROP run in one transaction so the drop can't leave a detached
   // orphan table behind.
-  const client = await db.connect();
-  try {
-    await client.query('BEGIN');
-    await client.query("SET LOCAL lock_timeout = '5s'");
-    await client.query(`ALTER TABLE ${quoteIdent(parentTable)} DETACH PARTITION ${quoteIdent(partitionTable)}`);
-    await client.query(`DROP TABLE ${quoteIdent(partitionTable)}`);
-    await client.query('COMMIT');
-  } catch (err) {
-    await client.query('ROLLBACK').catch(() => {});
-    throw err;
-  } finally {
-    client.release();
+  //
+  // Retry a few times within the run: the constantly-written high-volume tables
+  // (posts, post_scores) rarely have a clear 5s window on the first try, so a
+  // single attempt loses the drop for the whole day (observed 2026-07-08:
+  // likes/reposts/follows dropped but posts/post_scores hit "lock timeout").
+  // Each attempt keeps the SHORT 5s lock_timeout so a waiting ACCESS EXCLUSIVE
+  // never queues long enough to stall writers — we back off and try again for a
+  // quieter moment rather than holding the lock request open.
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= DETACH_RETRY_ATTEMPTS; attempt++) {
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query("SET LOCAL lock_timeout = '5s'");
+      await client.query(`ALTER TABLE ${quoteIdent(parentTable)} DETACH PARTITION ${quoteIdent(partitionTable)}`);
+      await client.query(`DROP TABLE ${quoteIdent(partitionTable)}`);
+      await client.query('COMMIT');
+      return;
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      lastErr = err;
+      if (attempt < DETACH_RETRY_ATTEMPTS) {
+        logger.warn(
+          { parentTable, partitionTable, attempt, err },
+          'DETACH PARTITION lock attempt failed; retrying after backoff'
+        );
+        await sleep(DETACH_RETRY_BACKOFF_MS);
+      }
+    } finally {
+      client.release();
+    }
   }
+  throw lastErr;
 }
 
 /**

--- a/src/maintenance/worker-supervisor.ts
+++ b/src/maintenance/worker-supervisor.ts
@@ -50,7 +50,19 @@ export interface WorkerSupervisor {
   isRunning: () => boolean;
 }
 
+// Order matters: workers start SEQUENTIALLY (see start() below), each awaiting
+// an initial pass. partition-manager goes FIRST so retention (DETACH/DROP of
+// aged partitions) runs before the cleanup worker's deletes start contending
+// for ACCESS EXCLUSIVE on posts/post_scores — otherwise the startup DETACH
+// loses its lock window and posts/post_scores partitions don't drop (observed
+// 2026-07-08, PROJ-917).
 const defaultWorkers: ManagedWorker[] = [
+  {
+    name: 'partition-manager',
+    start: startPartitionManager,
+    stop: stopPartitionManager,
+    isRunning: isPartitionManagerRunning,
+  },
   {
     name: 'cleanup',
     start: startCleanup,
@@ -74,12 +86,6 @@ const defaultWorkers: ManagedWorker[] = [
     start: startDiskMonitor,
     stop: stopDiskMonitor,
     isRunning: isDiskMonitorRunning,
-  },
-  {
-    name: 'partition-manager',
-    start: startPartitionManager,
-    stop: stopPartitionManager,
-    isRunning: isPartitionManagerRunning,
   },
 ];
 

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -478,7 +478,13 @@ async function getPostsForIncrementalScoring(
              COALESCE(pe.reply_count, 0) as reply_count
       FROM posts p
       LEFT JOIN post_engagement pe ON p.uri = pe.post_uri
-      LEFT JOIN post_scores ps ON p.uri = ps.post_uri AND ps.epoch_id = $2
+      -- ps.created_at = p.created_at is the partition key: post_scores is
+      -- RANGE-partitioned by created_at (a denormalized, immutable 1:1 copy of
+      -- posts.created_at), so this predicate lets the planner runtime-prune the
+      -- post_scores lookup to the one matching daily partition instead of
+      -- probing all ~36. Without it the anti-join scans every partition per
+      -- candidate post and the whole pipeline times out (PROJ-917).
+      LEFT JOIN post_scores ps ON p.uri = ps.post_uri AND ps.epoch_id = $2 AND ps.created_at = p.created_at
       WHERE p.deleted = FALSE
         AND p.created_at > $1
         AND p.created_at <= NOW()
@@ -497,7 +503,9 @@ async function getPostsForIncrementalScoring(
              COALESCE(pe.reply_count, 0) as reply_count
       FROM posts p
       INNER JOIN post_engagement pe ON p.uri = pe.post_uri
-      INNER JOIN post_scores ps ON p.uri = ps.post_uri AND ps.epoch_id = $2
+      -- Partition-key predicate (ps.created_at = p.created_at) — see the first
+      -- UNION half above; enables runtime partition pruning of post_scores.
+      INNER JOIN post_scores ps ON p.uri = ps.post_uri AND ps.epoch_id = $2 AND ps.created_at = p.created_at
       WHERE p.deleted = FALSE
         AND p.created_at > $1
         AND p.created_at <= NOW()
@@ -772,11 +780,21 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<void>
     `SELECT ps.post_uri, ps.total_score, p.embed_url,
             COALESCE(LENGTH(p.text), 0) as text_length
      FROM post_scores ps
-     INNER JOIN posts p ON p.uri = ps.post_uri
+     -- p.created_at = ps.created_at is the partition key (posts is
+     -- RANGE-partitioned by created_at); pairing it with the p.created_at
+     -- window below lets both posts and post_scores prune to the same handful
+     -- of daily partitions instead of scanning all ~36 (PROJ-917).
+     INNER JOIN posts p ON p.uri = ps.post_uri AND p.created_at = ps.created_at
      WHERE ps.epoch_id = $1
        AND p.deleted = FALSE
        AND p.created_at > $3
        AND p.created_at <= NOW()
+       -- Explicit cutoff on post_scores.created_at as well (identical to
+       -- p.created_at via the join equality). This epoch-driven query plans as a
+       -- hash join, which — unlike the nested-loop incremental query — does NOT
+       -- runtime-prune post_scores from the join alone; the explicit predicate
+       -- prunes the post_scores scan to the 72h partitions (18.7s -> 2.6s).
+       AND ps.created_at > $3
        AND ps.relevance_score >= $4
      ORDER BY ps.total_score DESC
      LIMIT $2`,

--- a/src/scoring/score-reader.ts
+++ b/src/scoring/score-reader.ts
@@ -189,7 +189,10 @@ async function readPostScoreFromLongTable({
   }>(
     `SELECT psc.component_key, psc.raw, psc.weight, psc.weighted
      FROM post_score_components psc
-     JOIN post_scores ps ON ps.post_uri = psc.post_uri AND ps.epoch_id = psc.epoch_id
+     -- ps.created_at = psc.created_at is the shared partition key (both tables
+     -- are RANGE-partitioned by the post's immutable created_at); it prunes the
+     -- post_scores probe to one partition instead of all ~36 (PROJ-917).
+     JOIN post_scores ps ON ps.post_uri = psc.post_uri AND ps.epoch_id = psc.epoch_id AND ps.created_at = psc.created_at
      WHERE psc.post_uri = $1 AND psc.epoch_id = $2 ${runClause}`,
     params
   );
@@ -270,7 +273,9 @@ export async function readPostScoresForEpoch(options: {
          jsonb_object_agg(psc.component_key, psc.weighted) FILTER (WHERE psc.component_key IS NOT NULL) AS components_weighted
        FROM post_scores ps
        LEFT JOIN post_score_components psc
-         ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id
+         -- psc.created_at = ps.created_at: shared partition key, prunes the
+         -- component probe to one partition per score row (PROJ-917).
+         ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id AND psc.created_at = ps.created_at
        WHERE ps.epoch_id = $1 ${runClause}
        GROUP BY ps.post_uri, ps.total_score
        ORDER BY ps.total_score DESC
@@ -374,7 +379,9 @@ export async function readEpochComponentStats(options: {
            COUNT(*)::text as count
          FROM post_scores ps
          JOIN post_score_components psc
-           ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id
+           -- psc.created_at = ps.created_at: shared partition key, runtime-prunes
+           -- the component probe to one partition per score row (PROJ-917).
+           ON psc.post_uri = ps.post_uri AND psc.epoch_id = ps.epoch_id AND psc.created_at = ps.created_at
          WHERE ps.epoch_id = $1
            AND psc.component_key = $2
            AND ps.component_details->>'run_id' = $${params.length}`,
@@ -482,7 +489,9 @@ export async function countPostsWithComponentAbove(options: {
     const result = await db.query<{ count: string }>(
       `SELECT COUNT(*)::text AS count
        FROM post_score_components psc
-       JOIN post_scores ps ON ps.post_uri = psc.post_uri AND ps.epoch_id = psc.epoch_id
+       -- ps.created_at = psc.created_at: shared partition key, prunes the
+       -- post_scores probe to one partition per component row (PROJ-917).
+       JOIN post_scores ps ON ps.post_uri = psc.post_uri AND ps.epoch_id = psc.epoch_id AND ps.created_at = psc.created_at
        WHERE psc.epoch_id = $1
          AND psc.component_key = $2
          AND psc.raw > $3

--- a/src/transparency/routes/feed-stats.ts
+++ b/src/transparency/routes/feed-stats.ts
@@ -148,7 +148,10 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
            COUNT(DISTINCT p.author_did)::text as unique_authors,
            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.total_score)::text as median_total
          FROM post_scores ps
-         JOIN posts p ON ps.post_uri = p.uri
+         -- p.created_at = ps.created_at is the shared partition key (posts is
+         -- RANGE-partitioned by created_at); prunes the posts probe to one
+         -- partition per score row instead of all ~36 (PROJ-917).
+         JOIN posts p ON ps.post_uri = p.uri AND p.created_at = ps.created_at
          WHERE ps.epoch_id = $1
            ${runScopeClause}`,
         baseStatsParams


### PR DESCRIPTION
## Problem

The partition rebuild (#307) RANGE-partitioned `post_scores` / `post_score_components` by a denormalized `created_at` and updated the **write** path, but every **read/JOIN** still matched on `post_uri`/`epoch_id` only. On the partitioned tables the planner could not prune, so it scanned **all ~36 partitions per row**. Incremental scoring (`getPostsForIncrementalScoring`) then timed out every 5 min at the 30s `DB_STATEMENT_TIMEOUT`, **freezing the live feed** on its first snapshot; feed-stats and admin reads regressed the same way.

## Fix

Add `<child>.created_at = <parent>.created_at` to every cross-partition JOIN (safe: `created_at` is the immutable, 1:1 denormalized copy of the post's `created_at`).

Verified on prod via `EXPLAIN ANALYZE`:
- Incremental anti-join: **timeout → 14s** (runtime partition pruning — 32/36 `post_scores` partitions `never executed`).
- Feed-build query (`writeToRedisFromDb`) plans as a hash join that doesn't runtime-prune from the join alone, so it also gets an explicit `ps.created_at > cutoff` (identical via the equality): **18.7s → 2.6s**.

## Retention hardening

posts/post_scores `DETACH` hit a 5s lock timeout on the constantly-written tables and didn't drop (2026-07-08):
- **partition-manager**: retry `DETACH` a few times within a run (short 5s `lock_timeout` each) to catch a quieter window before deferring to the next daily run.
- **worker-supervisor**: start partition-manager **before** the lock-heavy cleanup worker so startup retention runs without contending for `ACCESS EXCLUSIVE`.

## Also
- Fixes a stale `ps.uri`/`ps.final_score` in the admin vitals query (`post_scores` has neither column).
- feed-stats' epoch-wide driving scan remains slow pending the deferred stats-materialization work; the join predicate there is correct and neutral until then.

## Verification
- `tsc` clean; full mocked suite (944 tests) green.
- EXPLAIN ANALYZE on prod confirms pruning + timings above.
- Post-merge: deploy, confirm scoring runs green (unfreezes the feed), then drop the retained `_legacy` tables.