### PR TITLE
[PROJ-917] Raise DB statement_timeout to 60s for scoring; drop per-query transaction

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -157,8 +157,15 @@ export const ConfigSchema = z.object({
   // Database pool tuning
   /** Max connections in the PostgreSQL connection pool. */
   DB_POOL_MAX: z.coerce.number().min(5).default(50),
-  /** Statement timeout in milliseconds (prevents runaway queries). */
-  DB_STATEMENT_TIMEOUT: z.coerce.number().min(1000).default(30_000),
+  /**
+   * Statement timeout in milliseconds (prevents runaway queries). 60s, not 30s:
+   * the heaviest legitimate query in the system — the incremental scoring
+   * candidate UNION (src/scoring/pipeline.ts) — scans the full 72h firehose
+   * window and runs ~20-30s at current volume even after partition pruning. The
+   * dedicated health-check pool keeps its own tight 5s timeout (src/db/client.ts),
+   * so readiness is unaffected by this higher app-query cap.
+   */
+  DB_STATEMENT_TIMEOUT: z.coerce.number().min(1000).default(60_000),
 
   // Feed output: minimum relevance score to appear in feed
   FEED_MIN_RELEVANCE: z.coerce.number().min(0).max(1).default(0.15),

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -40,22 +40,6 @@ import { updateScoringStatus } from '../admin/status-tracker.js';
 // Maximum time allowed for a single scoring run.
 const SCORING_TIMEOUT_MS = config.SCORING_TIMEOUT_MS;
 const SCORING_CANDIDATE_LIMIT = config.SCORING_CANDIDATE_LIMIT;
-// Per-statement timeout for the incremental candidate query specifically: it
-// scans the full 72h firehose window and legitimately runs ~20-30s at current
-// volume, above the pool default (DB_STATEMENT_TIMEOUT, 30s). Applied via
-// SET LOCAL inside a read-only transaction so it does not weaken the global cap
-// for any other query. Still well under SCORING_TIMEOUT_MS (the pipeline bound).
-const INCREMENTAL_SCORING_STATEMENT_TIMEOUT = '120s';
-// Defense-in-depth: this constant is interpolated into `SET LOCAL
-// statement_timeout` (which cannot use a bind parameter). It is an internal
-// literal today, but assert it is a plain duration literal at module load so it
-// can never become a SQL-injection vector if a future change sources it from
-// config/env.
-if (!/^\d+\s*(ms|s|min|h)?$/.test(INCREMENTAL_SCORING_STATEMENT_TIMEOUT)) {
-  throw new Error(
-    `INCREMENTAL_SCORING_STATEMENT_TIMEOUT must be a plain duration literal, got: ${INCREMENTAL_SCORING_STATEMENT_TIMEOUT}`
-  );
-}
 const SQL_BOUNDARY_KEYWORD_PATTERN = /^[a-z0-9][a-z0-9\s-]*$/;
 
 // Track last successful run for health checks
@@ -534,28 +518,14 @@ async function getPostsForIncrementalScoring(
     )`;
 
   // This UNION scans the whole 72h firehose window (hundreds of thousands of
-  // posts/scores) and legitimately runs ~20-30s at current volume — above the
-  // pool's 30s statement_timeout default (src/db/client.ts). Run it in a short
-  // read-only transaction with a raised SET LOCAL statement_timeout so it is not
-  // cancelled mid-flight; SET LOCAL reverts on COMMIT, so nothing leaks back to
-  // the pooled connection. The overall pipeline is still bounded by
-  // SCORING_TIMEOUT_MS.
-  const client = await db.connect();
-  try {
-    // READ ONLY makes the read-only intent an enforced guarantee (the block
-    // only ever runs this SELECT), not just a comment; SET LOCAL is still
-    // permitted inside a read-only transaction.
-    await client.query('BEGIN READ ONLY');
-    await client.query(`SET LOCAL statement_timeout = '${INCREMENTAL_SCORING_STATEMENT_TIMEOUT}'`);
-    const result = await client.query(sql, params);
-    await client.query('COMMIT');
-    return result.rows.map(toPostForScoring);
-  } catch (err) {
-    await client.query('ROLLBACK').catch(() => {});
-    throw err;
-  } finally {
-    client.release();
-  }
+  // posts/scores) and legitimately runs ~20-30s at current volume. That is
+  // within the pool's statement_timeout (DB_STATEMENT_TIMEOUT, 60s) — sized for
+  // exactly this query, the heaviest in the system — and well under the
+  // pipeline-level SCORING_TIMEOUT_MS. The explicit ps.created_at > $1 on each
+  // half (see the SQL above) is what keeps it in that range: it prunes
+  // post_scores to the 72h daily partitions instead of scanning all ~36.
+  const result = await db.query(sql, params);
+  return result.rows.map(toPostForScoring);
 }
 
 /**


### PR DESCRIPTION
## Problem (follow-up to #318)

#318 wrapped the incremental candidate query in a read-only transaction with `SET LOCAL statement_timeout` for headroom. But that changed the db-call sequence (`BEGIN`/`SET`/`COMMIT` via `db.connect()`), which broke `tests/scoring-pipeline-rescore.test.ts` — it mocks `db` with only `.query` and asserts on the exact call order (`db.connect is not a function` + mode assertions). The **deploy's test gate caught it and aborted before restart**, so #318 merged but never actually deployed — the feed is still on #317 code with incremental scoring timing out.

## Fix
- **Keep** the explicit `ps.created_at > $1` partition-pruning on both UNION halves — that's the real fix (prunes `post_scores` from ~36 partitions to the 4 in-window ones).
- **Drop** the transaction wrapper; the query is a single `db.query` again (call sequence restored, test passes).
- **Raise `DB_STATEMENT_TIMEOUT` 30s → 60s.** The incremental scoring UNION is the heaviest legitimate query in the system (~20–30s over the full 72h firehose window even after pruning); 60s is a sane global cap for it. The dedicated health-check pool keeps its own 5s timeout, so `/health/ready` is unaffected.

## Verification
- `tsc` clean; **full mocked suite (944 tests) green** (incl. scoring-pipeline-rescore, the one #318 missed — ran the whole suite this time, not a subset).
- Droplet `.env` `DB_STATEMENT_TIMEOUT` already updated to 60000 for the deploy restart.
- Post-merge: confirm incremental runs complete green + feed refreshes, then drop legacy tables.