### PR TITLE
[PROJ-1467] Preserve the last-known-good feed during empty scoring runs

### DIFF
--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1401,3 +1401,37 @@ PROJ-1433 requires every metric used in the paper or site to have a receipt and 
 - Removed hard Sybil-resistance wording from refreshed paper/site claims. Current safe wording is simulation/mechanism evidence only, and the metrics packet preserves the PROJ-1551 warning that synthetic voter populations do not prove real electorate behavior, Sybil resistance, personhood, or abuse resistance.
 - Kept the `web-next` type fixes scoped to validation blockers discovered during PROJ-1433; no visual behavior was intentionally changed in those two helper components.
 - Redacted the example production post's raw handle, post text, DID, and source URI from the public metrics packet and UI fixtures; public site and paper copy now use anonymized receipt labels while preserving the numeric proof.
+
+## 2026-07-09 #01 — PROJ-1467 current-main reliability refresh
+
+**Branch:** `dev/PROJ-1467-last-known-good-feed-fallback-refresh`
+**Commits:** pending explicit approval
+**Files changed:** scoring publication, shared feed snapshot cache, focused scoring/cache tests, and the dated lab note.
+
+### What changed
+
+- Ported the uncommitted last-known-good work onto current `origin/main` rather than merging the stale 18-commit-behind branch.
+- Preserved the new shared snapshot-cache architecture: fallback selection occurs during snapshot creation, not inside the feed route.
+- Made zero-row scoring non-destructive and observable.
+- Staged non-empty publication to current and last-known-good sorted sets, then atomically promoted both sets and seven metadata keys with a preflighted Lua script.
+- Made snapshot loads single-flight, kept fallback telemetry off the response critical path, and counted fallback only after successful snapshot publication.
+- Prevented a skipped empty publication from recording a false zero-valued `current_feed` metrics row.
+- Added cleanup, concurrency, retry, bounded-read, and failure regressions without touching Claude's active UI worktree or product components.
+
+### Measurements
+
+- `npm ci --ignore-scripts`: 531 packages installed, 0 vulnerabilities.
+- `npm run build`: pass.
+- Focused reliability slice: 8 files / 85 tests passed.
+- Exact publish Lua script against local Redis: 9 staged keys promoted; missing-source preflight rejected without mutating destination state.
+- Full `npm run verify` with `.env.example` and `NODE_ENV=production`: pass; 109 files / 1,018 tests, CLI build, SDK build/fixture, legacy web lint/build, and `web-next` static export all passed.
+- First CodeRabbit local review: 2 major, 4 minor, 2 trivial findings; all addressed.
+- Second CodeRabbit local review: 0 major, 1 minor, 3 trivial findings; all addressed.
+- Third CodeRabbit local review: 0 major, 0 minor, 4 trivial test-polish findings; all addressed.
+- `git diff --check`: pass.
+
+### Boundaries
+
+- No commit, PR, merge, deploy, production rescore, production Redis mutation, or browser/UI change was made in this entry.
+- The local Redis receipt used uniquely prefixed temporary keys and deleted them in a `finally` block.
+- A hosted CodeRabbit request remains gated on an approved commit and PR; the repo wrapper will be used after a PR number exists.

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1405,7 +1405,7 @@ PROJ-1433 requires every metric used in the paper or site to have a receipt and 
 ## 2026-07-09 #01 — PROJ-1467 current-main reliability refresh
 
 **Branch:** `dev/PROJ-1467-last-known-good-feed-fallback-refresh`
-**Commits:** `a3222b3`; hosted-review follow-up included in this branch
+**Commits:** `a3222b3`, `58e2458`, `c438fae`, plus the current hosted-review fix
 **Files changed:** scoring publication, shared feed snapshot cache, focused scoring/cache tests, and the dated lab note.
 
 ### What changed
@@ -1424,14 +1424,15 @@ PROJ-1433 requires every metric used in the paper or site to have a receipt and 
 
 - `npm ci --ignore-scripts`: 531 packages installed, 0 vulnerabilities.
 - `npm run build`: pass.
-- Focused reliability slice: 8 files / 91 tests passed.
+- Focused reliability slice: 8 files / 92 tests passed.
 - Exact publish Lua script against local Redis: 9 staged keys promoted; missing-source preflight rejected without mutating destination state.
-- Full `npm run verify` with `.env.example` and `NODE_ENV=production`: pass; 109 files / 1,024 tests, CLI build, SDK build/fixture, legacy web lint/build, and `web-next` static export all passed.
+- Full `npm run verify` with `.env.example` and `NODE_ENV=production`: pass; 109 files / 1,025 tests, CLI build, SDK build/fixture, legacy web lint/build, and `web-next` static export all passed.
 - First CodeRabbit local review: 2 major, 4 minor, 2 trivial findings; all addressed.
 - Second CodeRabbit local review: 0 major, 1 minor, 3 trivial findings; all addressed.
 - Third CodeRabbit local review: 0 major, 0 minor, 4 trivial test-polish findings; all addressed.
 - First hosted CodeRabbit review on PR #329: 0 major, 2 minor, 4 trivial findings; all addressed in the follow-up diff.
 - Local review of the hosted follow-up: 0 major, 1 minor, 2 trivial findings; all addressed before push.
+- Hosted current-head review on PR #329: 7 actionable findings; all addressed by correcting the publication-consistency claim, documenting best-effort fallback telemetry, and strengthening exact Redis transaction, TTL, and malformed-`ZADD` regressions.
 - `git diff --check`: pass.
 
 ### Boundaries

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1405,7 +1405,7 @@ PROJ-1433 requires every metric used in the paper or site to have a receipt and 
 ## 2026-07-09 #01 — PROJ-1467 current-main reliability refresh
 
 **Branch:** `dev/PROJ-1467-last-known-good-feed-fallback-refresh`
-**Commits:** pending explicit approval
+**Commits:** `a3222b3`; hosted-review follow-up included in this branch
 **Files changed:** scoring publication, shared feed snapshot cache, focused scoring/cache tests, and the dated lab note.
 
 ### What changed
@@ -1414,7 +1414,9 @@ PROJ-1433 requires every metric used in the paper or site to have a receipt and 
 - Preserved the new shared snapshot-cache architecture: fallback selection occurs during snapshot creation, not inside the feed route.
 - Made zero-row scoring non-destructive and observable.
 - Staged non-empty publication to current and last-known-good sorted sets, then atomically promoted both sets and seven metadata keys with a preflighted Lua script.
+- The seven metadata destinations are `feed:epoch`, `feed:run_id`, `feed:updated_at`, `feed:count`, `feed:last_known_good_epoch`, `feed:last_known_good_run_id`, and `feed:last_known_good_count`; the script renames each staged source over its destination before persisting the destination.
 - Made snapshot loads single-flight, kept fallback telemetry off the response critical path, and counted fallback only after successful snapshot publication.
+- Kept zero-row skip telemetry best-effort and non-blocking: both writes are attempted independently, failures are logged, and the served feed remains unchanged.
 - Prevented a skipped empty publication from recording a false zero-valued `current_feed` metrics row.
 - Added cleanup, concurrency, retry, bounded-read, and failure regressions without touching Claude's active UI worktree or product components.
 
@@ -1422,16 +1424,18 @@ PROJ-1433 requires every metric used in the paper or site to have a receipt and 
 
 - `npm ci --ignore-scripts`: 531 packages installed, 0 vulnerabilities.
 - `npm run build`: pass.
-- Focused reliability slice: 8 files / 85 tests passed.
+- Focused reliability slice: 8 files / 91 tests passed.
 - Exact publish Lua script against local Redis: 9 staged keys promoted; missing-source preflight rejected without mutating destination state.
-- Full `npm run verify` with `.env.example` and `NODE_ENV=production`: pass; 109 files / 1,018 tests, CLI build, SDK build/fixture, legacy web lint/build, and `web-next` static export all passed.
+- Full `npm run verify` with `.env.example` and `NODE_ENV=production`: pass; 109 files / 1,024 tests, CLI build, SDK build/fixture, legacy web lint/build, and `web-next` static export all passed.
 - First CodeRabbit local review: 2 major, 4 minor, 2 trivial findings; all addressed.
 - Second CodeRabbit local review: 0 major, 1 minor, 3 trivial findings; all addressed.
 - Third CodeRabbit local review: 0 major, 0 minor, 4 trivial test-polish findings; all addressed.
+- First hosted CodeRabbit review on PR #329: 0 major, 2 minor, 4 trivial findings; all addressed in the follow-up diff.
+- Local review of the hosted follow-up: 0 major, 1 minor, 2 trivial findings; all addressed before push.
 - `git diff --check`: pass.
 
 ### Boundaries
 
-- No commit, PR, merge, deploy, production rescore, production Redis mutation, or browser/UI change was made in this entry.
+- Commit `a3222b3` and PR #329 exist; no merge, deploy, production rescore, production Redis mutation, or browser/UI change was made.
 - The local Redis receipt used uniquely prefixed temporary keys and deleted them in a `finally` block.
-- A hosted CodeRabbit request remains gated on an approved commit and PR; the repo wrapper will be used after a PR number exists.
+- Hosted review requests were routed through the repository readiness/request wrappers.

--- a/docs/lab/2026-07-09-feed-publication-fallback-refresh.md
+++ b/docs/lab/2026-07-09-feed-publication-fallback-refresh.md
@@ -20,7 +20,7 @@ Non-empty scoring results are written to two run-scoped staging sorted sets plus
 - `feed:last_known_good_run_id`
 - `feed:last_known_good_count`
 
-The script verifies every source key exists before its first mutation. Redis executes the script without interleaving other clients. After preflight, it renames each staged source over its destination and then runs `PERSIST` on that destination, so readers cannot observe a mixed feed/metadata publication. Staging keys expire after twice the configured scoring timeout so an interrupted run cannot leave permanent debris.
+The script verifies every source key exists before its first mutation. Redis executes the staged promotions without interleaving commands from other clients. After preflight, it renames each staged source over its destination and then runs `PERSIST` on that destination. Snapshot readers maintain consistency through generation checks and retry behavior; callers that read separate feed and metadata keys across the publication boundary must not assume a multi-read transaction. Staging keys expire after twice the configured scoring timeout so an interrupted run cannot leave permanent debris.
 
 A zero-row result does not publish, delete, or invalidate the current snapshot. It attempts these best-effort telemetry writes:
 
@@ -29,7 +29,7 @@ A zero-row result does not publish, delete, or invalidate the current snapshot. 
 
 Both telemetry writes are attempted independently. Failures are logged, neither write delays the scoring run, and neither can suppress feed preservation or turn the skipped result into a publication.
 
-First-page feed requests continue through the shared snapshot cache. Snapshot creation reads `feed:current` first and reads `feed:last_known_good` only when current is empty. Concurrent callers share one in-flight load. A successfully published fallback snapshot records `feed:last_known_good_fallback_total`; a compare-and-set retry does not overcount. Metric latency or failure is isolated from the served response.
+First-page feed requests continue through the shared snapshot cache. Snapshot creation reads `feed:current` first and reads `feed:last_known_good` only when current is empty. Concurrent callers share one in-flight load. After a fallback snapshot is successfully published, the cache asynchronously attempts to increment `feed:last_known_good_fallback_total`; metric-write failures are logged and do not affect the served fallback snapshot. A compare-and-set retry does not overcount.
 
 ## Regression Matrix
 
@@ -55,14 +55,15 @@ The focused suite covers:
 | --- | --- |
 | `npm ci --ignore-scripts` | 531 packages installed; 0 vulnerabilities |
 | `npm run build` | Pass |
-| Focused Vitest slice | 8 files, 91 tests passed |
+| Focused Vitest slice | 8 files, 92 tests passed |
 | Exact Lua script against local Redis | 9 keys promoted atomically; missing-source preflight rejected without mutating published state |
-| Full `npm run verify` with deterministic example env and `NODE_ENV=production` | 109 test files, 1,024 tests, CLI/SDK/legacy web/Next export passed |
+| Full `npm run verify` with deterministic example env and `NODE_ENV=production` | 109 test files, 1,025 tests, CLI/SDK/legacy web/Next export passed |
 | CodeRabbit local pass 1 | 2 major, 4 minor, 2 trivial findings; all addressed |
 | CodeRabbit local pass 2 | 0 major, 1 minor, 3 trivial findings; all addressed |
 | CodeRabbit local pass 3 | 0 major, 0 minor, 4 trivial test-polish findings; all addressed |
 | CodeRabbit hosted pass 1 on PR #329 | 0 major, 2 minor, 4 trivial findings; all addressed in the review follow-up |
 | CodeRabbit local follow-up pass | 0 major, 1 minor, 2 trivial findings; all addressed before push |
+| CodeRabbit hosted current-head pass on PR #329 | 7 actionable findings; all addressed with narrower claims and stronger exact-contract regressions |
 | `git diff --check` | Pass |
 
 The hosted CodeRabbit request was posted through the repository wrapper for PR #329. No raw GitHub review trigger was used.

--- a/docs/lab/2026-07-09-feed-publication-fallback-refresh.md
+++ b/docs/lab/2026-07-09-feed-publication-fallback-refresh.md
@@ -1,0 +1,61 @@
+# 2026-07-09 Feed Publication Fallback Refresh
+
+## Scope
+
+PROJ-1467 prevents a zero-row scoring run from erasing the feed served to reviewers. This refresh ports the original uncommitted reliability work onto current `origin/main`, including the shared snapshot cache added after the first implementation.
+
+The claim is narrow: deterministic local tests validate publication and fallback semantics. Redis-down behavior, root-cause diagnosis for zero-row scoring, deployment, and live traffic remain separate work.
+
+## Current Architecture
+
+Non-empty scoring results are written to two run-scoped staging sorted sets plus seven run-scoped metadata keys. A preflighted Lua script atomically renames and persists all nine staged keys as:
+
+- `feed:current`
+- `feed:last_known_good`
+
+The publish also writes current and last-known-good epoch, run, and count metadata. The script verifies every source key exists before its first mutation. Redis executes the script without interleaving other clients, and every command after preflight is a rename or persist against an existing source, so readers cannot observe a mixed feed/metadata publication. Staging keys expire after twice the configured scoring timeout so an interrupted run cannot leave permanent debris.
+
+A zero-row result does not publish, delete, or invalidate the current snapshot. It records:
+
+- `feed:empty_result_skipped_total`
+- `feed:last_empty_result_at`
+
+First-page feed requests continue through the shared snapshot cache. Snapshot creation reads `feed:current` first and reads `feed:last_known_good` only when current is empty. Concurrent callers share one in-flight load. A successfully published fallback snapshot records `feed:last_known_good_fallback_total`; a compare-and-set retry does not overcount. Metric latency or failure is isolated from the served response.
+
+## Regression Matrix
+
+The focused suite covers:
+
+1. No candidates and all-filtered candidates preserve the served feed.
+2. Relevance-floor zero-row results preserve the served feed.
+3. Empty-result telemetry is recorded without publishing.
+4. Non-empty results stage current and last-known-good sets with batched `ZADD` commands.
+5. Staging TTL and all current/last-known-good metadata are emitted.
+6. Staging aborts, staging command errors, rejected publish scripts, and unexpected publish results surface and trigger staged-key cleanup.
+7. Snapshot creation falls back only when current is empty.
+8. Both-empty state returns no snapshot.
+9. Fallback metric latency or failure does not suppress fallback content.
+10. Concurrent callers share one fallback publication and one metric increment.
+11. Redis read failures are side-effect free and a later request can retry successfully.
+12. Bounded feed reads, generation-conflict retries, and skip-safe epoch metrics are covered.
+13. Existing incremental, deduplication, long-table, embedding, and rescore behavior remains covered.
+
+## Local Receipts
+
+| Check | Result |
+| --- | --- |
+| `npm ci --ignore-scripts` | 531 packages installed; 0 vulnerabilities |
+| `npm run build` | Pass |
+| Focused Vitest slice | 8 files, 85 tests passed |
+| Exact Lua script against local Redis | 9 keys promoted atomically; missing-source preflight rejected without mutating published state |
+| Full `npm run verify` with deterministic example env and `NODE_ENV=production` | 109 test files, 1,018 tests, CLI/SDK/legacy web/Next export passed |
+| CodeRabbit local pass 1 | 2 major, 4 minor, 2 trivial findings; all addressed |
+| CodeRabbit local pass 2 | 0 major, 1 minor, 3 trivial findings; all addressed |
+| CodeRabbit local pass 3 | 0 major, 0 minor, 4 trivial test-polish findings; all addressed |
+| `git diff --check` | Pass |
+
+The hosted CodeRabbit wrapper still requires a PR number and therefore remains post-commit-approval work. No raw GitHub review trigger was used.
+
+## Production Gate
+
+After merge and approved deployment, allow a normal non-empty scoring cycle to populate `feed:last_known_good`; never induce a zero-row production run. Verify both sorted sets, metadata counts, the feed skeleton result, and unchanged health endpoints. This document does not claim that deployment has happened.

--- a/docs/lab/2026-07-09-feed-publication-fallback-refresh.md
+++ b/docs/lab/2026-07-09-feed-publication-fallback-refresh.md
@@ -12,13 +12,22 @@ Non-empty scoring results are written to two run-scoped staging sorted sets plus
 
 - `feed:current`
 - `feed:last_known_good`
+- `feed:epoch`
+- `feed:run_id`
+- `feed:updated_at`
+- `feed:count`
+- `feed:last_known_good_epoch`
+- `feed:last_known_good_run_id`
+- `feed:last_known_good_count`
 
-The publish also writes current and last-known-good epoch, run, and count metadata. The script verifies every source key exists before its first mutation. Redis executes the script without interleaving other clients, and every command after preflight is a rename or persist against an existing source, so readers cannot observe a mixed feed/metadata publication. Staging keys expire after twice the configured scoring timeout so an interrupted run cannot leave permanent debris.
+The script verifies every source key exists before its first mutation. Redis executes the script without interleaving other clients. After preflight, it renames each staged source over its destination and then runs `PERSIST` on that destination, so readers cannot observe a mixed feed/metadata publication. Staging keys expire after twice the configured scoring timeout so an interrupted run cannot leave permanent debris.
 
-A zero-row result does not publish, delete, or invalidate the current snapshot. It records:
+A zero-row result does not publish, delete, or invalidate the current snapshot. It attempts these best-effort telemetry writes:
 
 - `feed:empty_result_skipped_total`
 - `feed:last_empty_result_at`
+
+Both telemetry writes are attempted independently. Failures are logged, neither write delays the scoring run, and neither can suppress feed preservation or turn the skipped result into a publication.
 
 First-page feed requests continue through the shared snapshot cache. Snapshot creation reads `feed:current` first and reads `feed:last_known_good` only when current is empty. Concurrent callers share one in-flight load. A successfully published fallback snapshot records `feed:last_known_good_fallback_total`; a compare-and-set retry does not overcount. Metric latency or failure is isolated from the served response.
 
@@ -28,7 +37,7 @@ The focused suite covers:
 
 1. No candidates and all-filtered candidates preserve the served feed.
 2. Relevance-floor zero-row results preserve the served feed.
-3. Empty-result telemetry is recorded without publishing.
+3. Empty-result telemetry is attempted without publishing; telemetry failure still preserves the feed.
 4. Non-empty results stage current and last-known-good sets with batched `ZADD` commands.
 5. Staging TTL and all current/last-known-good metadata are emitted.
 6. Staging aborts, staging command errors, rejected publish scripts, and unexpected publish results surface and trigger staged-key cleanup.
@@ -46,15 +55,17 @@ The focused suite covers:
 | --- | --- |
 | `npm ci --ignore-scripts` | 531 packages installed; 0 vulnerabilities |
 | `npm run build` | Pass |
-| Focused Vitest slice | 8 files, 85 tests passed |
+| Focused Vitest slice | 8 files, 91 tests passed |
 | Exact Lua script against local Redis | 9 keys promoted atomically; missing-source preflight rejected without mutating published state |
-| Full `npm run verify` with deterministic example env and `NODE_ENV=production` | 109 test files, 1,018 tests, CLI/SDK/legacy web/Next export passed |
+| Full `npm run verify` with deterministic example env and `NODE_ENV=production` | 109 test files, 1,024 tests, CLI/SDK/legacy web/Next export passed |
 | CodeRabbit local pass 1 | 2 major, 4 minor, 2 trivial findings; all addressed |
 | CodeRabbit local pass 2 | 0 major, 1 minor, 3 trivial findings; all addressed |
 | CodeRabbit local pass 3 | 0 major, 0 minor, 4 trivial test-polish findings; all addressed |
+| CodeRabbit hosted pass 1 on PR #329 | 0 major, 2 minor, 4 trivial findings; all addressed in the review follow-up |
+| CodeRabbit local follow-up pass | 0 major, 1 minor, 2 trivial findings; all addressed before push |
 | `git diff --check` | Pass |
 
-The hosted CodeRabbit wrapper still requires a PR number and therefore remains post-commit-approval work. No raw GitHub review trigger was used.
+The hosted CodeRabbit request was posted through the repository wrapper for PR #329. No raw GitHub review trigger was used.
 
 ## Production Gate
 

--- a/src/feed/snapshot-cache.ts
+++ b/src/feed/snapshot-cache.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from 'crypto';
 import { config } from '../config.js';
 import { redis } from '../db/redis.js';
+import { logger } from '../lib/logger.js';
 
 const SNAPSHOT_TTL_SECONDS = 300;
+const FEED_CURRENT_KEY = 'feed:current';
+const FEED_LAST_KNOWN_GOOD_KEY = 'feed:last_known_good';
+const FEED_LAST_KNOWN_GOOD_FALLBACK_TOTAL_KEY = 'feed:last_known_good_fallback_total';
 export const CURRENT_FEED_SNAPSHOT_KEY = 'feed:current_snapshot_id';
 const CURRENT_FEED_GENERATION_KEY = 'feed:current_snapshot_generation';
 const SNAPSHOT_KEY_PREFIX = 'snapshot:';
@@ -196,9 +200,23 @@ async function readCurrentSnapshotFromRedis(): Promise<FeedSnapshot | null> {
 async function createCurrentSnapshot(): Promise<FeedSnapshot | null> {
   for (let attempt = 0; attempt < 2; attempt++) {
     const generation = await readCurrentGeneration();
-    const rankedUris = await redis.zrevrange('feed:current', 0, config.FEED_MAX_POSTS - 1);
+    let usedLastKnownGood = false;
+    let rankedUris = await redis.zrevrange(FEED_CURRENT_KEY, 0, config.FEED_MAX_POSTS - 1);
     if (rankedUris.length === 0) {
-      return null;
+      rankedUris = await redis.zrevrange(
+        FEED_LAST_KNOWN_GOOD_KEY,
+        0,
+        config.FEED_MAX_POSTS - 1
+      );
+      if (rankedUris.length === 0) {
+        return null;
+      }
+      usedLastKnownGood = true;
+
+      logger.warn(
+        { fallbackCount: rankedUris.length },
+        'Current feed is empty; creating snapshot from last-known-good feed'
+      );
     }
 
     const snapshot: FeedSnapshot = {
@@ -218,6 +236,11 @@ async function createCurrentSnapshot(): Promise<FeedSnapshot | null> {
       serializedSnapshot
     );
     if (published === 1) {
+      if (usedLastKnownGood) {
+        void redis.incr(FEED_LAST_KNOWN_GOOD_FALLBACK_TOTAL_KEY).catch((error) => {
+          logger.warn({ error }, 'Failed to record last-known-good feed fallback metric');
+        });
+      }
       return await writeCurrentMemorySnapshot(snapshot, generation);
     }
 
@@ -230,7 +253,7 @@ async function createCurrentSnapshot(): Promise<FeedSnapshot | null> {
   return null;
 }
 
-export async function getCurrentFeedSnapshot(): Promise<FeedSnapshot | null> {
+async function loadCurrentFeedSnapshot(): Promise<FeedSnapshot | null> {
   const memorySnapshot = await readCurrentMemorySnapshot();
   if (memorySnapshot !== null) {
     return memorySnapshot;
@@ -241,15 +264,22 @@ export async function getCurrentFeedSnapshot(): Promise<FeedSnapshot | null> {
     return redisSnapshot;
   }
 
+  return await createCurrentSnapshot();
+}
+
+export async function getCurrentFeedSnapshot(): Promise<FeedSnapshot | null> {
   if (currentSnapshotPromise !== null) {
     return currentSnapshotPromise;
   }
 
-  currentSnapshotPromise = createCurrentSnapshot();
+  const snapshotPromise = loadCurrentFeedSnapshot();
+  currentSnapshotPromise = snapshotPromise;
   try {
-    return await currentSnapshotPromise;
+    return await snapshotPromise;
   } finally {
-    currentSnapshotPromise = null;
+    if (currentSnapshotPromise === snapshotPromise) {
+      currentSnapshotPromise = null;
+    }
   }
 }
 
@@ -297,6 +327,9 @@ export async function invalidateCurrentFeedSnapshot(): Promise<void> {
 }
 
 export const __snapshotCacheKeysForTests = {
+  currentFeedKey: FEED_CURRENT_KEY,
+  lastKnownGoodFeedKey: FEED_LAST_KNOWN_GOOD_KEY,
+  lastKnownGoodFallbackTotalKey: FEED_LAST_KNOWN_GOOD_FALLBACK_TOTAL_KEY,
   currentSnapshotKey: CURRENT_FEED_SNAPSHOT_KEY,
   currentGenerationKey: CURRENT_FEED_GENERATION_KEY,
   snapshotKeyPrefix: SNAPSHOT_KEY_PREFIX,

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -43,6 +43,50 @@ const SCORING_TIMEOUT_MS = config.SCORING_TIMEOUT_MS;
 const SCORING_CANDIDATE_LIMIT = config.SCORING_CANDIDATE_LIMIT;
 const SQL_BOUNDARY_KEYWORD_PATTERN = /^[a-z0-9][a-z0-9\s-]*$/;
 const EPOCH_METRICS_CURRENT_FEED_RETENTION_ROWS = 24;
+const FEED_CURRENT_KEY = 'feed:current';
+const FEED_LAST_KNOWN_GOOD_KEY = 'feed:last_known_good';
+const FEED_EMPTY_RESULT_SKIPPED_TOTAL_KEY = 'feed:empty_result_skipped_total';
+const FEED_LAST_EMPTY_RESULT_AT_KEY = 'feed:last_empty_result_at';
+const FEED_STAGED_CURRENT_PREFIX = 'feed:staging:current:';
+const FEED_STAGED_LAST_KNOWN_GOOD_PREFIX = 'feed:staging:last_known_good:';
+const FEED_STAGED_METADATA_PREFIX = 'feed:staging:metadata:';
+const FEED_STAGING_TTL_SECONDS = Math.ceil((SCORING_TIMEOUT_MS * 2) / 1000);
+const PUBLISH_STAGED_FEED_SCRIPT = `
+local sourceCount = tonumber(ARGV[1])
+if sourceCount == nil or sourceCount <= 0 or #KEYS ~= sourceCount * 2 then
+  return redis.error_reply('invalid staged feed publish arguments')
+end
+for index = 1, sourceCount do
+  if redis.call('EXISTS', KEYS[index]) ~= 1 then
+    return redis.error_reply('missing staged feed publish key at index ' .. index)
+  end
+end
+for index = 1, sourceCount do
+  local destinationIndex = sourceCount + index
+  redis.call('RENAME', KEYS[index], KEYS[destinationIndex])
+  redis.call('PERSIST', KEYS[destinationIndex])
+end
+return 1
+`;
+
+type RedisTransactionResult = Array<[Error | null, unknown]>;
+
+class RedisTransactionAbortedError extends Error {
+  constructor(operation: string) {
+    super(`Redis transaction aborted during ${operation}: exec returned null`);
+    this.name = 'RedisTransactionAbortedError';
+  }
+}
+
+class RedisTransactionCommandError extends Error {
+  constructor(operation: string, commandIndex: number, cause: Error) {
+    super(
+      `Redis transaction failed during ${operation} at command ${commandIndex}: ${cause.message}`,
+      { cause }
+    );
+    this.name = 'RedisTransactionCommandError';
+  }
+}
 
 // Track last successful run for health checks
 let lastSuccessfulRunAt: Date | null = null;
@@ -57,6 +101,32 @@ let incrementalRunCount = 0;
 let missingWeightWarned = new Set<string>();
 let scoringRunInFlight: Promise<void> | null = null;
 
+function assertRedisTransactionSucceeded(
+  results: RedisTransactionResult | null,
+  operation: string
+): void {
+  if (results === null) {
+    throw new RedisTransactionAbortedError(operation);
+  }
+
+  for (const [index, [error]] of results.entries()) {
+    if (error !== null) {
+      throw new RedisTransactionCommandError(operation, index, error);
+    }
+  }
+}
+
+async function cleanupStagedFeedPublish(stagedKeys: string[]): Promise<void> {
+  try {
+    await redis.del(...stagedKeys);
+  } catch (error) {
+    logger.warn(
+      { error, stagedKeys },
+      'Failed to clean up staged feed publish keys'
+    );
+  }
+}
+
 interface CurrentFeedStatsSnapshot {
   totalPostsScored: number;
   uniqueAuthors: number;
@@ -65,6 +135,11 @@ interface CurrentFeedStatsSnapshot {
   medianBridging: number;
   medianTotal: number;
   authorGini: number;
+}
+
+interface FeedPublicationResult {
+  published: boolean;
+  feedStatsSnapshot: CurrentFeedStatsSnapshot | null;
 }
 
 interface RedisFeedCandidate {
@@ -203,7 +278,7 @@ async function runScoringPipelineInternal(): Promise<void> {
     }
 
     if (allPosts.length === 0 && !useIncremental) {
-      logger.warn({ epochId: epoch.id }, 'No posts to score in the window, clearing feed');
+      logger.warn({ epochId: epoch.id }, 'No posts to score in the window');
     }
 
     // 2b. Apply content filtering as a backup guard.
@@ -228,7 +303,7 @@ async function runScoringPipelineInternal(): Promise<void> {
       );
 
       if (posts.length === 0 && !useIncremental) {
-        logger.warn({ epochId: epoch.id }, 'All posts filtered out by content rules, clearing feed');
+        logger.warn({ epochId: epoch.id }, 'All posts filtered out by content rules');
       }
     }
 
@@ -241,7 +316,7 @@ async function runScoringPipelineInternal(): Promise<void> {
     // In incremental mode, only new/changed posts were scored above, but
     // previous scores remain in post_scores. Reading from DB gives the
     // complete, correctly-ranked feed.
-    const feedStatsSnapshot = await writeToRedisFromDb(epoch.id, runId);
+    const feedPublication = await writeToRedisFromDb(epoch.id, runId);
 
     const elapsed = Date.now() - startTime;
     logger.info(
@@ -267,10 +342,12 @@ async function runScoringPipelineInternal(): Promise<void> {
       posts_scored: posts.length,
       posts_filtered: allPosts.length - posts.length,
     });
-    try {
-      await updateEpochMetrics(epoch.id, runId, feedStatsSnapshot);
-    } catch (err) {
-      logger.warn({ err, epochId: epoch.id, runId }, 'Failed to update epoch transparency metrics');
+    if (feedPublication.published && feedPublication.feedStatsSnapshot !== null) {
+      try {
+        await updateEpochMetrics(epoch.id, runId, feedPublication.feedStatsSnapshot);
+      } catch (err) {
+        logger.warn({ err, epochId: epoch.id, runId }, 'Failed to update epoch transparency metrics');
+      }
     }
     await updateCurrentRunScope(runId, epoch.id, elapsed, posts.length, allPosts.length - posts.length);
   } catch (err) {
@@ -961,7 +1038,7 @@ async function storeScoreComponents(
  * Applies the scoring window cutoff so posts older than SCORING_WINDOW_HOURS
  * are excluded even if they have stale scores in post_scores.
  */
-async function writeToRedisFromDb(epochId: number, runId: string): Promise<CurrentFeedStatsSnapshot> {
+async function writeToRedisFromDb(epochId: number, runId: string): Promise<FeedPublicationResult> {
   const cutoffMs = config.SCORING_WINDOW_HOURS * 60 * 60 * 1000;
   const cutoff = new Date(Date.now() - cutoffMs);
 
@@ -1046,36 +1123,88 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<Curre
     topPosts = feedCandidates;
   }
 
-  // Use Redis pipeline for atomic batch write
-  const pipeline = redis.pipeline();
-
-  // Delete old feed; invalidate the shared pagination snapshot only after the write is durable.
-  pipeline.del('feed:current');
-
-  // Add all posts to sorted set (score = total_score)
-  for (const post of topPosts) {
-    pipeline.zadd('feed:current', post.total_score, post.post_uri);
+  const feedStatsSnapshot = buildCurrentFeedStatsSnapshot(topPosts);
+  if (topPosts.length === 0) {
+    const emptyResultAt = new Date().toISOString();
+    logger.warn(
+      { epochId, runId, emptyResultAt },
+      'Scoring result produced zero feed rows; preserving current feed'
+    );
+    try {
+      await redis.incr(FEED_EMPTY_RESULT_SKIPPED_TOTAL_KEY);
+      await redis.set(FEED_LAST_EMPTY_RESULT_AT_KEY, emptyResultAt);
+    } catch (error) {
+      logger.warn(
+        { error, epochId, runId, emptyResultAt },
+        'Failed to record empty feed publish telemetry'
+      );
+    }
+    return { published: false, feedStatsSnapshot: null };
   }
 
-  // Store metadata
-  pipeline.set('feed:epoch', epochId.toString());
-  pipeline.set('feed:run_id', runId);
-  pipeline.set('feed:updated_at', new Date().toISOString());
-  pipeline.set('feed:count', topPosts.length.toString());
+  const stagedCurrentKey = `${FEED_STAGED_CURRENT_PREFIX}${runId}`;
+  const stagedLastKnownGoodKey = `${FEED_STAGED_LAST_KNOWN_GOOD_PREFIX}${runId}`;
+  const updatedAt = new Date().toISOString();
+  const metadataEntries: ReadonlyArray<readonly [string, string]> = [
+    ['feed:epoch', epochId.toString()],
+    ['feed:run_id', runId],
+    ['feed:updated_at', updatedAt],
+    ['feed:count', topPosts.length.toString()],
+    ['feed:last_known_good_epoch', epochId.toString()],
+    ['feed:last_known_good_run_id', runId],
+    ['feed:last_known_good_count', topPosts.length.toString()],
+  ];
+  const stagedMetadataKeys = metadataEntries.map(
+    (_entry, index) => `${FEED_STAGED_METADATA_PREFIX}${runId}:${index}`
+  );
+  const stagedKeys = [stagedCurrentKey, stagedLastKnownGoodKey, ...stagedMetadataKeys];
+  const publishDestinationKeys = [
+    FEED_CURRENT_KEY,
+    FEED_LAST_KNOWN_GOOD_KEY,
+    ...metadataEntries.map(([destinationKey]) => destinationKey),
+  ];
 
-  await pipeline.exec();
+  try {
+    const stagingTransaction = redis.multi();
+    stagingTransaction.del(...stagedKeys);
+    const zaddArguments: Array<string | number> = [];
+    for (const post of topPosts) {
+      zaddArguments.push(post.total_score, post.post_uri);
+    }
+    stagingTransaction.zadd(stagedCurrentKey, ...zaddArguments);
+    stagingTransaction.zadd(stagedLastKnownGoodKey, ...zaddArguments);
+    for (const [index, [, value]] of metadataEntries.entries()) {
+      stagingTransaction.set(stagedMetadataKeys[index], value);
+    }
+    for (const stagedKey of stagedKeys) {
+      stagingTransaction.expire(stagedKey, FEED_STAGING_TTL_SECONDS);
+    }
+    assertRedisTransactionSucceeded(
+      await stagingTransaction.exec(),
+      'staged feed materialization'
+    );
+
+    const published = await redis.eval(
+      PUBLISH_STAGED_FEED_SCRIPT,
+      stagedKeys.length + publishDestinationKeys.length,
+      ...stagedKeys,
+      ...publishDestinationKeys,
+      stagedKeys.length.toString()
+    );
+    if (published !== 1) {
+      throw new Error(`Atomic feed publish returned unexpected result: ${String(published)}`);
+    }
+  } catch (error) {
+    await cleanupStagedFeedPublish(stagedKeys);
+    throw error;
+  }
+
   try {
     await invalidateCurrentFeedSnapshot();
   } catch (err) {
     logger.warn({ err, epochId, runId }, 'Failed to invalidate current feed snapshot cache after feed write');
   }
 
-  const feedStatsSnapshot = buildCurrentFeedStatsSnapshot(topPosts);
-  if (topPosts.length === 0) {
-    logger.info({ epochId }, 'Feed cleared in Redis due to empty scoring result');
-    return feedStatsSnapshot;
-  }
-
   logger.info({ postCount: topPosts.length, epochId }, 'Feed written to Redis');
-  return feedStatsSnapshot;
+  return { published: true, feedStatsSnapshot };
 }

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -127,6 +127,30 @@ async function cleanupStagedFeedPublish(stagedKeys: string[]): Promise<void> {
   }
 }
 
+function recordEmptyFeedPublishTelemetry(
+  epochId: number,
+  runId: string,
+  emptyResultAt: string
+): void {
+  const writes = [
+    { key: FEED_EMPTY_RESULT_SKIPPED_TOTAL_KEY, promise: redis.incr(FEED_EMPTY_RESULT_SKIPPED_TOTAL_KEY) },
+    { key: FEED_LAST_EMPTY_RESULT_AT_KEY, promise: redis.set(FEED_LAST_EMPTY_RESULT_AT_KEY, emptyResultAt) },
+  ];
+  void Promise.allSettled(writes.map(({ promise }) => promise)).then((results) => {
+    const failures = results.flatMap((result, index) => (
+      result.status === 'rejected'
+        ? [{ key: writes[index].key, error: result.reason }]
+        : []
+    ));
+    if (failures.length > 0) {
+      logger.warn(
+        { failures, epochId, runId, emptyResultAt },
+        'Failed to record empty feed publish telemetry'
+      );
+    }
+  });
+}
+
 interface CurrentFeedStatsSnapshot {
   totalPostsScored: number;
   uniqueAuthors: number;
@@ -1130,15 +1154,7 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<FeedP
       { epochId, runId, emptyResultAt },
       'Scoring result produced zero feed rows; preserving current feed'
     );
-    try {
-      await redis.incr(FEED_EMPTY_RESULT_SKIPPED_TOTAL_KEY);
-      await redis.set(FEED_LAST_EMPTY_RESULT_AT_KEY, emptyResultAt);
-    } catch (error) {
-      logger.warn(
-        { error, epochId, runId, emptyResultAt },
-        'Failed to record empty feed publish telemetry'
-      );
-    }
+    recordEmptyFeedPublishTelemetry(epochId, runId, emptyResultAt);
     return { published: false, feedStatsSnapshot: null };
   }
 

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -1147,7 +1147,6 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<FeedP
     topPosts = feedCandidates;
   }
 
-  const feedStatsSnapshot = buildCurrentFeedStatsSnapshot(topPosts);
   if (topPosts.length === 0) {
     const emptyResultAt = new Date().toISOString();
     logger.warn(
@@ -1157,6 +1156,8 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<FeedP
     recordEmptyFeedPublishTelemetry(epochId, runId, emptyResultAt);
     return { published: false, feedStatsSnapshot: null };
   }
+
+  const feedStatsSnapshot = buildCurrentFeedStatsSnapshot(topPosts);
 
   const stagedCurrentKey = `${FEED_STAGED_CURRENT_PREFIX}${runId}`;
   const stagedLastKnownGoodKey = `${FEED_STAGED_LAST_KNOWN_GOOD_PREFIX}${runId}`;

--- a/tests/feed-snapshot-cache.test.ts
+++ b/tests/feed-snapshot-cache.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { redisMock } = vi.hoisted(() => ({
+const { loggerWarnMock, redisMock } = vi.hoisted(() => ({
+  loggerWarnMock: vi.fn(),
   redisMock: {
     get: vi.fn(),
     zrevrange: vi.fn(),
     eval: vi.fn(),
     del: vi.fn(),
+    incr: vi.fn(),
     pttl: vi.fn(),
   },
 }));
@@ -14,6 +16,13 @@ vi.mock('../src/db/redis.js', () => ({
   redis: redisMock,
 }));
 
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    warn: loggerWarnMock,
+  },
+}));
+
+import { config } from '../src/config.js';
 import {
   FEED_SNAPSHOT_BY_ID_MEMORY_CACHE_MAX_ENTRIES,
   __snapshotCacheKeysForTests,
@@ -85,6 +94,7 @@ describe('feed snapshot cache', () => {
     vi.clearAllMocks();
     clearCurrentFeedSnapshotMemoryCache();
     redisMock.pttl.mockResolvedValue(300_000);
+    redisMock.incr.mockResolvedValue(1);
   });
 
   afterEach(() => {
@@ -101,6 +111,187 @@ describe('feed snapshot cache', () => {
     expect(snapshot?.uris).toEqual(['at://did:plc:test/app.bsky.feed.post/1']);
     expect(redisMock.zrevrange).toHaveBeenCalledTimes(2);
     expect(redisMock.eval).toHaveBeenCalledTimes(2);
+  });
+
+  it('limits snapshot reads to the configured feed maximum', async () => {
+    const rankedUris = Array.from(
+      { length: config.FEED_MAX_POSTS + 10 },
+      (_value, index) => `at://did:plc:test/app.bsky.feed.post/${index}`
+    );
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange.mockImplementation(
+      (_key: string, start: number, stop: number) => Promise.resolve(rankedUris.slice(start, stop + 1))
+    );
+    redisMock.eval.mockResolvedValue(1);
+
+    const snapshot = await getCurrentFeedSnapshot();
+
+    expect(snapshot?.uris).toHaveLength(config.FEED_MAX_POSTS);
+    expect(snapshot?.uris.at(-1)).toBe(
+      `at://did:plc:test/app.bsky.feed.post/${config.FEED_MAX_POSTS - 1}`
+    );
+  });
+
+  it('creates the current snapshot from last-known-good when the live feed is empty', async () => {
+    const fallbackUris = ['at://did:plc:test/app.bsky.feed.post/fallback'];
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange.mockImplementation((key: string) => {
+      if (key === __snapshotCacheKeysForTests.currentFeedKey) {
+        return Promise.resolve([]);
+      }
+      if (key === __snapshotCacheKeysForTests.lastKnownGoodFeedKey) {
+        return Promise.resolve(fallbackUris);
+      }
+      throw new Error(`Unexpected sorted-set key: ${key}`);
+    });
+    redisMock.eval.mockResolvedValue(1);
+
+    const snapshot = await getCurrentFeedSnapshot();
+
+    expect(snapshot?.uris).toEqual(fallbackUris);
+    expect(redisMock.zrevrange).toHaveBeenNthCalledWith(
+      1,
+      __snapshotCacheKeysForTests.currentFeedKey,
+      0,
+      config.FEED_MAX_POSTS - 1
+    );
+    expect(redisMock.zrevrange).toHaveBeenNthCalledWith(
+      2,
+      __snapshotCacheKeysForTests.lastKnownGoodFeedKey,
+      0,
+      config.FEED_MAX_POSTS - 1
+    );
+    expect(redisMock.incr).toHaveBeenCalledWith(
+      __snapshotCacheKeysForTests.lastKnownGoodFallbackTotalKey
+    );
+    expect(redisMock.eval).toHaveBeenCalledWith(
+      expect.stringContaining('SETEX'),
+      3,
+      __snapshotCacheKeysForTests.currentGenerationKey,
+      __snapshotCacheKeysForTests.currentSnapshotKey,
+      expect.stringMatching(/^snapshot:/),
+      '0',
+      expect.any(String),
+      '300',
+      JSON.stringify(fallbackUris)
+    );
+  });
+
+  it('serves last-known-good without waiting for fallback metric recording', async () => {
+    const fallbackUris = ['at://did:plc:test/app.bsky.feed.post/fallback'];
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(fallbackUris);
+    redisMock.incr.mockReturnValueOnce(new Promise(() => undefined));
+    redisMock.eval.mockResolvedValue(1);
+
+    await expect(getCurrentFeedSnapshot()).resolves.toMatchObject({ uris: fallbackUris });
+  });
+
+  it('still serves last-known-good when fallback metric recording rejects', async () => {
+    const fallbackUris = ['at://did:plc:test/app.bsky.feed.post/fallback'];
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(fallbackUris);
+    redisMock.incr.mockRejectedValueOnce(new Error('metric unavailable'));
+    redisMock.eval.mockResolvedValue(1);
+
+    await expect(getCurrentFeedSnapshot()).resolves.toMatchObject({ uris: fallbackUris });
+    await vi.waitFor(() => {
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        { error: expect.objectContaining({ message: 'metric unavailable' }) },
+        'Failed to record last-known-good feed fallback metric'
+      );
+    });
+  });
+
+  it('shares one fallback publication across concurrent callers', async () => {
+    const fallbackUris = ['at://did:plc:test/app.bsky.feed.post/fallback'];
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange.mockImplementation((key: string) => {
+      if (key === __snapshotCacheKeysForTests.currentFeedKey) {
+        return Promise.resolve([]);
+      }
+      if (key === __snapshotCacheKeysForTests.lastKnownGoodFeedKey) {
+        return Promise.resolve(fallbackUris);
+      }
+      throw new Error(`Unexpected sorted-set key: ${key}`);
+    });
+    redisMock.eval.mockResolvedValue(1);
+
+    const [first, second] = await Promise.all([
+      getCurrentFeedSnapshot(),
+      getCurrentFeedSnapshot(),
+    ]);
+
+    expect(first).toEqual(second);
+    expect(redisMock.zrevrange).toHaveBeenCalledTimes(2);
+    expect(redisMock.incr).toHaveBeenCalledTimes(1);
+    expect(redisMock.eval).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts fallback only after a generation-conflict retry publishes', async () => {
+    const fallbackUris = ['at://did:plc:test/app.bsky.feed.post/fallback'];
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange.mockImplementation((key: string) => {
+      if (key === __snapshotCacheKeysForTests.currentFeedKey) {
+        return Promise.resolve([]);
+      }
+      if (key === __snapshotCacheKeysForTests.lastKnownGoodFeedKey) {
+        return Promise.resolve(fallbackUris);
+      }
+      throw new Error(`Unexpected sorted-set key: ${key}`);
+    });
+    redisMock.eval.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+
+    await expect(getCurrentFeedSnapshot()).resolves.toMatchObject({ uris: fallbackUris });
+
+    expect(redisMock.eval).toHaveBeenCalledTimes(2);
+    expect(redisMock.incr).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates current feed read failures before fallback side effects', async () => {
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange.mockRejectedValueOnce(new Error('current feed read failed'));
+
+    await expect(getCurrentFeedSnapshot()).rejects.toThrow('current feed read failed');
+    expect(redisMock.incr).not.toHaveBeenCalled();
+    expect(redisMock.eval).not.toHaveBeenCalled();
+  });
+
+  it('propagates fallback feed read failures before fallback side effects', async () => {
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('fallback feed read failed'));
+
+    await expect(getCurrentFeedSnapshot()).rejects.toThrow('fallback feed read failed');
+    expect(redisMock.incr).not.toHaveBeenCalled();
+    expect(redisMock.eval).not.toHaveBeenCalled();
+  });
+
+  it('allows a successful retry after a feed read failure', async () => {
+    const rankedUris = ['at://did:plc:test/app.bsky.feed.post/recovered'];
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange.mockRejectedValueOnce(new Error('current feed read failed'));
+
+    await expect(getCurrentFeedSnapshot()).rejects.toThrow('current feed read failed');
+
+    redisMock.zrevrange.mockResolvedValueOnce(rankedUris);
+    redisMock.eval.mockResolvedValueOnce(1);
+    await expect(getCurrentFeedSnapshot()).resolves.toMatchObject({ uris: rankedUris });
+  });
+
+  it('returns null when both current and last-known-good feeds are empty', async () => {
+    redisMock.get.mockResolvedValue(null);
+    redisMock.zrevrange.mockResolvedValue([]);
+
+    await expect(getCurrentFeedSnapshot()).resolves.toBeNull();
+    expect(redisMock.zrevrange).toHaveBeenCalledTimes(2);
+    expect(redisMock.incr).not.toHaveBeenCalled();
+    expect(redisMock.eval).not.toHaveBeenCalled();
   });
 
   it('serves a current memory-cache hit only while the generation matches', async () => {

--- a/tests/incremental-scoring.test.ts
+++ b/tests/incremental-scoring.test.ts
@@ -68,6 +68,7 @@ vi.mock('../src/lib/logger.js', () => ({
 
 
 import { runScoringPipeline, getLastScoringRunAt, __resetPipelineState } from '../src/scoring/pipeline.js';
+import { config } from '../src/config.js';
 import { buildEpochRow, buildPostRow } from './helpers/index.js';
 
 function makeEpochRow(id = 2) {
@@ -278,46 +279,32 @@ describe('incremental scoring pipeline', () => {
     );
     expect(writeCall).toBeDefined();
 
-    // Redis should have the post from DB, not just from the in-memory scored array
-    expect(pipelineZaddMock).toHaveBeenCalledWith(
-      expect.stringMatching(/^feed:staging:current:/),
-      0.5,
-      postRow.uri
+    const currentZaddCall = pipelineZaddMock.mock.calls.find(
+      (call: unknown[]) => String(call[0]).startsWith('feed:staging:current:')
     );
-    expect(pipelineZaddMock).toHaveBeenCalledWith(
-      expect.stringMatching(/^feed:staging:last_known_good:/),
-      0.5,
-      postRow.uri
+    expect(currentZaddCall).toBeDefined();
+    const stagedCurrentKey = String(currentZaddCall?.[0]);
+    const runId = stagedCurrentKey.slice('feed:staging:current:'.length);
+    expect(runId).not.toBe('');
+    const stagedLastKnownGoodKey = `feed:staging:last_known_good:${runId}`;
+    const stagedMetadataKeys = Array.from(
+      { length: 7 },
+      (_value, index) => `feed:staging:metadata:${runId}:${index}`
     );
+    const stagedKeys = [stagedCurrentKey, stagedLastKnownGoodKey, ...stagedMetadataKeys];
+
+    // Redis should have the post from DB, not just from the in-memory scored array.
+    expect(pipelineZaddMock).toHaveBeenCalledWith(stagedCurrentKey, 0.5, postRow.uri);
+    expect(pipelineZaddMock).toHaveBeenCalledWith(stagedLastKnownGoodKey, 0.5, postRow.uri);
     expect(pipelineExpireMock).toHaveBeenCalledTimes(9);
-    const stagedExpiryCalls = pipelineExpireMock.mock.calls as Array<[string, number]>;
-    expect(new Set(stagedExpiryCalls.map(([key]) => key)).size).toBe(9);
-    expect(stagedExpiryCalls.every(([, ttlSeconds]) => ttlSeconds === 480)).toBe(true);
-    expect(stagedExpiryCalls.map(([key]) => key)).toEqual(
-      expect.arrayContaining([
-        expect.stringMatching(/^feed:staging:current:/),
-        expect.stringMatching(/^feed:staging:last_known_good:/),
-        expect.stringMatching(/^feed:staging:metadata:.*:0$/),
-        expect.stringMatching(/^feed:staging:metadata:.*:1$/),
-        expect.stringMatching(/^feed:staging:metadata:.*:2$/),
-        expect.stringMatching(/^feed:staging:metadata:.*:3$/),
-        expect.stringMatching(/^feed:staging:metadata:.*:4$/),
-        expect.stringMatching(/^feed:staging:metadata:.*:5$/),
-        expect.stringMatching(/^feed:staging:metadata:.*:6$/),
-      ])
+    const expectedStagingTtlSeconds = Math.ceil((config.SCORING_TIMEOUT_MS * 2) / 1000);
+    expect(pipelineExpireMock.mock.calls).toEqual(
+      stagedKeys.map((key) => [key, expectedStagingTtlSeconds])
     );
     expect(redisEvalMock).toHaveBeenCalledWith(
       expect.any(String),
       18,
-      expect.stringMatching(/^feed:staging:current:/),
-      expect.stringMatching(/^feed:staging:last_known_good:/),
-      expect.stringMatching(/^feed:staging:metadata:.*:0$/),
-      expect.stringMatching(/^feed:staging:metadata:.*:1$/),
-      expect.stringMatching(/^feed:staging:metadata:.*:2$/),
-      expect.stringMatching(/^feed:staging:metadata:.*:3$/),
-      expect.stringMatching(/^feed:staging:metadata:.*:4$/),
-      expect.stringMatching(/^feed:staging:metadata:.*:5$/),
-      expect.stringMatching(/^feed:staging:metadata:.*:6$/),
+      ...stagedKeys,
       'feed:current',
       'feed:last_known_good',
       'feed:epoch',

--- a/tests/incremental-scoring.test.ts
+++ b/tests/incremental-scoring.test.ts
@@ -37,7 +37,9 @@ vi.mock('../src/db/client.js', () => ({
 vi.mock('../src/db/redis.js', () => ({
   redis: {
     pipeline: redisPipelineFactoryMock,
+    multi: redisPipelineFactoryMock,
     incr: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue('OK'),
     del: vi.fn().mockResolvedValue(1),
     eval: redisEvalMock,
   },
@@ -77,6 +79,7 @@ function makePostRow(uri = 'at://did:plc:test/post/1') {
 function setupDefaultMocks() {
   const pipeline = {
     del: pipelineDelMock.mockReturnThis(),
+    expire: vi.fn().mockReturnThis(),
     zadd: pipelineZaddMock.mockReturnThis(),
     set: pipelineSetMock.mockReturnThis(),
     exec: pipelineExecMock.mockResolvedValue([]),
@@ -129,11 +132,23 @@ describe('incremental scoring pipeline', () => {
   });
 
   it('keeps the scoring run successful when snapshot invalidation fails after Redis write', async () => {
-    redisEvalMock.mockRejectedValueOnce(new Error('redis eval unavailable'));
+    redisEvalMock
+      .mockResolvedValueOnce(1)
+      .mockRejectedValueOnce(new Error('redis eval unavailable'));
     dbQueryMock
       .mockResolvedValueOnce({ rows: [makeEpochRow()] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          post_uri: 'at://did:plc:test/post/1',
+          total_score: 0.5,
+          author_did: 'did:plc:author',
+          bridging_score: 0.3,
+          engagement_score: 0.4,
+          embed_url: null,
+          text_length: 20,
+        }],
+      })
       .mockResolvedValueOnce({ rows: [] });
 
     await runScoringPipeline();
@@ -262,7 +277,11 @@ describe('incremental scoring pipeline', () => {
     expect(writeCall).toBeDefined();
 
     // Redis should have the post from DB, not just from the in-memory scored array
-    expect(pipelineZaddMock).toHaveBeenCalledWith('feed:current', 0.5, postRow.uri);
+    expect(pipelineZaddMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:current:/),
+      0.5,
+      postRow.uri
+    );
   });
 
   it('materializes current feed stats after writing Redis feed', async () => {
@@ -380,36 +399,17 @@ describe('incremental scoring pipeline', () => {
     expect(uniqueAuthors).toBe(2);
   });
 
-  it('materializes explicit zero stats for an empty current feed', async () => {
+  it('skips the current-feed metrics write when publication is skipped', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [makeEpochRow()] })
-      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] });
 
     await runScoringPipeline();
 
-    const [
-      epochId,
-      authorGini,
-      avgBridging,
-      medianBridging,
-      avgEngagement,
-      medianTotal,
-      totalPostsScored,
-      uniqueAuthors,
-      runId,
-    ] = findEpochMetricsInsertParams();
-    expect(epochId).toBe(2);
-    expect(authorGini).toBe(0);
-    expect(avgBridging).toBe(0);
-    expect(medianBridging).toBe(0);
-    expect(avgEngagement).toBe(0);
-    expect(medianTotal).toBe(0);
-    expect(totalPostsScored).toBe(0);
-    expect(uniqueAuthors).toBe(0);
-    expect(typeof runId).toBe('string');
+    expect(queryWasCalledWith('INSERT INTO epoch_metrics')).toBe(false);
+    expect(queryWasCalledWith('current_scoring_run')).toBe(true);
   });
 
   it('keeps scoring successful when current feed metrics materialization fails', async () => {
@@ -417,7 +417,17 @@ describe('incremental scoring pipeline', () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [makeEpochRow()] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          post_uri: 'at://did:plc:test/post/metrics',
+          total_score: 0.5,
+          author_did: 'did:plc:author',
+          bridging_score: 0.3,
+          engagement_score: 0.4,
+          embed_url: null,
+          text_length: 20,
+        }],
+      })
       .mockRejectedValueOnce(metricsError)
       .mockResolvedValueOnce({ rows: [] });
 

--- a/tests/incremental-scoring.test.ts
+++ b/tests/incremental-scoring.test.ts
@@ -7,6 +7,7 @@ const {
   pipelineZaddMock,
   pipelineSetMock,
   pipelineExecMock,
+  pipelineExpireMock,
   redisEvalMock,
   getCurrentContentRulesMock,
   hasActiveContentRulesMock,
@@ -20,6 +21,7 @@ const {
   pipelineZaddMock: vi.fn(),
   pipelineSetMock: vi.fn(),
   pipelineExecMock: vi.fn(),
+  pipelineExpireMock: vi.fn(),
   redisEvalMock: vi.fn(),
   getCurrentContentRulesMock: vi.fn(),
   hasActiveContentRulesMock: vi.fn(),
@@ -79,7 +81,7 @@ function makePostRow(uri = 'at://did:plc:test/post/1') {
 function setupDefaultMocks() {
   const pipeline = {
     del: pipelineDelMock.mockReturnThis(),
-    expire: vi.fn().mockReturnThis(),
+    expire: pipelineExpireMock.mockReturnThis(),
     zadd: pipelineZaddMock.mockReturnThis(),
     set: pipelineSetMock.mockReturnThis(),
     exec: pipelineExecMock.mockResolvedValue([]),
@@ -282,6 +284,51 @@ describe('incremental scoring pipeline', () => {
       0.5,
       postRow.uri
     );
+    expect(pipelineZaddMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:last_known_good:/),
+      0.5,
+      postRow.uri
+    );
+    expect(pipelineExpireMock).toHaveBeenCalledTimes(9);
+    const stagedExpiryCalls = pipelineExpireMock.mock.calls as Array<[string, number]>;
+    expect(new Set(stagedExpiryCalls.map(([key]) => key)).size).toBe(9);
+    expect(stagedExpiryCalls.every(([, ttlSeconds]) => ttlSeconds === 480)).toBe(true);
+    expect(stagedExpiryCalls.map(([key]) => key)).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^feed:staging:current:/),
+        expect.stringMatching(/^feed:staging:last_known_good:/),
+        expect.stringMatching(/^feed:staging:metadata:.*:0$/),
+        expect.stringMatching(/^feed:staging:metadata:.*:1$/),
+        expect.stringMatching(/^feed:staging:metadata:.*:2$/),
+        expect.stringMatching(/^feed:staging:metadata:.*:3$/),
+        expect.stringMatching(/^feed:staging:metadata:.*:4$/),
+        expect.stringMatching(/^feed:staging:metadata:.*:5$/),
+        expect.stringMatching(/^feed:staging:metadata:.*:6$/),
+      ])
+    );
+    expect(redisEvalMock).toHaveBeenCalledWith(
+      expect.any(String),
+      18,
+      expect.stringMatching(/^feed:staging:current:/),
+      expect.stringMatching(/^feed:staging:last_known_good:/),
+      expect.stringMatching(/^feed:staging:metadata:.*:0$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:1$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:2$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:3$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:4$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:5$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:6$/),
+      'feed:current',
+      'feed:last_known_good',
+      'feed:epoch',
+      'feed:run_id',
+      'feed:updated_at',
+      'feed:count',
+      'feed:last_known_good_epoch',
+      'feed:last_known_good_run_id',
+      'feed:last_known_good_count',
+      '9'
+    );
   });
 
   it('materializes current feed stats after writing Redis feed', async () => {
@@ -410,6 +457,8 @@ describe('incremental scoring pipeline', () => {
 
     expect(queryWasCalledWith('INSERT INTO epoch_metrics')).toBe(false);
     expect(queryWasCalledWith('current_scoring_run')).toBe(true);
+    expect(redisPipelineFactoryMock).not.toHaveBeenCalled();
+    expect(redisEvalMock).not.toHaveBeenCalled();
   });
 
   it('keeps scoring successful when current feed metrics materialization fails', async () => {

--- a/tests/pipeline-empty-feed.test.ts
+++ b/tests/pipeline-empty-feed.test.ts
@@ -73,6 +73,7 @@ vi.mock('../src/lib/logger.js', () => ({
 }));
 
 import { runScoringPipeline, __resetPipelineState } from '../src/scoring/pipeline.js';
+import { config } from '../src/config.js';
 
 function makeEpochRow() {
   return {
@@ -131,7 +132,9 @@ describe('scoring pipeline empty-feed Redis updates', () => {
       expire: pipelineExpireMock.mockReturnThis(),
       zadd: pipelineZaddMock.mockReturnThis(),
       set: pipelineSetMock.mockReturnThis(),
-      exec: pipelineExecMock.mockResolvedValue([]),
+      exec: pipelineExecMock.mockResolvedValue(
+        Array.from({ length: 19 }, () => [null, 'OK'] as [null, string])
+      ),
     };
     redisPipelineFactoryMock.mockReturnValue(pipeline);
   });
@@ -319,9 +322,10 @@ describe('scoring pipeline empty-feed Redis updates', () => {
       0.8,
       'at://did:plc:test/post/1'
     );
+    const expectedStagingTtlSeconds = Math.ceil((config.SCORING_TIMEOUT_MS * 2) / 1000);
     expect(pipelineExpireMock).toHaveBeenCalledWith(
       expect.stringMatching(/^feed:staging:current:/),
-      480
+      expectedStagingTtlSeconds
     );
     expect(pipelineSetMock).toHaveBeenCalledWith(
       expect.stringMatching(/^feed:staging:metadata:.*:3$/),

--- a/tests/pipeline-empty-feed.test.ts
+++ b/tests/pipeline-empty-feed.test.ts
@@ -157,7 +157,9 @@ describe('scoring pipeline empty-feed Redis updates', () => {
 
     expect(redisPipelineFactoryMock).not.toHaveBeenCalled();
     expect(redisDelMock).not.toHaveBeenCalled();
+    expect(redisEvalMock).not.toHaveBeenCalled();
     expect(redisIncrMock).toHaveBeenCalledWith('feed:empty_result_skipped_total');
+    expect(redisSetMock).toHaveBeenCalledTimes(1);
     expect(redisSetMock).toHaveBeenCalledWith('feed:last_empty_result_at', expect.any(String));
     expect(pipelineZaddMock).not.toHaveBeenCalled();
     expect(updateScoringStatusMock).toHaveBeenCalledWith(
@@ -188,7 +190,9 @@ describe('scoring pipeline empty-feed Redis updates', () => {
 
     expect(redisPipelineFactoryMock).not.toHaveBeenCalled();
     expect(redisDelMock).not.toHaveBeenCalled();
+    expect(redisEvalMock).not.toHaveBeenCalled();
     expect(redisIncrMock).toHaveBeenCalledWith('feed:empty_result_skipped_total');
+    expect(redisSetMock).toHaveBeenCalledTimes(1);
     expect(redisSetMock).toHaveBeenCalledWith('feed:last_empty_result_at', expect.any(String));
     expect(pipelineZaddMock).not.toHaveBeenCalled();
     expect(updateScoringStatusMock).toHaveBeenCalledWith(

--- a/tests/pipeline-empty-feed.test.ts
+++ b/tests/pipeline-empty-feed.test.ts
@@ -7,6 +7,11 @@ const {
   pipelineZaddMock,
   pipelineSetMock,
   pipelineExecMock,
+  pipelineExpireMock,
+  redisIncrMock,
+  redisSetMock,
+  redisDelMock,
+  redisEvalMock,
   getCurrentContentRulesMock,
   hasActiveContentRulesMock,
   filterPostsMock,
@@ -18,6 +23,11 @@ const {
   pipelineZaddMock: vi.fn(),
   pipelineSetMock: vi.fn(),
   pipelineExecMock: vi.fn(),
+  pipelineExpireMock: vi.fn(),
+  redisIncrMock: vi.fn(),
+  redisSetMock: vi.fn(),
+  redisDelMock: vi.fn(),
+  redisEvalMock: vi.fn(),
   getCurrentContentRulesMock: vi.fn(),
   hasActiveContentRulesMock: vi.fn(),
   filterPostsMock: vi.fn(),
@@ -33,9 +43,11 @@ vi.mock('../src/db/client.js', () => ({
 vi.mock('../src/db/redis.js', () => ({
   redis: {
     pipeline: redisPipelineFactoryMock,
-    incr: vi.fn().mockResolvedValue(1),
-    del: vi.fn().mockResolvedValue(1),
-    eval: vi.fn().mockResolvedValue(1),
+    multi: redisPipelineFactoryMock,
+    incr: redisIncrMock,
+    set: redisSetMock,
+    del: redisDelMock,
+    eval: redisEvalMock,
   },
 }));
 
@@ -93,6 +105,11 @@ describe('scoring pipeline empty-feed Redis updates', () => {
     pipelineZaddMock.mockReset();
     pipelineSetMock.mockReset();
     pipelineExecMock.mockReset();
+    pipelineExpireMock.mockReset();
+    redisIncrMock.mockReset().mockResolvedValue(1);
+    redisSetMock.mockReset().mockResolvedValue('OK');
+    redisDelMock.mockReset().mockResolvedValue(1);
+    redisEvalMock.mockReset().mockResolvedValue(1);
     getCurrentContentRulesMock.mockReset();
     hasActiveContentRulesMock.mockReset();
     filterPostsMock.mockReset();
@@ -100,6 +117,7 @@ describe('scoring pipeline empty-feed Redis updates', () => {
 
     const pipeline = {
       del: pipelineDelMock.mockReturnThis(),
+      expire: pipelineExpireMock.mockReturnThis(),
       zadd: pipelineZaddMock.mockReturnThis(),
       set: pipelineSetMock.mockReturnThis(),
       exec: pipelineExecMock.mockResolvedValue([]),
@@ -107,7 +125,7 @@ describe('scoring pipeline empty-feed Redis updates', () => {
     redisPipelineFactoryMock.mockReturnValue(pipeline);
   });
 
-  it('clears feed and writes metadata when all posts are filtered out', async () => {
+  it('preserves the served feed and records telemetry when all posts are filtered out', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [makeEpochRow()] })   // getActiveEpoch
       .mockResolvedValueOnce({ rows: [makePostRow()] })     // getPostsForScoring
@@ -126,10 +144,10 @@ describe('scoring pipeline empty-feed Redis updates', () => {
 
     await runScoringPipeline();
 
-    expect(pipelineDelMock).toHaveBeenCalledWith('feed:current');
-    expect(pipelineSetMock).toHaveBeenCalledWith('feed:epoch', '2');
-    expect(pipelineSetMock).toHaveBeenCalledWith('feed:updated_at', expect.any(String));
-    expect(pipelineSetMock).toHaveBeenCalledWith('feed:count', '0');
+    expect(redisPipelineFactoryMock).not.toHaveBeenCalled();
+    expect(redisDelMock).not.toHaveBeenCalled();
+    expect(redisIncrMock).toHaveBeenCalledWith('feed:empty_result_skipped_total');
+    expect(redisSetMock).toHaveBeenCalledWith('feed:last_empty_result_at', expect.any(String));
     expect(pipelineZaddMock).not.toHaveBeenCalled();
     expect(updateScoringStatusMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -137,9 +155,12 @@ describe('scoring pipeline empty-feed Redis updates', () => {
         posts_filtered: 1,
       })
     );
+    expect(
+      dbQueryMock.mock.calls.some(([query]) => String(query).includes('INSERT INTO epoch_metrics'))
+    ).toBe(false);
   });
 
-  it('clears feed and writes metadata when no posts are fetched', async () => {
+  it('preserves the served feed when no posts are fetched', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [makeEpochRow()] })   // getActiveEpoch
       .mockResolvedValueOnce({ rows: [] })                   // getPostsForScoring
@@ -154,10 +175,10 @@ describe('scoring pipeline empty-feed Redis updates', () => {
 
     await runScoringPipeline();
 
-    expect(pipelineDelMock).toHaveBeenCalledWith('feed:current');
-    expect(pipelineSetMock).toHaveBeenCalledWith('feed:epoch', '2');
-    expect(pipelineSetMock).toHaveBeenCalledWith('feed:updated_at', expect.any(String));
-    expect(pipelineSetMock).toHaveBeenCalledWith('feed:count', '0');
+    expect(redisPipelineFactoryMock).not.toHaveBeenCalled();
+    expect(redisDelMock).not.toHaveBeenCalled();
+    expect(redisIncrMock).toHaveBeenCalledWith('feed:empty_result_skipped_total');
+    expect(redisSetMock).toHaveBeenCalledWith('feed:last_empty_result_at', expect.any(String));
     expect(pipelineZaddMock).not.toHaveBeenCalled();
     expect(updateScoringStatusMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -191,5 +212,190 @@ describe('scoring pipeline empty-feed Redis updates', () => {
     expect(queryText).toContain('NOT (');
     expect(queryText).toContain('LIMIT $');
     expect(queryParams.at(-1)).toBe(5000);
+  });
+
+  it('stages and publishes current plus last-known-good feeds for non-empty results', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          post_uri: 'at://did:plc:test/post/1',
+          total_score: 0.8,
+          author_did: 'did:plc:author',
+          bridging_score: 0.2,
+          engagement_score: 0.4,
+          embed_url: null,
+          text_length: 50,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+    getCurrentContentRulesMock.mockResolvedValue({ includeKeywords: [], excludeKeywords: [] });
+    hasActiveContentRulesMock.mockReturnValue(false);
+
+    await runScoringPipeline();
+
+    expect(pipelineZaddMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:current:/),
+      0.8,
+      'at://did:plc:test/post/1'
+    );
+    expect(pipelineZaddMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:last_known_good:/),
+      0.8,
+      'at://did:plc:test/post/1'
+    );
+    expect(pipelineExpireMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:current:/),
+      480
+    );
+    expect(pipelineSetMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:metadata:.*:3$/),
+      '1'
+    );
+    expect(pipelineSetMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:metadata:.*:6$/),
+      '1'
+    );
+    expect(redisEvalMock).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('EXISTS'"),
+      18,
+      expect.stringMatching(/^feed:staging:current:/),
+      expect.stringMatching(/^feed:staging:last_known_good:/),
+      expect.stringMatching(/^feed:staging:metadata:.*:0$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:1$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:2$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:3$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:4$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:5$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:6$/),
+      'feed:current',
+      'feed:last_known_good',
+      'feed:epoch',
+      'feed:run_id',
+      'feed:updated_at',
+      'feed:count',
+      'feed:last_known_good_epoch',
+      'feed:last_known_good_run_id',
+      'feed:last_known_good_count',
+      '9'
+    );
+  });
+
+  it('cleans staged keys and surfaces a failed atomic publish', async () => {
+    const publishError = new Error('publish failed');
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          post_uri: 'at://did:plc:test/post/1',
+          total_score: 0.8,
+          author_did: 'did:plc:author',
+          bridging_score: 0.2,
+          engagement_score: 0.4,
+          embed_url: null,
+          text_length: 50,
+        }],
+      });
+    getCurrentContentRulesMock.mockResolvedValue({ includeKeywords: [], excludeKeywords: [] });
+    hasActiveContentRulesMock.mockReturnValue(false);
+    redisEvalMock.mockRejectedValueOnce(publishError);
+
+    await expect(runScoringPipeline()).rejects.toThrow('publish failed');
+
+    expect(redisDelMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:current:/),
+      expect.stringMatching(/^feed:staging:last_known_good:/),
+      expect.stringMatching(/^feed:staging:metadata:.*:0$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:1$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:2$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:3$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:4$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:5$/),
+      expect.stringMatching(/^feed:staging:metadata:.*:6$/)
+    );
+  });
+
+  it('cleans staged keys when atomic publish returns an unexpected value', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          post_uri: 'at://did:plc:test/post/1',
+          total_score: 0.8,
+          author_did: 'did:plc:author',
+          bridging_score: 0.2,
+          engagement_score: 0.4,
+          embed_url: null,
+          text_length: 50,
+        }],
+      });
+    getCurrentContentRulesMock.mockResolvedValue({ includeKeywords: [], excludeKeywords: [] });
+    hasActiveContentRulesMock.mockReturnValue(false);
+    redisEvalMock.mockResolvedValueOnce(0);
+
+    await expect(runScoringPipeline()).rejects.toThrow(
+      'Atomic feed publish returned unexpected result: 0'
+    );
+
+    expect(redisDelMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not publish when staged materialization is aborted', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          post_uri: 'at://did:plc:test/post/1',
+          total_score: 0.8,
+          author_did: 'did:plc:author',
+          bridging_score: 0.2,
+          engagement_score: 0.4,
+          embed_url: null,
+          text_length: 50,
+        }],
+      });
+    getCurrentContentRulesMock.mockResolvedValue({ includeKeywords: [], excludeKeywords: [] });
+    hasActiveContentRulesMock.mockReturnValue(false);
+    pipelineExecMock.mockResolvedValueOnce(null);
+
+    await expect(runScoringPipeline()).rejects.toThrow('exec returned null');
+
+    expect(redisEvalMock).not.toHaveBeenCalled();
+    expect(redisDelMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not publish when a staged materialization command fails', async () => {
+    const stagingError = new Error('staging command failed');
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          post_uri: 'at://did:plc:test/post/1',
+          total_score: 0.8,
+          author_did: 'did:plc:author',
+          bridging_score: 0.2,
+          engagement_score: 0.4,
+          embed_url: null,
+          text_length: 50,
+        }],
+      });
+    getCurrentContentRulesMock.mockResolvedValue({ includeKeywords: [], excludeKeywords: [] });
+    hasActiveContentRulesMock.mockReturnValue(false);
+    pipelineExecMock.mockResolvedValueOnce([
+      [null, 1],
+      [stagingError, null],
+    ]);
+
+    await expect(runScoringPipeline()).rejects.toThrow(
+      'staged feed materialization at command 1: staging command failed'
+    );
+
+    expect(redisEvalMock).not.toHaveBeenCalled();
+    expect(redisDelMock).toHaveBeenCalledOnce();
   });
 });

--- a/tests/pipeline-empty-feed.test.ts
+++ b/tests/pipeline-empty-feed.test.ts
@@ -16,6 +16,7 @@ const {
   hasActiveContentRulesMock,
   filterPostsMock,
   updateScoringStatusMock,
+  loggerWarnMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
   redisPipelineFactoryMock: vi.fn(),
@@ -32,6 +33,7 @@ const {
   hasActiveContentRulesMock: vi.fn(),
   filterPostsMock: vi.fn(),
   updateScoringStatusMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
 }));
 
 vi.mock('../src/db/client.js', () => ({
@@ -59,6 +61,15 @@ vi.mock('../src/governance/content-filter.js', () => ({
 
 vi.mock('../src/admin/status-tracker.js', () => ({
   updateScoringStatus: updateScoringStatusMock,
+}));
+
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: loggerWarnMock,
+  },
 }));
 
 import { runScoringPipeline, __resetPipelineState } from '../src/scoring/pipeline.js';
@@ -188,6 +199,65 @@ describe('scoring pipeline empty-feed Redis updates', () => {
     );
   });
 
+  it('preserves the served feed when empty-result telemetry fails', async () => {
+    const telemetryError = new Error('empty-result telemetry unavailable');
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    getCurrentContentRulesMock.mockResolvedValue({ includeKeywords: [], excludeKeywords: [] });
+    hasActiveContentRulesMock.mockReturnValue(false);
+    redisIncrMock.mockRejectedValueOnce(telemetryError);
+
+    await expect(runScoringPipeline()).resolves.toBeUndefined();
+
+    expect(redisPipelineFactoryMock).not.toHaveBeenCalled();
+    expect(redisEvalMock).not.toHaveBeenCalled();
+    expect(redisDelMock).not.toHaveBeenCalled();
+    expect(redisSetMock).toHaveBeenCalledWith('feed:last_empty_result_at', expect.any(String));
+    expect(updateScoringStatusMock).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          failures: [{ key: 'feed:empty_result_skipped_total', error: telemetryError }],
+          epochId: 2,
+          runId: expect.any(String),
+        }),
+        'Failed to record empty feed publish telemetry'
+      );
+    });
+  });
+
+  it('preserves the served feed when empty-result timestamp telemetry fails', async () => {
+    const telemetryError = new Error('empty-result timestamp unavailable');
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    getCurrentContentRulesMock.mockResolvedValue({ includeKeywords: [], excludeKeywords: [] });
+    hasActiveContentRulesMock.mockReturnValue(false);
+    redisSetMock.mockRejectedValueOnce(telemetryError);
+
+    await expect(runScoringPipeline()).resolves.toBeUndefined();
+
+    expect(redisIncrMock).toHaveBeenCalledWith('feed:empty_result_skipped_total');
+    expect(redisPipelineFactoryMock).not.toHaveBeenCalled();
+    expect(redisEvalMock).not.toHaveBeenCalled();
+    expect(redisDelMock).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          failures: [{ key: 'feed:last_empty_result_at', error: telemetryError }],
+          epochId: 2,
+          runId: expect.any(String),
+        }),
+        'Failed to record empty feed publish telemetry'
+      );
+    });
+  });
+
   it('builds SQL keyword prefilter so LIMIT applies to matching posts', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [makeEpochRow()] })   // getActiveEpoch
@@ -304,6 +374,7 @@ describe('scoring pipeline empty-feed Redis updates', () => {
 
     await expect(runScoringPipeline()).rejects.toThrow('publish failed');
 
+    expect(pipelineExpireMock).toHaveBeenCalledTimes(9);
     expect(redisDelMock).toHaveBeenCalledWith(
       expect.stringMatching(/^feed:staging:current:/),
       expect.stringMatching(/^feed:staging:last_known_good:/),

--- a/tests/relevance-floor.test.ts
+++ b/tests/relevance-floor.test.ts
@@ -43,7 +43,9 @@ vi.mock('../src/db/client.js', () => ({
 vi.mock('../src/db/redis.js', () => ({
   redis: {
     pipeline: redisPipelineFactoryMock,
+    multi: redisPipelineFactoryMock,
     incr: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue('OK'),
     del: vi.fn().mockResolvedValue(1),
     eval: vi.fn().mockResolvedValue(1),
   },
@@ -104,6 +106,7 @@ describe('relevance floor in feed output', () => {
 
     const pipeline = {
       del: pipelineDelMock.mockReturnThis(),
+      expire: vi.fn().mockReturnThis(),
       zadd: pipelineZaddMock.mockReturnThis(),
       set: pipelineSetMock.mockReturnThis(),
       exec: pipelineExecMock.mockResolvedValue([]),
@@ -166,7 +169,7 @@ describe('relevance floor in feed output', () => {
     expect(writeCall![1][3]).toBe(0.15);
   });
 
-  it('clears feed and writes zero count when no posts pass floor', async () => {
+  it('preserves the served feed when no posts pass floor', async () => {
     // No posts to score → writeToRedisFromDb returns empty
     dbQueryMock
       .mockResolvedValueOnce({ rows: [makeEpochRow()] })
@@ -176,8 +179,7 @@ describe('relevance floor in feed output', () => {
 
     await runScoringPipeline();
 
-    expect(pipelineDelMock).toHaveBeenCalledWith('feed:current');
-    expect(pipelineSetMock).toHaveBeenCalledWith('feed:count', '0');
+    expect(redisPipelineFactoryMock).not.toHaveBeenCalled();
     expect(pipelineZaddMock).not.toHaveBeenCalled();
   });
 
@@ -196,11 +198,14 @@ describe('relevance floor in feed output', () => {
     await runScoringPipeline();
 
     expect(pipelineZaddMock).toHaveBeenCalledWith(
-      'feed:current',
+      expect.stringMatching(/^feed:staging:current:/),
       0.85,
       'at://did:plc:test/post/high'
     );
-    expect(pipelineSetMock).toHaveBeenCalledWith('feed:count', '1');
+    expect(pipelineSetMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:metadata:.*:3$/),
+      '1'
+    );
   });
 
   it('writes correct metadata count for multiple posts', async () => {
@@ -217,8 +222,18 @@ describe('relevance floor in feed output', () => {
 
     await runScoringPipeline();
 
-    expect(pipelineSetMock).toHaveBeenCalledWith('feed:count', '2');
+    expect(pipelineSetMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:metadata:.*:3$/),
+      '2'
+    );
     expect(pipelineZaddMock).toHaveBeenCalledTimes(2);
+    expect(pipelineZaddMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^feed:staging:current:/),
+      0.9,
+      'at://post/1',
+      0.7,
+      'at://post/2'
+    );
   });
 
   it('epoch ID is passed as first parameter to writeToRedisFromDb query', async () => {

--- a/tests/scoring-longtable-dualwrite.test.ts
+++ b/tests/scoring-longtable-dualwrite.test.ts
@@ -55,7 +55,14 @@ vi.mock('../src/db/client.js', () => ({
 }));
 
 vi.mock('../src/db/redis.js', () => ({
-  redis: { pipeline: redisPipelineFactoryMock, incr: vi.fn().mockResolvedValue(1), del: vi.fn().mockResolvedValue(1), eval: vi.fn().mockResolvedValue(1) },
+  redis: {
+    pipeline: redisPipelineFactoryMock,
+    multi: redisPipelineFactoryMock,
+    incr: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue('OK'),
+    del: vi.fn().mockResolvedValue(1),
+    eval: vi.fn().mockResolvedValue(1),
+  },
 }));
 
 vi.mock('../src/governance/content-filter.js', () => ({
@@ -87,6 +94,7 @@ import { buildEpochRow, buildPostRow } from './helpers/index.js';
 function setupDefaultMocks() {
   const pipeline = {
     del: pipelineDelMock.mockReturnThis(),
+    expire: vi.fn().mockReturnThis(),
     zadd: pipelineZaddMock.mockReturnThis(),
     set: pipelineSetMock.mockReturnThis(),
     exec: pipelineExecMock.mockResolvedValue([]),

--- a/tests/scoring-pipeline-embeddings.test.ts
+++ b/tests/scoring-pipeline-embeddings.test.ts
@@ -46,7 +46,14 @@ vi.mock('../src/db/client.js', () => ({
 }));
 
 vi.mock('../src/db/redis.js', () => ({
-  redis: { pipeline: redisPipelineFactoryMock, incr: vi.fn().mockResolvedValue(1), del: vi.fn().mockResolvedValue(1), eval: vi.fn().mockResolvedValue(1) },
+  redis: {
+    pipeline: redisPipelineFactoryMock,
+    multi: redisPipelineFactoryMock,
+    incr: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue('OK'),
+    del: vi.fn().mockResolvedValue(1),
+    eval: vi.fn().mockResolvedValue(1),
+  },
 }));
 
 vi.mock('../src/governance/content-filter.js', () => ({
@@ -80,6 +87,7 @@ import { buildEpochRow, buildPostRow } from './helpers/index.js';
 function setupDefaultMocks() {
   const pipeline = {
     del: pipelineDelMock.mockReturnThis(),
+    expire: vi.fn().mockReturnThis(),
     zadd: pipelineZaddMock.mockReturnThis(),
     set: pipelineSetMock.mockReturnThis(),
     exec: pipelineExecMock.mockResolvedValue([]),

--- a/tests/scoring-pipeline-rescore.test.ts
+++ b/tests/scoring-pipeline-rescore.test.ts
@@ -31,7 +31,9 @@ vi.mock('../src/db/client.js', () => ({
 vi.mock('../src/db/redis.js', () => ({
   redis: {
     pipeline: redisPipelineFactoryMock,
+    multi: redisPipelineFactoryMock,
     incr: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue('OK'),
     del: vi.fn().mockResolvedValue(1),
     eval: vi.fn().mockResolvedValue(1),
   },
@@ -57,6 +59,7 @@ function makeEpochRow(id = 2) {
 function setupDefaultMocks() {
   const pipeline = {
     del: pipelineDelMock.mockReturnThis(),
+    expire: vi.fn().mockReturnThis(),
     zadd: pipelineZaddMock.mockReturnThis(),
     set: pipelineSetMock.mockReturnThis(),
     exec: pipelineExecMock.mockResolvedValue([]),

--- a/tests/scoring-source-diversity-determinism.test.ts
+++ b/tests/scoring-source-diversity-determinism.test.ts
@@ -53,7 +53,13 @@ const {
 
 vi.mock('../src/db/client.js', () => ({ db: { query: dbQueryMock } }));
 vi.mock('../src/db/redis.js', () => ({
-  redis: { pipeline: redisPipelineFactoryMock, incr: vi.fn().mockResolvedValue(1), del: vi.fn().mockResolvedValue(1), eval: vi.fn().mockResolvedValue(1) },
+  redis: {
+    pipeline: redisPipelineFactoryMock,
+    incr: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue('OK'),
+    del: vi.fn().mockResolvedValue(1),
+    eval: vi.fn().mockResolvedValue(1),
+  },
 }));
 vi.mock('../src/governance/content-filter.js', () => ({
   getCurrentContentRules: getCurrentContentRulesMock,

--- a/tests/url-dedup.test.ts
+++ b/tests/url-dedup.test.ts
@@ -114,11 +114,15 @@ function getZaddCalls(): Array<{ score: number; member: string }> {
   return pipelineZaddMock.mock.calls
     .filter((call: unknown[]) => String(call[0]).startsWith('feed:staging:current:'))
     .flatMap((call: unknown[]) => {
+      expect((call.length - 1) % 2).toBe(0);
       const entries: Array<{ score: number; member: string }> = [];
       for (let index = 1; index < call.length; index += 2) {
+        expect(typeof call[index]).toBe('number');
+        expect(Number.isFinite(call[index])).toBe(true);
+        expect(typeof call[index + 1]).toBe('string');
         entries.push({
-          score: Number(call[index]),
-          member: String(call[index + 1]),
+          score: call[index] as number,
+          member: call[index + 1] as string,
         });
       }
       return entries;
@@ -130,6 +134,39 @@ describe('URL deduplication in writeToRedisFromDb', () => {
     __resetPipelineState();
     vi.clearAllMocks();
     setupDefaultMocks();
+  });
+
+  it('parses multiple score-member pairs from one staged ZADD', () => {
+    pipelineZaddMock(
+      'feed:staging:current:test-run',
+      0.9,
+      'at://post/1',
+      0.7,
+      'at://post/2'
+    );
+
+    expect(getZaddCalls()).toEqual([
+      { score: 0.9, member: 'at://post/1' },
+      { score: 0.7, member: 'at://post/2' },
+    ]);
+  });
+
+  it('rejects a malformed staged ZADD command', () => {
+    pipelineZaddMock('feed:staging:current:test-run', 0.9);
+
+    expect(() => getZaddCalls()).toThrow();
+  });
+
+  it('rejects a staged ZADD with a non-numeric score', () => {
+    pipelineZaddMock('feed:staging:current:test-run', '0.9', 'at://post/1');
+
+    expect(() => getZaddCalls()).toThrow();
+  });
+
+  it('rejects a staged ZADD with a non-string member', () => {
+    pipelineZaddMock('feed:staging:current:test-run', 0.9, 12345);
+
+    expect(() => getZaddCalls()).toThrow();
   });
 
   it('first post with a URL gets full score', async () => {

--- a/tests/url-dedup.test.ts
+++ b/tests/url-dedup.test.ts
@@ -114,6 +114,7 @@ function getZaddCalls(): Array<{ score: number; member: string }> {
   return pipelineZaddMock.mock.calls
     .filter((call: unknown[]) => String(call[0]).startsWith('feed:staging:current:'))
     .flatMap((call: unknown[]) => {
+      expect(call.length).toBeGreaterThanOrEqual(3);
       expect((call.length - 1) % 2).toBe(0);
       const entries: Array<{ score: number; member: string }> = [];
       for (let index = 1; index < call.length; index += 2) {
@@ -153,6 +154,12 @@ describe('URL deduplication in writeToRedisFromDb', () => {
 
   it('rejects a malformed staged ZADD command', () => {
     pipelineZaddMock('feed:staging:current:test-run', 0.9);
+
+    expect(() => getZaddCalls()).toThrow();
+  });
+
+  it('rejects a staged ZADD with no score-member pairs', () => {
+    pipelineZaddMock('feed:staging:current:test-run');
 
     expect(() => getZaddCalls()).toThrow();
   });

--- a/tests/url-dedup.test.ts
+++ b/tests/url-dedup.test.ts
@@ -39,7 +39,9 @@ vi.mock('../src/db/client.js', () => ({
 vi.mock('../src/db/redis.js', () => ({
   redis: {
     pipeline: redisPipelineFactoryMock,
+    multi: redisPipelineFactoryMock,
     incr: vi.fn().mockResolvedValue(1),
+    set: vi.fn().mockResolvedValue('OK'),
     del: vi.fn().mockResolvedValue(1),
     eval: vi.fn().mockResolvedValue(1),
   },
@@ -66,6 +68,7 @@ function makeEpochRow(id = 2) {
 function setupDefaultMocks() {
   const pipeline = {
     del: pipelineDelMock.mockReturnThis(),
+    expire: vi.fn().mockReturnThis(),
     zadd: pipelineZaddMock.mockReturnThis(),
     set: pipelineSetMock.mockReturnThis(),
     exec: pipelineExecMock.mockResolvedValue([]),
@@ -108,12 +111,18 @@ async function runWithFeedRows(
 
 /** Extract zadd calls as an array of { score, member } objects. */
 function getZaddCalls(): Array<{ score: number; member: string }> {
-  return pipelineZaddMock.mock.calls.map(
-    (call: [string, number, string]) => ({
-      score: call[1],
-      member: call[2],
-    })
-  );
+  return pipelineZaddMock.mock.calls
+    .filter((call: unknown[]) => String(call[0]).startsWith('feed:staging:current:'))
+    .flatMap((call: unknown[]) => {
+      const entries: Array<{ score: number; member: string }> = [];
+      for (let index = 1; index < call.length; index += 2) {
+        entries.push({
+          score: Number(call[index]),
+          member: String(call[index + 1]),
+        });
+      }
+      return entries;
+    });
 }
 
 describe('URL deduplication in writeToRedisFromDb', () => {


### PR DESCRIPTION
## Summary

- preserve the currently served feed when scoring produces zero publishable rows
- atomically promote staged current, last-known-good, and metadata keys with a preflighted Redis Lua script
- serve last-known-good through the shared snapshot cache only when current is empty
- keep fallback telemetry independent, non-blocking, and free of false zero-valued current-feed metrics

## Verification

- focused reliability slice: 8 files / 92 tests passed
- exact Lua script against local Redis: 9 keys promoted; failed preflight preserved destination state
- full `npm run verify` with `.env.example` and `NODE_ENV=production`: 109 files / 1,025 tests passed; CLI, SDK, legacy web, and `web-next` export passed
- docs verification: 14 tracked docs / 33 Markdown files passed
- first hosted CodeRabbit findings addressed: 0 major, 2 minor, and 4 trivial
- hosted current-head CodeRabbit findings addressed: 7 actionable findings
- `git diff --check`: pass

## Boundaries

- no production rescore or Redis mutation was induced
- `feed:last_known_good` should be populated by the next normal non-empty scoring cycle after an approved deployment
- no public route, schema, auth contract, or UI component changes
- merge and deployment remain separately approval-gated

Linear: PROJ-1467

## CodeRabbit Audit

- Status: exempt
- Reason: The implementation head received a clean CodeRabbit review; a later empty event-refresh commit caused three superseded review threads and sticky legacy review state to block otherwise-green gates.
- Follow-up: Remove the exemption after merge; reopen review immediately if any new current-head finding appears.
- Expires: 2026-07-11
