### PR TITLE
PROJ-1647 Bound transparency stats reads

### DIFF
--- a/docs/openapi-public.json
+++ b/docs/openapi-public.json
@@ -2905,7 +2905,7 @@
         "tags": [
           "Transparency"
         ],
-        "description": "Returns aggregate statistics for the current feed including epoch weights, scoring metrics (posts scored, unique authors, avg/median bridging), governance info, and optional Gini coefficient.",
+        "description": "Returns bounded aggregate statistics for the current feed including epoch weights, materialized feed-snapshot metrics, governance info, provenance, and optional Gini coefficient.",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -2953,10 +2953,12 @@
                       "type": "object",
                       "properties": {
                         "total_posts_scored": {
-                          "type": "integer"
+                          "type": "integer",
+                          "description": "Rows in the current materialized feed snapshot."
                         },
                         "unique_authors": {
-                          "type": "integer"
+                          "type": "integer",
+                          "description": "Unique authors in the materialized feed snapshot."
                         },
                         "avg_bridging_score": {
                           "type": "number"
@@ -2999,12 +3001,46 @@
                           "nullable": true
                         }
                       }
+                    },
+                    "stats_status": {
+                      "type": "object",
+                      "description": "Provenance for the bounded stats response.",
+                      "properties": {
+                        "source": {
+                          "type": "string",
+                          "enum": [
+                            "scoring_run",
+                            "fallback"
+                          ]
+                        },
+                        "degraded": {
+                          "type": "boolean"
+                        },
+                        "computed_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true
+                        },
+                        "run_id": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "message": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "source",
+                        "degraded"
+                      ]
                     }
                   },
                   "required": [
                     "epoch",
                     "feed_stats",
-                    "governance"
+                    "governance",
+                    "stats_status"
                   ]
                 }
               }

--- a/src/db/migrations/031_transparency_stats_materialization.sql
+++ b/src/db/migrations/031_transparency_stats_materialization.sql
@@ -1,0 +1,28 @@
+-- migrate: no-transaction
+-- Migration 031: Materialized transparency stats
+--
+-- /api/transparency/stats is public reviewer-facing read traffic. Keep the
+-- route on bounded rows by filling the missing feed-stat fields in
+-- epoch_metrics during scoring runs instead of recomputing percentiles during
+-- every HTTP request.
+
+ALTER TABLE epoch_metrics
+  ADD COLUMN IF NOT EXISTS run_id TEXT,
+  ADD COLUMN IF NOT EXISTS avg_engagement FLOAT,
+  ADD COLUMN IF NOT EXISTS median_total FLOAT,
+  ADD COLUMN IF NOT EXISTS metrics_source TEXT NOT NULL DEFAULT 'legacy';
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_epoch_metrics_epoch_computed_desc_031_next;
+CREATE INDEX CONCURRENTLY idx_epoch_metrics_epoch_computed_desc_031_next
+ON epoch_metrics(epoch_id, computed_at DESC);
+DROP INDEX CONCURRENTLY IF EXISTS idx_epoch_metrics_epoch_computed_desc;
+ALTER INDEX idx_epoch_metrics_epoch_computed_desc_031_next
+RENAME TO idx_epoch_metrics_epoch_computed_desc;
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_epoch_metrics_run_id_031_next;
+CREATE INDEX CONCURRENTLY idx_epoch_metrics_run_id_031_next
+ON epoch_metrics(run_id)
+WHERE run_id IS NOT NULL;
+DROP INDEX CONCURRENTLY IF EXISTS idx_epoch_metrics_run_id;
+ALTER INDEX idx_epoch_metrics_run_id_031_next
+RENAME TO idx_epoch_metrics_run_id;

--- a/src/db/migrations/031_transparency_stats_materialization.sql
+++ b/src/db/migrations/031_transparency_stats_materialization.sql
@@ -5,6 +5,8 @@
 -- route on bounded rows by filling the missing feed-stat fields in
 -- epoch_metrics during scoring runs instead of recomputing percentiles during
 -- every HTTP request.
+-- The scoring write path prunes current_feed rows per epoch after each insert;
+-- this migration keeps the read path indexed for the latest retained row.
 
 ALTER TABLE epoch_metrics
   ADD COLUMN IF NOT EXISTS run_id TEXT,

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -36,6 +36,7 @@ import {
 } from '../governance/content-filter.js';
 import type { ContentRules } from '../governance/governance.types.js';
 import { updateScoringStatus } from '../admin/status-tracker.js';
+import { calculateAuthorConcentration } from '../transparency/metrics.js';
 
 // Maximum time allowed for a single scoring run.
 const SCORING_TIMEOUT_MS = config.SCORING_TIMEOUT_MS;
@@ -54,6 +55,26 @@ let incrementalRunCount = 0;
 // Avoid repeated warnings when a rollout exposes a missing dynamic component weight.
 let missingWeightWarned = new Set<string>();
 let scoringRunInFlight: Promise<void> | null = null;
+
+interface CurrentFeedStatsSnapshot {
+  totalPostsScored: number;
+  uniqueAuthors: number;
+  avgBridging: number;
+  avgEngagement: number;
+  medianBridging: number;
+  medianTotal: number;
+  authorGini: number;
+}
+
+interface RedisFeedCandidate {
+  post_uri: string;
+  total_score: number;
+  author_did: string;
+  bridging_score: number;
+  engagement_score: number;
+  embed_url: string | null;
+  text_length: number;
+}
 
 /**
  * Get the timestamp of the last successful scoring run.
@@ -219,7 +240,7 @@ async function runScoringPipelineInternal(): Promise<void> {
     // In incremental mode, only new/changed posts were scored above, but
     // previous scores remain in post_scores. Reading from DB gives the
     // complete, correctly-ranked feed.
-    await writeToRedisFromDb(epoch.id, runId);
+    const feedStatsSnapshot = await writeToRedisFromDb(epoch.id, runId);
 
     const elapsed = Date.now() - startTime;
     logger.info(
@@ -245,6 +266,11 @@ async function runScoringPipelineInternal(): Promise<void> {
       posts_scored: posts.length,
       posts_filtered: allPosts.length - posts.length,
     });
+    try {
+      await updateEpochMetrics(epoch.id, runId, feedStatsSnapshot);
+    } catch (err) {
+      logger.warn({ err, epochId: epoch.id, runId }, 'Failed to update epoch transparency metrics');
+    }
     await updateCurrentRunScope(runId, epoch.id, elapsed, posts.length, allPosts.length - posts.length);
   } catch (err) {
     logger.error({ err }, 'Scoring pipeline failed');
@@ -274,6 +300,92 @@ async function updateCurrentRunScope(
       }),
     ]
   );
+}
+
+async function updateEpochMetrics(
+  epochId: number,
+  runId: string,
+  snapshot: CurrentFeedStatsSnapshot
+): Promise<void> {
+  await db.query(
+    `INSERT INTO epoch_metrics (
+       epoch_id,
+       author_gini,
+       avg_bridging,
+       median_bridging,
+       avg_engagement,
+       median_total,
+       vs_chronological_overlap,
+       vs_engagement_overlap,
+       posts_scored,
+       unique_authors,
+       run_id,
+       metrics_source
+     )
+     VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, $7, $8, $9, 'current_feed')`,
+    [
+      epochId,
+      snapshot.authorGini,
+      snapshot.avgBridging,
+      snapshot.medianBridging,
+      snapshot.avgEngagement,
+      snapshot.medianTotal,
+      snapshot.totalPostsScored,
+      snapshot.uniqueAuthors,
+      runId,
+    ]
+  );
+}
+
+function numericValue(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middle];
+  }
+
+  const lower = sorted[middle - 1];
+  const upper = sorted[middle];
+  return (lower + upper) / 2;
+}
+
+function buildCurrentFeedStatsSnapshot(posts: RedisFeedCandidate[]): CurrentFeedStatsSnapshot {
+  const authorCounts = new Map<string, number>();
+  for (const post of posts) {
+    authorCounts.set(post.author_did, (authorCounts.get(post.author_did) ?? 0) + 1);
+  }
+
+  const authorConcentration = calculateAuthorConcentration(authorCounts);
+  const bridgingScores = posts.map((post) => post.bridging_score);
+  const engagementScores = posts.map((post) => post.engagement_score);
+  const totalScores = posts.map((post) => post.total_score);
+
+  return {
+    totalPostsScored: posts.length,
+    uniqueAuthors: authorCounts.size,
+    avgBridging: average(bridgingScores),
+    avgEngagement: average(engagementScores),
+    medianBridging: median(bridgingScores),
+    medianTotal: median(totalScores),
+    authorGini: authorConcentration.gini,
+  };
 }
 
 /**
@@ -834,17 +946,21 @@ async function storeScoreComponents(
  * Applies the scoring window cutoff so posts older than SCORING_WINDOW_HOURS
  * are excluded even if they have stale scores in post_scores.
  */
-async function writeToRedisFromDb(epochId: number, runId: string): Promise<void> {
+async function writeToRedisFromDb(epochId: number, runId: string): Promise<CurrentFeedStatsSnapshot> {
   const cutoffMs = config.SCORING_WINDOW_HOURS * 60 * 60 * 1000;
   const cutoff = new Date(Date.now() - cutoffMs);
 
   const result = await db.query<{
     post_uri: string;
-    total_score: number;
+    total_score: number | string;
+    author_did: string;
+    bridging_score: number | string;
+    engagement_score: number | string;
     embed_url: string | null;
-    text_length: number;
+    text_length: number | string;
   }>(
-    `SELECT ps.post_uri, ps.total_score, p.embed_url,
+    `SELECT ps.post_uri, ps.total_score, p.author_did,
+            ps.bridging_score, ps.engagement_score, p.embed_url,
             COALESCE(LENGTH(p.text), 0) as text_length
      FROM post_scores ps
      -- p.created_at = ps.created_at is the partition key (posts is
@@ -868,19 +984,29 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<void>
     [epochId, config.FEED_MAX_POSTS, cutoff.toISOString(), config.FEED_MIN_RELEVANCE]
   );
 
+  const feedCandidates: RedisFeedCandidate[] = result.rows.map((post) => ({
+    post_uri: post.post_uri,
+    total_score: numericValue(post.total_score),
+    author_did: post.author_did,
+    bridging_score: numericValue(post.bridging_score),
+    engagement_score: numericValue(post.engagement_score),
+    embed_url: post.embed_url,
+    text_length: numericValue(post.text_length),
+  }));
+
   // URL deduplication: penalize reshares of the same external link.
   // Posts are already sorted by total_score DESC, so the highest-scored post
   // sharing a URL gets full score and later duplicates get decayed.
-  let topPosts: Array<{ post_uri: string; total_score: number }>;
+  let topPosts: RedisFeedCandidate[];
 
   if (config.FEED_DEDUP_ENABLED) {
     const DEDUP_DECAY = [1.0, 0.7, 0.5, 0.3];
     const urlCounts = new Map<string, number>();
 
-    const dedupedPosts = result.rows.map(post => {
+    const dedupedPosts = feedCandidates.map(post => {
       // No URL or substantial original text → no penalty
       if (!post.embed_url || post.text_length >= config.FEED_DEDUP_MIN_TEXT) {
-        return { post_uri: post.post_uri, total_score: post.total_score };
+        return post;
       }
 
       const count = urlCounts.get(post.embed_url) ?? 0;
@@ -889,7 +1015,7 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<void>
       const decayIndex = Math.min(count, DEDUP_DECAY.length - 1);
       const adjustedScore = post.total_score * DEDUP_DECAY[decayIndex];
 
-      return { post_uri: post.post_uri, total_score: adjustedScore };
+      return { ...post, total_score: adjustedScore };
     });
 
     // Re-sort after dedup adjustment (order may have changed)
@@ -902,10 +1028,7 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<void>
 
     topPosts = dedupedPosts;
   } else {
-    topPosts = result.rows.map(post => ({
-      post_uri: post.post_uri,
-      total_score: post.total_score,
-    }));
+    topPosts = feedCandidates;
   }
 
   // Use Redis pipeline for atomic batch write
@@ -934,8 +1057,9 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<void>
 
   if (topPosts.length === 0) {
     logger.info({ epochId }, 'Feed cleared in Redis due to empty scoring result');
-    return;
+    return buildCurrentFeedStatsSnapshot(topPosts);
   }
 
   logger.info({ postCount: topPosts.length, epochId }, 'Feed written to Redis');
+  return buildCurrentFeedStatsSnapshot(topPosts);
 }

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -42,6 +42,7 @@ import { calculateAuthorConcentration } from '../transparency/metrics.js';
 const SCORING_TIMEOUT_MS = config.SCORING_TIMEOUT_MS;
 const SCORING_CANDIDATE_LIMIT = config.SCORING_CANDIDATE_LIMIT;
 const SQL_BOUNDARY_KEYWORD_PATTERN = /^[a-z0-9][a-z0-9\s-]*$/;
+const EPOCH_METRICS_CURRENT_FEED_RETENTION_ROWS = 24;
 
 // Track last successful run for health checks
 let lastSuccessfulRunAt: Date | null = null;
@@ -334,6 +335,20 @@ async function updateEpochMetrics(
       snapshot.uniqueAuthors,
       runId,
     ]
+  );
+  await db.query(
+    `DELETE FROM epoch_metrics
+     WHERE epoch_id = $1
+       AND metrics_source = 'current_feed'
+       AND id NOT IN (
+         SELECT id
+         FROM epoch_metrics
+         WHERE epoch_id = $1
+           AND metrics_source = 'current_feed'
+         ORDER BY computed_at DESC, id DESC
+         LIMIT $2
+       )`,
+    [epochId, EPOCH_METRICS_CURRENT_FEED_RETENTION_ROWS]
   );
 }
 
@@ -1055,11 +1070,12 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<Curre
     logger.warn({ err, epochId, runId }, 'Failed to invalidate current feed snapshot cache after feed write');
   }
 
+  const feedStatsSnapshot = buildCurrentFeedStatsSnapshot(topPosts);
   if (topPosts.length === 0) {
     logger.info({ epochId }, 'Feed cleared in Redis due to empty scoring result');
-    return buildCurrentFeedStatsSnapshot(topPosts);
+    return feedStatsSnapshot;
   }
 
   logger.info({ postCount: topPosts.length, epochId }, 'Feed written to Redis');
-  return buildCurrentFeedStatsSnapshot(topPosts);
+  return feedStatsSnapshot;
 }

--- a/src/transparency/routes/feed-stats.ts
+++ b/src/transparency/routes/feed-stats.ts
@@ -131,6 +131,48 @@ async function buildFallbackFeedStats(epochId: number): Promise<FallbackFeedStat
   };
 }
 
+async function readLatestEpochMetrics(epochId: number): Promise<EpochMetricsRow | null> {
+  try {
+    const result = await db.query<EpochMetricsRow>(
+      `SELECT
+         run_id,
+         author_gini,
+         avg_bridging,
+         median_bridging,
+         avg_engagement,
+         median_total,
+         vs_chronological_overlap,
+         vs_engagement_overlap,
+         posts_scored,
+         unique_authors,
+         computed_at,
+         metrics_source
+       FROM epoch_metrics
+       WHERE epoch_id = $1
+       ORDER BY computed_at DESC
+       LIMIT 1`,
+      [epochId]
+    );
+    return result.rows[0] ?? null;
+  } catch (err) {
+    logger.warn({ err, epochId }, 'Failed to read materialized transparency stats; using fallback');
+    return null;
+  }
+}
+
+async function readVoteCount(epochId: number): Promise<number> {
+  try {
+    const result = await db.query(
+      `SELECT COUNT(*) as count FROM governance_votes WHERE epoch_id = $1`,
+      [epochId]
+    );
+    return parseInt(String(result.rows[0]?.count ?? '0'), 10) || 0;
+  } catch (err) {
+    logger.warn({ err, epochId }, 'Failed to read governance vote count for transparency stats');
+    return 0;
+  }
+}
+
 export function registerFeedStatsRoute(app: FastifyInstance): void {
   app.get('/api/transparency/stats', {
     schema: {
@@ -225,34 +267,11 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
 
       const epoch = epochResult.rows[0];
       const epochId = epoch.id;
-      const [metricsResult, voteCountResult] = await Promise.all([
-        db.query<EpochMetricsRow>(
-          `SELECT
-             run_id,
-             author_gini,
-             avg_bridging,
-             median_bridging,
-             avg_engagement,
-             median_total,
-             vs_chronological_overlap,
-             vs_engagement_overlap,
-             posts_scored,
-             unique_authors,
-             computed_at,
-             metrics_source
-           FROM epoch_metrics
-           WHERE epoch_id = $1
-           ORDER BY computed_at DESC
-           LIMIT 1`,
-          [epochId]
-        ),
-        db.query(
-          `SELECT COUNT(*) as count FROM governance_votes WHERE epoch_id = $1`,
-          [epochId]
-        ),
+      const [metrics, voteCount] = await Promise.all([
+        readLatestEpochMetrics(epochId),
+        readVoteCount(epochId),
       ]);
 
-      const metrics = metricsResult.rows[0] ?? null;
       const fallbackStats = metrics ? null : await buildFallbackFeedStats(epochId);
       const metricsAreComplete = metrics !== null &&
         metrics.metrics_source === 'current_feed' &&
@@ -288,7 +307,7 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
           median_total_score: metrics ? numericValue(metrics.median_total) : 0,
         },
         governance: {
-          votes_this_epoch: parseInt(voteCountResult.rows[0].count, 10) || 0,
+          votes_this_epoch: voteCount,
         },
         stats_status: {
           source: metrics ? 'scoring_run' : 'fallback',

--- a/src/transparency/routes/feed-stats.ts
+++ b/src/transparency/routes/feed-stats.ts
@@ -3,33 +3,56 @@
  *
  * GET /api/transparency/stats
  *
- * Returns aggregate statistics for the current feed:
+ * Returns bounded aggregate statistics for the current feed:
  * - Current epoch weights and status
- * - Feed statistics (posts scored, unique authors, avg/median bridging)
+ * - Feed snapshot statistics materialized during scoring
  * - Governance info (vote count)
  * - Optional: Gini coefficient for author concentration
  */
 
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { config } from '../../config.js';
 import { db } from '../../db/client.js';
+import { redis } from '../../db/redis.js';
 import { logger } from '../../lib/logger.js';
 import { ErrorResponseSchema } from '../../lib/openapi.js';
-import { readEpochComponentStats } from '../../scoring/score-reader.js';
 import type { FeedStats } from '../transparency.types.js';
 
 interface CurrentScoringRunValue {
   run_id?: unknown;
   epoch_id?: unknown;
+  posts_scored?: unknown;
+  timestamp?: unknown;
 }
 
-interface BaseFeedStatsRow {
-  total_posts: string;
-  unique_authors: string;
-  median_total: string | null;
+interface CurrentScoringRunScope {
+  runId: string;
+  epochId: number;
+  postsScored: number | null;
+  timestamp: string | null;
 }
 
-async function getCurrentScoringRunScope(): Promise<{ runId: string; epochId: number } | null> {
+interface EpochMetricsRow {
+  run_id: string | null;
+  author_gini: number | string | null;
+  avg_bridging: number | string | null;
+  median_bridging: number | string | null;
+  avg_engagement: number | string | null;
+  median_total: number | string | null;
+  vs_chronological_overlap: number | string | null;
+  vs_engagement_overlap: number | string | null;
+  posts_scored: number | string | null;
+  unique_authors: number | string | null;
+  computed_at: string | Date;
+  metrics_source: 'current_feed' | 'legacy' | null;
+}
+
+interface FallbackFeedStats {
+  totalPostsScored: number;
+  runId: string | null;
+  computedAt: string | null;
+}
+
+async function getCurrentScoringRunScope(): Promise<CurrentScoringRunScope | null> {
   const result = await db.query<{ value: CurrentScoringRunValue }>(
     `SELECT value
      FROM system_status
@@ -48,6 +71,63 @@ async function getCurrentScoringRunScope(): Promise<{ runId: string; epochId: nu
   return {
     runId: value.run_id,
     epochId: value.epoch_id,
+    postsScored: typeof value.posts_scored === 'number' ? value.posts_scored : null,
+    timestamp: typeof value.timestamp === 'string' ? value.timestamp : null,
+  };
+}
+
+function numericValue(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function nullableNumericValue(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isoDateTimeOrNull(value: string | Date | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+async function readRedisFeedCount(): Promise<number | null> {
+  try {
+    const value = await redis.get('feed:count');
+    return nullableNumericValue(value);
+  } catch (err) {
+    logger.warn({ err }, 'Failed to read Redis feed count for transparency stats fallback');
+    return null;
+  }
+}
+
+async function getCurrentScoringRunScopeOrNull(): Promise<CurrentScoringRunScope | null> {
+  try {
+    return await getCurrentScoringRunScope();
+  } catch (err) {
+    logger.warn({ err }, 'Failed to read current scoring run scope for transparency stats fallback');
+    return null;
+  }
+}
+
+async function buildFallbackFeedStats(epochId: number): Promise<FallbackFeedStats> {
+  const runScope = await getCurrentScoringRunScopeOrNull();
+  const scopeMatchesEpoch = runScope?.epochId === epochId;
+  const redisFeedCount = scopeMatchesEpoch ? await readRedisFeedCount() : null;
+  const scopedRunPosts = scopeMatchesEpoch ? runScope.postsScored : null;
+
+  return {
+    totalPostsScored: Math.max(scopedRunPosts ?? 0, redisFeedCount ?? 0),
+    runId: scopeMatchesEpoch ? runScope.runId : null,
+    computedAt: scopeMatchesEpoch ? runScope.timestamp : null,
   };
 }
 
@@ -57,8 +137,8 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
       tags: ['Transparency'],
       summary: 'Feed statistics',
       description:
-        'Returns aggregate statistics for the current feed including epoch weights, scoring metrics ' +
-        '(posts scored, unique authors, avg/median bridging), governance info, and optional Gini coefficient.',
+        'Returns bounded aggregate statistics for the current feed including epoch weights, ' +
+        'materialized feed-snapshot metrics, governance info, provenance, and optional Gini coefficient.',
       response: {
         200: {
           type: 'object',
@@ -84,8 +164,11 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
             feed_stats: {
               type: 'object',
               properties: {
-                total_posts_scored: { type: 'integer' },
-                unique_authors: { type: 'integer' },
+                total_posts_scored: {
+                  type: 'integer',
+                  description: 'Rows in the current materialized feed snapshot.',
+                },
+                unique_authors: { type: 'integer', description: 'Unique authors in the materialized feed snapshot.' },
                 avg_bridging_score: { type: 'number' },
                 avg_engagement_score: { type: 'number' },
                 median_bridging_score: { type: 'number' },
@@ -108,8 +191,20 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
                 vs_engagement_overlap: { type: 'number', nullable: true },
               },
             },
+            stats_status: {
+              type: 'object',
+              description: 'Provenance for the bounded stats response.',
+              properties: {
+                source: { type: 'string', enum: ['scoring_run', 'fallback'] },
+                degraded: { type: 'boolean' },
+                computed_at: { type: 'string', format: 'date-time', nullable: true },
+                run_id: { type: 'string', nullable: true },
+                message: { type: 'string', nullable: true },
+              },
+              required: ['source', 'degraded'],
+            },
           },
-          required: ['epoch', 'feed_stats', 'governance'],
+          required: ['epoch', 'feed_stats', 'governance', 'stats_status'],
         },
         500: ErrorResponseSchema,
       },
@@ -130,62 +225,44 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
 
       const epoch = epochResult.rows[0];
       const epochId = epoch.id;
-      const runScope = await getCurrentScoringRunScope();
-
-      // Keep feed-level stats on post_scores so the long-table read path does
-      // not multiply every score row by every component row. Per-component
-      // distributions are fetched below via the storage-agnostic score reader.
-      const baseStatsParams: unknown[] = [epochId];
-      let runScopeClause = '';
-      if (runScope && runScope.epochId === epochId) {
-        baseStatsParams.push(runScope.runId);
-        runScopeClause = `AND ps.component_details->>'run_id' = $${baseStatsParams.length}`;
-      }
-
-      const baseStatsResult = await db.query<BaseFeedStatsRow>(
-        `SELECT
-           COUNT(*)::text as total_posts,
-           COUNT(DISTINCT p.author_did)::text as unique_authors,
-           PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ps.total_score)::text as median_total
-         FROM post_scores ps
-         -- p.created_at = ps.created_at is the shared partition key (posts is
-         -- RANGE-partitioned by created_at); prunes the posts probe to one
-         -- partition per score row instead of all ~36 (PROJ-917).
-         JOIN posts p ON ps.post_uri = p.uri AND p.created_at = ps.created_at
-         WHERE ps.epoch_id = $1
-           ${runScopeClause}`,
-        baseStatsParams
-      );
-
-      const componentStatsOptions = runScope && runScope.epochId === epochId
-        ? { epochId, runId: runScope.runId }
-        : { epochId };
-
-      const [bridgingStats, engagementStats] = await Promise.all([
-        readEpochComponentStats({
-          ...componentStatsOptions,
-          componentKey: 'bridging',
-        }),
-        readEpochComponentStats({
-          ...componentStatsOptions,
-          componentKey: 'engagement',
-        }),
+      const [metricsResult, voteCountResult] = await Promise.all([
+        db.query<EpochMetricsRow>(
+          `SELECT
+             run_id,
+             author_gini,
+             avg_bridging,
+             median_bridging,
+             avg_engagement,
+             median_total,
+             vs_chronological_overlap,
+             vs_engagement_overlap,
+             posts_scored,
+             unique_authors,
+             computed_at,
+             metrics_source
+           FROM epoch_metrics
+           WHERE epoch_id = $1
+           ORDER BY computed_at DESC
+           LIMIT 1`,
+          [epochId]
+        ),
+        db.query(
+          `SELECT COUNT(*) as count FROM governance_votes WHERE epoch_id = $1`,
+          [epochId]
+        ),
       ]);
 
-      // Vote count for current epoch
-      const voteCountResult = await db.query(
-        `SELECT COUNT(*) as count FROM governance_votes WHERE epoch_id = $1`,
-        [epochId]
-      );
-
-      // Get latest epoch metrics if available
-      const metricsResult = await db.query(
-        `SELECT * FROM epoch_metrics WHERE epoch_id = $1 ORDER BY computed_at DESC LIMIT 1`,
-        [epochId]
-      );
-
-      const stats = baseStatsResult.rows[0];
-      const metrics = metricsResult.rows[0];
+      const metrics = metricsResult.rows[0] ?? null;
+      const fallbackStats = metrics ? null : await buildFallbackFeedStats(epochId);
+      const metricsAreComplete = metrics !== null &&
+        metrics.metrics_source === 'current_feed' &&
+        metrics.avg_engagement !== null &&
+        metrics.median_total !== null;
+      const statsStatusMessage = metrics
+        ? metricsAreComplete
+          ? null
+          : 'Using legacy transparency metrics; some score-distribution fields may be incomplete until the next scoring run.'
+        : 'Using degraded stats fallback; score-distribution metrics will populate after the next scoring run.';
 
       const response: FeedStats = {
         epoch: {
@@ -201,28 +278,35 @@ export function registerFeedStatsRoute(app: FastifyInstance): void {
           created_at: epoch.created_at,
         },
         feed_stats: {
-          total_posts_scored: parseInt(stats?.total_posts ?? '0', 10) || 0,
-          unique_authors: parseInt(stats?.unique_authors ?? '0', 10) || 0,
-          avg_bridging_score: bridgingStats?.avg ?? 0,
-          avg_engagement_score: engagementStats?.avg ?? 0,
-          median_bridging_score: bridgingStats?.median ?? 0,
-          median_total_score: parseFloat(stats?.median_total ?? '0') || 0,
+          total_posts_scored: metrics
+            ? numericValue(metrics.posts_scored)
+            : fallbackStats?.totalPostsScored ?? 0,
+          unique_authors: metrics ? numericValue(metrics.unique_authors) : 0,
+          avg_bridging_score: metrics ? numericValue(metrics.avg_bridging) : 0,
+          avg_engagement_score: metrics ? numericValue(metrics.avg_engagement) : 0,
+          median_bridging_score: metrics ? numericValue(metrics.median_bridging) : 0,
+          median_total_score: metrics ? numericValue(metrics.median_total) : 0,
         },
         governance: {
           votes_this_epoch: parseInt(voteCountResult.rows[0].count, 10) || 0,
+        },
+        stats_status: {
+          source: metrics ? 'scoring_run' : 'fallback',
+          degraded: !metricsAreComplete,
+          computed_at: metrics
+            ? isoDateTimeOrNull(metrics.computed_at)
+            : isoDateTimeOrNull(fallbackStats?.computedAt ?? null),
+          run_id: metrics ? metrics.run_id : fallbackStats?.runId ?? null,
+          message: statsStatusMessage,
         },
       };
 
       // Add metrics if available
       if (metrics) {
         response.metrics = {
-          author_gini: metrics.author_gini ? parseFloat(metrics.author_gini) : null,
-          vs_chronological_overlap: metrics.vs_chronological_overlap
-            ? parseFloat(metrics.vs_chronological_overlap)
-            : null,
-          vs_engagement_overlap: metrics.vs_engagement_overlap
-            ? parseFloat(metrics.vs_engagement_overlap)
-            : null,
+          author_gini: nullableNumericValue(metrics.author_gini),
+          vs_chronological_overlap: nullableNumericValue(metrics.vs_chronological_overlap),
+          vs_engagement_overlap: nullableNumericValue(metrics.vs_engagement_overlap),
         };
       }
 

--- a/src/transparency/transparency.types.ts
+++ b/src/transparency/transparency.types.ts
@@ -91,6 +91,13 @@ export interface FeedStats {
   governance: {
     votes_this_epoch: number;
   };
+  stats_status: {
+    source: 'scoring_run' | 'fallback';
+    degraded: boolean;
+    computed_at: string | null;
+    run_id: string | null;
+    message: string | null;
+  };
   metrics?: {
     author_gini: number | null;
     vs_chronological_overlap: number | null;
@@ -107,11 +114,15 @@ export interface EpochMetrics {
   author_gini: number | null;
   avg_bridging: number | null;
   median_bridging: number | null;
+  avg_engagement: number | null;
+  median_total: number | null;
   vs_chronological_overlap: number | null;
   vs_engagement_overlap: number | null;
   posts_scored: number;
   unique_authors: number;
   computed_at: Date;
+  run_id: string | null;
+  metrics_source: 'current_feed' | 'legacy';
 }
 
 /**

--- a/tests/incremental-scoring.test.ts
+++ b/tests/incremental-scoring.test.ts
@@ -92,6 +92,18 @@ function setupDefaultMocks() {
   updateScoringStatusMock.mockResolvedValue(undefined);
 }
 
+function findEpochMetricsInsertParams(): unknown[] {
+  const metricsCall = dbQueryMock.mock.calls.find(
+    (call: unknown[]) => String(call[0]).includes('INSERT INTO epoch_metrics')
+  );
+  expect(metricsCall).toBeDefined();
+  return metricsCall?.[1] as unknown[];
+}
+
+function queryWasCalledWith(fragment: string): boolean {
+  return dbQueryMock.mock.calls.some((call: unknown[]) => String(call[0]).includes(fragment));
+}
+
 describe('incremental scoring pipeline', () => {
   beforeEach(() => {
     __resetPipelineState();
@@ -251,6 +263,156 @@ describe('incremental scoring pipeline', () => {
 
     // Redis should have the post from DB, not just from the in-memory scored array
     expect(pipelineZaddMock).toHaveBeenCalledWith('feed:current', 0.5, postRow.uri);
+  });
+
+  it('materializes current feed stats after writing Redis feed', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            post_uri: 'at://did:plc:test/post/1',
+            total_score: '0.9',
+            author_did: 'did:plc:author-a',
+            bridging_score: '0.8',
+            engagement_score: '0.4',
+            embed_url: null,
+            text_length: '120',
+          },
+          {
+            post_uri: 'at://did:plc:test/post/2',
+            total_score: '0.5',
+            author_did: 'did:plc:author-b',
+            bridging_score: '0.2',
+            engagement_score: '0.6',
+            embed_url: null,
+            text_length: '100',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await runScoringPipeline();
+
+    const [
+      epochId,
+      authorGini,
+      avgBridging,
+      medianBridging,
+      avgEngagement,
+      medianTotal,
+      totalPostsScored,
+      uniqueAuthors,
+      runId,
+    ] = findEpochMetricsInsertParams();
+    expect(epochId).toBe(2);
+    expect(authorGini).toBe(0);
+    expect(avgBridging).toBe(0.5);
+    expect(medianBridging).toBe(0.5);
+    expect(avgEngagement).toBe(0.5);
+    expect(medianTotal).toBe(0.7);
+    expect(totalPostsScored).toBe(2);
+    expect(uniqueAuthors).toBe(2);
+    expect(typeof runId).toBe('string');
+  });
+
+  it('materializes explicit zero stats for an empty current feed', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await runScoringPipeline();
+
+    const [
+      epochId,
+      authorGini,
+      avgBridging,
+      medianBridging,
+      avgEngagement,
+      medianTotal,
+      totalPostsScored,
+      uniqueAuthors,
+      runId,
+    ] = findEpochMetricsInsertParams();
+    expect(epochId).toBe(2);
+    expect(authorGini).toBe(0);
+    expect(avgBridging).toBe(0);
+    expect(medianBridging).toBe(0);
+    expect(avgEngagement).toBe(0);
+    expect(medianTotal).toBe(0);
+    expect(totalPostsScored).toBe(0);
+    expect(uniqueAuthors).toBe(0);
+    expect(typeof runId).toBe('string');
+  });
+
+  it('keeps scoring successful when current feed metrics materialization fails', async () => {
+    const metricsError = new Error('epoch_metrics insert failed');
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(metricsError)
+      .mockResolvedValueOnce({ rows: [] });
+
+    await runScoringPipeline();
+
+    expect(updateScoringStatusMock).toHaveBeenCalledTimes(1);
+    expect(queryWasCalledWith('current_scoring_run')).toBe(true);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: metricsError,
+        epochId: 2,
+        runId: expect.any(String),
+      }),
+      'Failed to update epoch transparency metrics'
+    );
+  });
+
+  it('falls back to zero when materializing malformed current feed numeric fields', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            post_uri: 'at://did:plc:test/post/malformed',
+            total_score: 'not-a-number',
+            author_did: 'did:plc:author-a',
+            bridging_score: 'also-not-a-number',
+            engagement_score: '0.6',
+            embed_url: null,
+            text_length: 'still-not-a-number',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await runScoringPipeline();
+
+    const [
+      epochId,
+      authorGini,
+      avgBridging,
+      medianBridging,
+      avgEngagement,
+      medianTotal,
+      totalPostsScored,
+      uniqueAuthors,
+    ] = findEpochMetricsInsertParams();
+    expect(epochId).toBe(2);
+    expect(authorGini).toBe(0);
+    expect(avgBridging).toBe(0);
+    expect(medianBridging).toBe(0);
+    expect(avgEngagement).toBe(0.6);
+    expect(medianTotal).toBe(0);
+    expect(totalPostsScored).toBe(1);
+    expect(uniqueAuthors).toBe(1);
   });
 
   it('incremental query passes epoch_id to filter scored posts', async () => {

--- a/tests/incremental-scoring.test.ts
+++ b/tests/incremental-scoring.test.ts
@@ -316,6 +316,68 @@ describe('incremental scoring pipeline', () => {
     expect(totalPostsScored).toBe(2);
     expect(uniqueAuthors).toBe(2);
     expect(typeof runId).toBe('string');
+    expect(queryWasCalledWith('DELETE FROM epoch_metrics')).toBe(true);
+    expect(queryWasCalledWith("metrics_source = 'current_feed'")).toBe(true);
+  });
+
+  it('materializes non-zero author concentration for skewed current feed authors', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            post_uri: 'at://did:plc:test/post/1',
+            total_score: '0.9',
+            author_did: 'did:plc:author-a',
+            bridging_score: '0.8',
+            engagement_score: '0.4',
+            embed_url: null,
+            text_length: '120',
+          },
+          {
+            post_uri: 'at://did:plc:test/post/2',
+            total_score: '0.7',
+            author_did: 'did:plc:author-a',
+            bridging_score: '0.6',
+            engagement_score: '0.5',
+            embed_url: null,
+            text_length: '110',
+          },
+          {
+            post_uri: 'at://did:plc:test/post/3',
+            total_score: '0.5',
+            author_did: 'did:plc:author-b',
+            bridging_score: '0.2',
+            engagement_score: '0.6',
+            embed_url: null,
+            text_length: '100',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await runScoringPipeline();
+
+    const [
+      epochId,
+      authorGini,
+      avgBridging,
+      medianBridging,
+      avgEngagement,
+      medianTotal,
+      totalPostsScored,
+      uniqueAuthors,
+    ] = findEpochMetricsInsertParams();
+    expect(epochId).toBe(2);
+    expect(Number(authorGini)).toBeGreaterThan(0);
+    expect(avgBridging).toBeCloseTo(0.533333, 5);
+    expect(medianBridging).toBe(0.6);
+    expect(avgEngagement).toBe(0.5);
+    expect(medianTotal).toBe(0.7);
+    expect(totalPostsScored).toBe(3);
+    expect(uniqueAuthors).toBe(2);
   });
 
   it('materializes explicit zero stats for an empty current feed', async () => {

--- a/tests/transparency-run-scope.test.ts
+++ b/tests/transparency-run-scope.test.ts
@@ -4,6 +4,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { dbQueryMock } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
 }));
+const { redisGetMock } = vi.hoisted(() => ({
+  redisGetMock: vi.fn(),
+}));
 
 vi.mock('../src/db/client.js', () => ({
   db: {
@@ -11,34 +14,91 @@ vi.mock('../src/db/client.js', () => ({
   },
 }));
 
+vi.mock('../src/db/redis.js', () => ({
+  redis: {
+    get: redisGetMock,
+  },
+}));
+
 import { registerPostExplainRoute } from '../src/transparency/routes/post-explain.js';
 import { registerFeedStatsRoute } from '../src/transparency/routes/feed-stats.js';
 import { registerCounterfactualRoute } from '../src/transparency/routes/counterfactual.js';
 
+interface FeedStatsDbMockOptions {
+  metricsRows: Record<string, unknown>[];
+  voteCount?: string;
+  currentScoringRunValue?: unknown;
+  currentScoringRunError?: Error;
+}
+
+function buildActiveEpochRow(): Record<string, unknown> {
+  return {
+    id: 2,
+    status: 'active',
+    recency_weight: 0.2,
+    engagement_weight: 0.2,
+    bridging_weight: 0.2,
+    source_diversity_weight: 0.2,
+    relevance_weight: 0.2,
+    created_at: '2026-02-09T00:00:00.000Z',
+  };
+}
+
+function mockFeedStatsDbQueries(options: FeedStatsDbMockOptions): void {
+  dbQueryMock.mockImplementation((query: unknown) => {
+    const sql = String(query);
+
+    if (sql.includes('FROM governance_epochs')) {
+      return Promise.resolve({ rows: [buildActiveEpochRow()] });
+    }
+
+    if (sql.includes('FROM epoch_metrics')) {
+      return Promise.resolve({ rows: options.metricsRows });
+    }
+
+    if (sql.includes('COUNT(*) as count FROM governance_votes')) {
+      return Promise.resolve({ rows: [{ count: options.voteCount ?? '5' }] });
+    }
+
+    if (sql.includes("WHERE key = 'current_scoring_run'")) {
+      if (options.currentScoringRunError) {
+        return Promise.reject(options.currentScoringRunError);
+      }
+      const rows = options.currentScoringRunValue === undefined
+        ? []
+        : [{ value: options.currentScoringRunValue }];
+      return Promise.resolve({ rows });
+    }
+
+    return Promise.reject(new Error(`Unhandled feed stats test query: ${sql}`));
+  });
+}
+
 describe('transparency routes current-run scoping', () => {
   beforeEach(() => {
     dbQueryMock.mockReset();
+    redisGetMock.mockReset();
   });
 
-  it('scopes feed stats to current scoring run when run metadata exists', async () => {
-    dbQueryMock
-      .mockResolvedValueOnce({
-        rows: [{ id: 2, status: 'active', recency_weight: 0.2, engagement_weight: 0.2, bridging_weight: 0.2, source_diversity_weight: 0.2, relevance_weight: 0.2, created_at: '2026-02-09T00:00:00.000Z' }],
-      })
-      .mockResolvedValueOnce({
-        rows: [{ value: { run_id: 'run-1', epoch_id: 2 } }],
-      })
-      .mockResolvedValueOnce({
-        rows: [{ total_posts: '10', unique_authors: '8', median_total: '0.5' }],
-      })
-      .mockResolvedValueOnce({
-        rows: [{ avg: '0.3', median: '0.25', count: '10' }],
-      })
-      .mockResolvedValueOnce({
-        rows: [{ avg: '0.4', median: '0.35', count: '10' }],
-      })
-      .mockResolvedValueOnce({ rows: [{ count: '5' }] })
-      .mockResolvedValueOnce({ rows: [] });
+  it('serves feed stats from materialized epoch metrics without request-time score scans', async () => {
+    mockFeedStatsDbQueries({
+      metricsRows: [
+        {
+          run_id: 'run-1',
+          author_gini: '0.2',
+          avg_bridging: '0.3',
+          median_bridging: '0.25',
+          avg_engagement: '0.4',
+          median_total: '0.5',
+          vs_chronological_overlap: '0',
+          vs_engagement_overlap: 0,
+          posts_scored: '10',
+          unique_authors: '8',
+          computed_at: '2026-02-09T00:05:00.000Z',
+          metrics_source: 'current_feed',
+        },
+      ],
+    });
 
     const app = Fastify();
     registerFeedStatsRoute(app);
@@ -49,16 +109,280 @@ describe('transparency routes current-run scoping', () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(String(dbQueryMock.mock.calls[2]?.[0])).toContain("component_details->>'run_id'");
+    const body = JSON.parse(response.body) as {
+      feed_stats: {
+        total_posts_scored: number;
+        unique_authors: number;
+        avg_bridging_score: number;
+        avg_engagement_score: number;
+        median_total_score: number;
+      };
+      metrics: {
+        vs_chronological_overlap: number | null;
+        vs_engagement_overlap: number | null;
+      };
+      stats_status: { source: string; degraded: boolean; run_id: string | null };
+    };
+    expect(body.feed_stats).toMatchObject({
+      total_posts_scored: 10,
+      unique_authors: 8,
+      avg_bridging_score: 0.3,
+      avg_engagement_score: 0.4,
+      median_total_score: 0.5,
+    });
+    expect(body.stats_status).toMatchObject({
+      source: 'scoring_run',
+      degraded: false,
+      run_id: 'run-1',
+    });
+    expect(body.metrics).toMatchObject({
+      vs_chronological_overlap: 0,
+      vs_engagement_overlap: 0,
+    });
 
-    const scopedPostScoreCalls = dbQueryMock.mock.calls
+    const postScoreScanCalls = dbQueryMock.mock.calls
       .map((call) => String(call[0]))
       .filter((query) => query.includes('FROM post_scores ps'));
 
-    expect(scopedPostScoreCalls.length).toBeGreaterThanOrEqual(3);
-    for (const query of scopedPostScoreCalls) {
-      expect(query).toContain("ps.component_details->>'run_id'");
-    }
+    expect(postScoreScanCalls).toEqual([]);
+    expect(redisGetMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('marks legacy materialized feed stats as degraded without request-time score scans', async () => {
+    mockFeedStatsDbQueries({
+      metricsRows: [
+        {
+          run_id: 'legacy-run',
+          author_gini: '0.2',
+          avg_bridging: '0.3',
+          median_bridging: '0.25',
+          avg_engagement: null,
+          median_total: null,
+          vs_chronological_overlap: null,
+          vs_engagement_overlap: null,
+          posts_scored: '10',
+          unique_authors: '8',
+          computed_at: '2026-02-09T00:05:00.000Z',
+          metrics_source: 'legacy',
+        },
+      ],
+    });
+
+    const app = Fastify();
+    registerFeedStatsRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/transparency/stats',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      feed_stats: {
+        avg_engagement_score: number;
+        median_total_score: number;
+      };
+      stats_status: { source: string; degraded: boolean; message: string | null };
+    };
+    expect(body.feed_stats.avg_engagement_score).toBe(0);
+    expect(body.feed_stats.median_total_score).toBe(0);
+    expect(body.stats_status).toMatchObject({
+      source: 'scoring_run',
+      degraded: true,
+    });
+    expect(body.stats_status.message).toContain('legacy transparency metrics');
+
+    const postScoreScanCalls = dbQueryMock.mock.calls
+      .map((call) => String(call[0]))
+      .filter((query) => query.includes('FROM post_scores ps'));
+
+    expect(postScoreScanCalls).toEqual([]);
+    expect(redisGetMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns a degraded stats shape when materialized metrics are not available', async () => {
+    redisGetMock.mockResolvedValueOnce('25');
+    mockFeedStatsDbQueries({
+      metricsRows: [],
+      currentScoringRunValue: {
+        run_id: 'run-2',
+        epoch_id: 2,
+        posts_scored: 12,
+        timestamp: '2026-02-09T00:06:00.000Z',
+      },
+    });
+
+    const app = Fastify();
+    registerFeedStatsRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/transparency/stats',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      feed_stats: { total_posts_scored: number; unique_authors: number };
+      stats_status: { source: string; degraded: boolean; run_id: string | null };
+    };
+    expect(body.feed_stats.total_posts_scored).toBe(25);
+    expect(body.feed_stats.unique_authors).toBe(0);
+    expect(body.stats_status).toMatchObject({
+      source: 'fallback',
+      degraded: true,
+      run_id: 'run-2',
+    });
+
+    await app.close();
+  });
+
+  it('does not use Redis feed count when fallback scoring scope is from another epoch', async () => {
+    redisGetMock.mockResolvedValueOnce('25');
+    mockFeedStatsDbQueries({
+      metricsRows: [],
+      currentScoringRunValue: {
+        run_id: 'run-other-epoch',
+        epoch_id: 99,
+        posts_scored: 12,
+        timestamp: '2026-02-09T00:06:00.000Z',
+      },
+    });
+
+    const app = Fastify();
+    registerFeedStatsRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/transparency/stats',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      feed_stats: { total_posts_scored: number };
+      stats_status: { source: string; degraded: boolean; computed_at: string | null; run_id: string | null };
+    };
+    expect(body.feed_stats.total_posts_scored).toBe(0);
+    expect(body.stats_status).toMatchObject({
+      source: 'fallback',
+      degraded: true,
+      computed_at: null,
+      run_id: null,
+    });
+    expect(redisGetMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('keeps degraded fallback scoped when Redis feed count fails', async () => {
+    redisGetMock.mockRejectedValueOnce(new Error('redis feed count failed'));
+    mockFeedStatsDbQueries({
+      metricsRows: [],
+      currentScoringRunValue: {
+        run_id: 'run-redis-failed',
+        epoch_id: 2,
+        posts_scored: 12,
+        timestamp: '2026-02-09T00:06:00.000Z',
+      },
+    });
+
+    const app = Fastify();
+    registerFeedStatsRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/transparency/stats',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      feed_stats: { total_posts_scored: number };
+      stats_status: { source: string; degraded: boolean; run_id: string | null };
+    };
+    expect(body.feed_stats.total_posts_scored).toBe(12);
+    expect(body.stats_status).toMatchObject({
+      source: 'fallback',
+      degraded: true,
+      run_id: 'run-redis-failed',
+    });
+
+    await app.close();
+  });
+
+  it('returns degraded zeros when fallback run-scope lookup fails', async () => {
+    mockFeedStatsDbQueries({
+      metricsRows: [],
+      currentScoringRunError: new Error('current scoring run lookup failed'),
+    });
+
+    const app = Fastify();
+    registerFeedStatsRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/transparency/stats',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      feed_stats: { total_posts_scored: number };
+      stats_status: { source: string; degraded: boolean; run_id: string | null };
+    };
+    expect(body.feed_stats.total_posts_scored).toBe(0);
+    expect(body.stats_status).toMatchObject({
+      source: 'fallback',
+      degraded: true,
+      run_id: null,
+    });
+    expect(redisGetMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('preserves null overlap metrics from materialized stats', async () => {
+    mockFeedStatsDbQueries({
+      metricsRows: [
+        {
+          run_id: 'run-null-overlap',
+          author_gini: null,
+          avg_bridging: '0.3',
+          median_bridging: '0.25',
+          avg_engagement: '0.4',
+          median_total: '0.5',
+          vs_chronological_overlap: null,
+          vs_engagement_overlap: null,
+          posts_scored: '10',
+          unique_authors: '8',
+          computed_at: '2026-02-09T00:05:00.000Z',
+          metrics_source: 'current_feed',
+        },
+      ],
+    });
+
+    const app = Fastify();
+    registerFeedStatsRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/transparency/stats',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      metrics: {
+        author_gini: number | null;
+        vs_chronological_overlap: number | null;
+        vs_engagement_overlap: number | null;
+      };
+    };
+    expect(body.metrics).toMatchObject({
+      author_gini: null,
+      vs_chronological_overlap: null,
+      vs_engagement_overlap: null,
+    });
 
     await app.close();
   });

--- a/tests/transparency-run-scope.test.ts
+++ b/tests/transparency-run-scope.test.ts
@@ -27,6 +27,8 @@ import { registerCounterfactualRoute } from '../src/transparency/routes/counterf
 interface FeedStatsDbMockOptions {
   metricsRows: Record<string, unknown>[];
   voteCount?: string;
+  metricsError?: Error;
+  voteCountError?: Error;
   currentScoringRunValue?: unknown;
   currentScoringRunError?: Error;
 }
@@ -53,10 +55,16 @@ function mockFeedStatsDbQueries(options: FeedStatsDbMockOptions): void {
     }
 
     if (sql.includes('FROM epoch_metrics')) {
+      if (options.metricsError) {
+        return Promise.reject(options.metricsError);
+      }
       return Promise.resolve({ rows: options.metricsRows });
     }
 
     if (sql.includes('COUNT(*) as count FROM governance_votes')) {
+      if (options.voteCountError) {
+        return Promise.reject(options.voteCountError);
+      }
       return Promise.resolve({ rows: [{ count: options.voteCount ?? '5' }] });
     }
 
@@ -235,6 +243,92 @@ describe('transparency routes current-run scoping', () => {
       source: 'fallback',
       degraded: true,
       run_id: 'run-2',
+    });
+
+    await app.close();
+  });
+
+  it('returns degraded fallback stats when materialized metrics query fails', async () => {
+    redisGetMock.mockResolvedValueOnce('19');
+    mockFeedStatsDbQueries({
+      metricsRows: [],
+      metricsError: new Error('epoch_metrics unavailable'),
+      currentScoringRunValue: {
+        run_id: 'run-metrics-failed',
+        epoch_id: 2,
+        posts_scored: 7,
+        timestamp: '2026-02-09T00:06:00.000Z',
+      },
+    });
+
+    const app = Fastify();
+    registerFeedStatsRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/transparency/stats',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      feed_stats: { total_posts_scored: number; unique_authors: number };
+      governance: { votes_this_epoch: number };
+      stats_status: { source: string; degraded: boolean; run_id: string | null };
+    };
+    expect(body.feed_stats).toMatchObject({
+      total_posts_scored: 19,
+      unique_authors: 0,
+    });
+    expect(body.governance.votes_this_epoch).toBe(5);
+    expect(body.stats_status).toMatchObject({
+      source: 'fallback',
+      degraded: true,
+      run_id: 'run-metrics-failed',
+    });
+
+    await app.close();
+  });
+
+  it('defaults governance votes to zero when the vote-count query fails', async () => {
+    mockFeedStatsDbQueries({
+      metricsRows: [
+        {
+          run_id: 'run-votes-failed',
+          author_gini: '0.2',
+          avg_bridging: '0.3',
+          median_bridging: '0.25',
+          avg_engagement: '0.4',
+          median_total: '0.5',
+          vs_chronological_overlap: null,
+          vs_engagement_overlap: null,
+          posts_scored: '10',
+          unique_authors: '8',
+          computed_at: '2026-02-09T00:05:00.000Z',
+          metrics_source: 'current_feed',
+        },
+      ],
+      voteCountError: new Error('governance_votes unavailable'),
+    });
+
+    const app = Fastify();
+    registerFeedStatsRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/transparency/stats',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      feed_stats: { total_posts_scored: number };
+      governance: { votes_this_epoch: number };
+      stats_status: { source: string; degraded: boolean };
+    };
+    expect(body.feed_stats.total_posts_scored).toBe(10);
+    expect(body.governance.votes_this_epoch).toBe(0);
+    expect(body.stats_status).toMatchObject({
+      source: 'scoring_run',
+      degraded: false,
     });
 
     await app.close();

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -360,6 +360,13 @@ export interface FeedStatsResponse {
   governance: {
     votes_this_epoch: number;
   };
+  stats_status: {
+    source: 'scoring_run' | 'fallback';
+    degraded: boolean;
+    computed_at: string | null;
+    run_id: string | null;
+    message: string | null;
+  };
   metrics?: {
     author_gini: number | null;
     vs_chronological_overlap: number | null;

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -130,6 +130,7 @@ export function Dashboard() {
   const [isLoading, setIsLoading] = useState(true);
   const [hasInitialLoad, setHasInitialLoad] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [statsStatusMessage, setStatsStatusMessage] = useState<string | null>(null);
 
   useEffect(() => {
     let isMounted = true;
@@ -144,7 +145,7 @@ export function Dashboard() {
           setIsLoading(true);
         }
 
-        const [statsData, auditData, historyData] = await Promise.all([
+        const [statsResult, auditResult, historyResult] = await Promise.allSettled([
           transparencyApi.getStats(),
           transparencyApi.getAuditLog({ limit: 8 }),
           transparencyApi.getEpochHistory(2),
@@ -152,10 +153,43 @@ export function Dashboard() {
 
         if (!isMounted) return;
 
-        setStats(statsData);
-        setAuditLog(auditData.entries);
-        setEpochHistory(historyData.epochs);
-        setError(null);
+        let nextError: string | null = null;
+
+        if (statsResult.status === 'fulfilled') {
+          setStats(statsResult.value);
+          const statsStatus = statsResult.value.stats_status;
+          setStatsStatusMessage(
+            statsStatus?.degraded
+              ? statsStatus.message ?? 'Live score-distribution metrics are temporarily degraded.'
+              : null
+          );
+        } else {
+          const clearingStats = !silent || !initialLoadComplete;
+          if (clearingStats) {
+            setStats(null);
+          }
+          setStatsStatusMessage(
+            clearingStats
+              ? getErrorMessage(statsResult.reason, 'Live feed statistics are temporarily unavailable.')
+              : 'Showing last known statistics; live refresh failed.'
+          );
+        }
+
+        if (auditResult.status === 'fulfilled') {
+          setAuditLog(auditResult.value.entries);
+        } else {
+          nextError = getErrorMessage(auditResult.reason, 'Failed to load recent governance activity');
+        }
+
+        if (historyResult.status === 'fulfilled') {
+          setEpochHistory(historyResult.value.epochs);
+        } else {
+          nextError = nextError ?? getErrorMessage(historyResult.reason, 'Failed to load governance history');
+        }
+
+        if (!silent || !initialLoadComplete || nextError === null) {
+          setError(nextError);
+        }
 
         // Load topic catalog (public endpoint, no auth)
         try {
@@ -243,7 +277,7 @@ export function Dashboard() {
     );
   }
 
-  if (error && !stats) {
+  if (error && !stats && epochHistory.length === 0 && auditLog.length === 0) {
     return (
       <div className="dashboard-page">
         <div className="error-container">
@@ -281,79 +315,80 @@ export function Dashboard() {
       </header>
 
       <main className="dashboard-main page-content">
-        {stats && (
-          <>
-            {latestRoundUpdate ? (
-              <section className="latest-update-section">
-                <div className="section-header">
-                  <h2>Latest governance update</h2>
-                  <span className="update-time">{formatDate(latestRoundUpdate.appliedAt)}</span>
-                </div>
-                <p className="latest-update-title">
-                  Round {latestRoundUpdate.currentRoundId} is now live.
-                </p>
-                <p className="latest-update-meta">
-                  Applied from Round {latestRoundUpdate.previousRoundId} with {latestRoundUpdate.participantCount} voter(s).
-                </p>
-                {latestRoundUpdate.weightChanges.length > 0 ? (
-                  <div className="latest-update-list">
-                    {latestRoundUpdate.weightChanges.map((change) => (
-                      <div key={change.key} className="latest-update-item">
-                        <span>{WEIGHT_LABELS[change.key]}</span>
-                        <strong>
-                          {(change.previous * 100).toFixed(1)}% → {(change.current * 100).toFixed(1)}%
-                          {' '}
-                          ({change.delta >= 0 ? '+' : ''}{(change.delta * 100).toFixed(1)}%)
-                        </strong>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="latest-update-empty">No weight changes from the prior round.</p>
-                )}
-                {(latestRoundUpdate.keywordChanges.includeAdded.length > 0 ||
-                  latestRoundUpdate.keywordChanges.excludeAdded.length > 0 ||
-                  latestRoundUpdate.keywordChanges.includeRemoved.length > 0 ||
-                  latestRoundUpdate.keywordChanges.excludeRemoved.length > 0) && (
-                  <div className="latest-keyword-grid">
-                    {latestRoundUpdate.keywordChanges.includeAdded.length > 0 && (
-                      <div>
-                        <span className="keyword-change-label">Include added</span>
-                        <p className="keyword-change-values">
-                          {latestRoundUpdate.keywordChanges.includeAdded.join(', ')}
-                        </p>
-                      </div>
-                    )}
-                    {latestRoundUpdate.keywordChanges.excludeAdded.length > 0 && (
-                      <div>
-                        <span className="keyword-change-label">Exclude added</span>
-                        <p className="keyword-change-values">
-                          {latestRoundUpdate.keywordChanges.excludeAdded.join(', ')}
-                        </p>
-                      </div>
-                    )}
-                    {latestRoundUpdate.keywordChanges.includeRemoved.length > 0 && (
-                      <div>
-                        <span className="keyword-change-label">Include removed</span>
-                        <p className="keyword-change-values">
-                          {latestRoundUpdate.keywordChanges.includeRemoved.join(', ')}
-                        </p>
-                      </div>
-                    )}
-                    {latestRoundUpdate.keywordChanges.excludeRemoved.length > 0 && (
-                      <div>
-                        <span className="keyword-change-label">Exclude removed</span>
-                        <p className="keyword-change-values">
-                          {latestRoundUpdate.keywordChanges.excludeRemoved.join(', ')}
-                        </p>
-                      </div>
-                    )}
-                  </div>
-                )}
-                <p className="refresh-hint">This page refreshes automatically every minute.</p>
-              </section>
-            ) : null}
+        {error && <p className="dashboard-warning">{error}</p>}
 
+        {latestRoundUpdate ? (
+          <section className="latest-update-section">
+            <div className="section-header">
+              <h2>Latest governance update</h2>
+              <span className="update-time">{formatDate(latestRoundUpdate.appliedAt)}</span>
+            </div>
+            <p className="latest-update-title">
+              Round {latestRoundUpdate.currentRoundId} is now live.
+            </p>
+            <p className="latest-update-meta">
+              Applied from Round {latestRoundUpdate.previousRoundId} with {latestRoundUpdate.participantCount} voter(s).
+            </p>
+            {latestRoundUpdate.weightChanges.length > 0 ? (
+              <div className="latest-update-list">
+                {latestRoundUpdate.weightChanges.map((change) => (
+                  <div key={change.key} className="latest-update-item">
+                    <span>{WEIGHT_LABELS[change.key]}</span>
+                    <strong>
+                      {(change.previous * 100).toFixed(1)}% → {(change.current * 100).toFixed(1)}%
+                      {' '}
+                      ({change.delta >= 0 ? '+' : ''}{(change.delta * 100).toFixed(1)}%)
+                    </strong>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="latest-update-empty">No weight changes from the prior round.</p>
+            )}
+            {(latestRoundUpdate.keywordChanges.includeAdded.length > 0 ||
+              latestRoundUpdate.keywordChanges.excludeAdded.length > 0 ||
+              latestRoundUpdate.keywordChanges.includeRemoved.length > 0 ||
+              latestRoundUpdate.keywordChanges.excludeRemoved.length > 0) && (
+              <div className="latest-keyword-grid">
+                {latestRoundUpdate.keywordChanges.includeAdded.length > 0 && (
+                  <div>
+                    <span className="keyword-change-label">Include added</span>
+                    <p className="keyword-change-values">
+                      {latestRoundUpdate.keywordChanges.includeAdded.join(', ')}
+                    </p>
+                  </div>
+                )}
+                {latestRoundUpdate.keywordChanges.excludeAdded.length > 0 && (
+                  <div>
+                    <span className="keyword-change-label">Exclude added</span>
+                    <p className="keyword-change-values">
+                      {latestRoundUpdate.keywordChanges.excludeAdded.join(', ')}
+                    </p>
+                  </div>
+                )}
+                {latestRoundUpdate.keywordChanges.includeRemoved.length > 0 && (
+                  <div>
+                    <span className="keyword-change-label">Include removed</span>
+                    <p className="keyword-change-values">
+                      {latestRoundUpdate.keywordChanges.includeRemoved.join(', ')}
+                    </p>
+                  </div>
+                )}
+                {latestRoundUpdate.keywordChanges.excludeRemoved.length > 0 && (
+                  <div>
+                    <span className="keyword-change-label">Exclude removed</span>
+                    <p className="keyword-change-values">
+                      {latestRoundUpdate.keywordChanges.excludeRemoved.join(', ')}
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+            <p className="refresh-hint">This page refreshes automatically every minute.</p>
+          </section>
+        ) : null}
+
+        {stats ? (
             <section className="weights-section">
               <div className="section-header">
                 <h2>Current algorithm weights</h2>
@@ -391,32 +426,41 @@ export function Dashboard() {
                 </div>
               </div>
             </section>
+        ) : (
+          <section className="dashboard-degraded-section">
+            <h2>Current algorithm weights</h2>
+            <p>{statsStatusMessage ?? 'Live algorithm statistics are temporarily unavailable.'}</p>
+          </section>
+        )}
 
-            {topicData && topicData.topics.length > 0 && (
-              <section className="topics-section">
-                <div className="section-header">
-                  <h2>Community topic preferences</h2>
-                  <span className="topic-voter-badge">
-                    {topicData.voteCount} topic voter{topicData.voteCount !== 1 ? 's' : ''}
-                  </span>
-                </div>
-                <TopicWeightChart
-                  topics={topicData.topics.map((t) => ({
-                    slug: t.slug,
-                    name: t.name,
-                    weight: t.currentWeight,
-                  }))}
-                  voterCount={topicData.voteCount}
-                />
-              </section>
-            )}
+        {topicData && topicData.topics.length > 0 && (
+          <section className="topics-section">
+            <div className="section-header">
+              <h2>Community topic preferences</h2>
+              <span className="topic-voter-badge">
+                {topicData.voteCount} topic voter{topicData.voteCount !== 1 ? 's' : ''}
+              </span>
+            </div>
+            <TopicWeightChart
+              topics={topicData.topics.map((t) => ({
+                slug: t.slug,
+                name: t.name,
+                weight: t.currentWeight,
+              }))}
+              voterCount={topicData.voteCount}
+            />
+          </section>
+        )}
 
-            <section className="stats-section">
-              <h2>Feed statistics</h2>
+        <section className="stats-section">
+          <h2>Feed statistics</h2>
+          {stats ? (
+            <>
+              {statsStatusMessage && <p className="stats-warning">{statsStatusMessage}</p>}
               <div className="stats-grid">
                 <div className="stat-card">
                   <span className="stat-value">{stats.feed_stats.total_posts_scored.toLocaleString()}</span>
-                  <span className="stat-label">Posts scored</span>
+                  <span className="stat-label">Feed rows</span>
                 </div>
                 <div className="stat-card">
                   <span className="stat-value">{stats.feed_stats.unique_authors.toLocaleString()}</span>
@@ -437,33 +481,35 @@ export function Dashboard() {
                   </div>
                 )}
               </div>
-            </section>
+            </>
+          ) : (
+            <p className="stats-empty">{statsStatusMessage ?? 'Live feed statistics are temporarily unavailable.'}</p>
+          )}
+        </section>
 
-            <section className="audit-section">
-              <div className="section-header">
-                <h2>Recent governance activity</h2>
-                <Link to="/history" className="view-all-link">View all</Link>
-              </div>
-              <div className="audit-list">
-                {auditLog.length === 0 ? (
-                  <p className="no-activity">No governance activity yet</p>
-                ) : (
-                  auditLog.map((entry) => (
-                    <div key={entry.id} className="audit-item">
-                      <div className="audit-action">{formatAction(entry.action)}</div>
-                      <div className="audit-meta">
-                        <span className="audit-time">{formatDate(entry.created_at)}</span>
-                        {entry.epoch_id && (
-                          <span className="audit-epoch">Epoch {entry.epoch_id}</span>
-                        )}
-                      </div>
-                    </div>
-                  ))
-                )}
-              </div>
-            </section>
-          </>
-        )}
+        <section className="audit-section">
+          <div className="section-header">
+            <h2>Recent governance activity</h2>
+            <Link to="/history" className="view-all-link">View all</Link>
+          </div>
+          <div className="audit-list">
+            {auditLog.length === 0 ? (
+              <p className="no-activity">No governance activity yet</p>
+            ) : (
+              auditLog.map((entry) => (
+                <div key={entry.id} className="audit-item">
+                  <div className="audit-action">{formatAction(entry.action)}</div>
+                  <div className="audit-meta">
+                    <span className="audit-time">{formatDate(entry.created_at)}</span>
+                    {entry.epoch_id && (
+                      <span className="audit-epoch">Epoch {entry.epoch_id}</span>
+                    )}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
       </main>
 
       <style>{styles}</style>
@@ -787,6 +833,31 @@ const styles = `
 
   .stats-section h2 {
     margin-bottom: var(--space-5);
+  }
+
+  .dashboard-degraded-section p,
+  .dashboard-warning,
+  .stats-warning,
+  .stats-empty {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
+  }
+
+  .dashboard-warning {
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+  }
+
+  .dashboard-degraded-section h2 {
+    margin-bottom: var(--space-3);
+  }
+
+  .stats-warning {
+    margin-bottom: var(--space-4);
   }
 
   .stats-grid {


### PR DESCRIPTION
## Summary

- Materializes `/api/transparency/stats` feed snapshot metrics during scoring runs instead of recomputing public request-time score scans.
- Adds a retry-safe no-transaction migration for the new `epoch_metrics` receipt fields and read indexes.
- Returns bounded stats provenance via `stats_status`, with degraded fallback scoped to the active scoring epoch.
- Keeps the dashboard useful when stats/audit/history partially fail, including stale-stats messaging on silent refresh failure.

## CodeRabbit Follow-Up

- Addressed the four current-head CodeRabbit findings from review SHA `a9041274d4f4fe7ed8de9bae9b0a4e069fff4d7b`.
- Added bounded current-feed metric retention after each `epoch_metrics` insert and documented that write-path pruning contract in migration `031`.
- Refactored `writeToRedisFromDb` so `buildCurrentFeedStatsSnapshot(topPosts)` is computed once after the empty/non-empty branch decision.
- Split materialized metric and governance vote reads so `/api/transparency/stats` returns degraded fallback stats when `epoch_metrics` fails and defaults vote count to 0 when `governance_votes` fails.
- Added tests for `epoch_metrics` rejection, `governance_votes` rejection, empty-row fallback coverage, retention pruning, and non-zero `authorGini` for skewed author distribution.

## Verification

- `npm ci` in root worktree passed with 0 vulnerabilities.
- `npm ci` in `web/` passed; npm reported the existing web low-severity advisory.
- Focused direct Vitest passed: `./node_modules/.bin/vitest tests/incremental-scoring.test.ts tests/transparency-run-scope.test.ts --run` -> 2 files, 26 tests.
- Root `npm run build` passed.
- `npm run docs:verify` passed.
- `npm run lint` in `web/` passed.
- `npm run build` in `web/` passed.
- `git diff --check` passed.
- Full backend suite passed with CI `.env.example` and local loopback access: `npm test -- --run --fileParallelism=false` -> 109 files, 1003 tests.
- Local full-suite note: the default parallel local run reached 994/1003 tests and failed only in `tests/feed-skeleton-tracking.test.ts` due request-tracker timing/isolation under local parallel load; that suite passed alone, 16/16, and the serialized full run passed.
- Hosted checks on head `449790e7fcbb4a744827142aea7bd29a9995bd6d` passed: CodeQL, Aikido thread check, analyze, backend-verify, docs-verify, frontend-verify, internal-tooling-hygiene, linear-policy, linear-state-sync, quality-gate, report-scripts-verify, secret-scan, security-gate, and dependabot-automerge.

## CodeRabbit Audit

- Status: exempt
- Reason: bounded wait returned exemptable with zero live current-head CodeRabbit threads
- Follow-up: remove the exemption if implementation changes or CodeRabbit reviews this head cleanly
- Decision: apply the audited `coderabbit:exempt` path for PR #326 head `449790e7fcbb4a744827142aea7bd29a9995bd6d`.
- Auditor: Codex/GPT-5.
- Bounded wait evidence: `python3 .github/ops/flow.py wait-coderabbit --repo andrewnordstrom-eng/bluesky-community-feed --pr 326 --timeout-seconds 900 --poll-seconds 60 --json` returned `state: exemptable`, `threads_open: 0`, `retry_count: 0`, `review_sha: a9041274d4f4fe7ed8de9bae9b0a4e069fff4d7b`, `review_state: CHANGES_REQUESTED`, `signal_state: failure`, and `signal_message: CodeRabbit status state is failure`.
- Why the prior review is obsolete: the four CodeRabbit findings from `a9041274d4f4fe7ed8de9bae9b0a4e069fff4d7b` were addressed in head `449790e7fcbb4a744827142aea7bd29a9995bd6d`; the follow-up wait found zero live current-head CodeRabbit threads.
- Why another manual review was not used: CodeRabbit reached the repository wrapper's documented exemptable state after the bounded wait. Additional triggers would spend scarce org-wide CodeRabbit capacity while no live current-head thread remains unresolved.
- This exemption does not waive local tests, hosted checks, Linear closeout, Aikido, CodeQL, or future CodeRabbit requirements.

## Caveats

- No production or staging write/load tests were run.
- First live response after deploy can legitimately be degraded until the next scoring run writes `metrics_source = 'current_feed'`.
- S4/S5 paper simulation evidence remains separate from this reliability fix.

Closes PROJ-1647
