### PR TITLE
[PROJ-1692] Fix demo Redis deploy permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,9 +72,9 @@ jobs:
             cd ..
             cd cli && npm ci && npx tsc
             cd ..
-            docker compose -f docker-compose.prod.yml up -d --no-deps demo-redis
+            sudo docker compose -f docker-compose.prod.yml up -d --no-deps demo-redis
             for i in 1 2 3 4 5; do
-              if docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli ping | grep -q PONG; then
+              if sudo docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli ping | grep -q PONG; then
                 echo "Isolated demo Redis is ready (attempt $i/5)"
                 break
               fi
@@ -123,27 +123,27 @@ jobs:
                 DEMO_MAXMEMORY="probe-failed"
                 DEMO_APPENDONLY="probe-failed"
                 DEMO_SAVE="probe-failed"
-                if ! DEMO_KEY_EXISTS=$(docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw EXISTS "$DEMO_KEY"); then
+                if ! DEMO_KEY_EXISTS=$(sudo docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw EXISTS "$DEMO_KEY"); then
                   echo "Demo Redis session-key probe failed"
                   HEALTHY=false
                 fi
-                if ! PRODUCTION_KEY_EXISTS=$(docker compose -f docker-compose.prod.yml exec -T redis redis-cli --raw EXISTS "$DEMO_KEY"); then
+                if ! PRODUCTION_KEY_EXISTS=$(sudo docker compose -f docker-compose.prod.yml exec -T redis redis-cli --raw EXISTS "$DEMO_KEY"); then
                   echo "Production Redis isolation probe failed"
                   HEALTHY=false
                 fi
-                if ! DEMO_POLICY=$(docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw CONFIG GET maxmemory-policy | tail -n 1); then
+                if ! DEMO_POLICY=$(sudo docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw CONFIG GET maxmemory-policy | tail -n 1); then
                   echo "Demo Redis maxmemory-policy probe failed"
                   HEALTHY=false
                 fi
-                if ! DEMO_MAXMEMORY=$(docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw CONFIG GET maxmemory | tail -n 1); then
+                if ! DEMO_MAXMEMORY=$(sudo docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw CONFIG GET maxmemory | tail -n 1); then
                   echo "Demo Redis maxmemory probe failed"
                   HEALTHY=false
                 fi
-                if ! DEMO_APPENDONLY=$(docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw CONFIG GET appendonly | tail -n 1); then
+                if ! DEMO_APPENDONLY=$(sudo docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw CONFIG GET appendonly | tail -n 1); then
                   echo "Demo Redis appendonly probe failed"
                   HEALTHY=false
                 fi
-                if ! DEMO_SAVE=$(docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw CONFIG GET save | tail -n 1); then
+                if ! DEMO_SAVE=$(sudo docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli --raw CONFIG GET save | tail -n 1); then
                   echo "Demo Redis save-policy probe failed"
                   HEALTHY=false
                 fi

--- a/tests/demo-shadow-isolation.test.ts
+++ b/tests/demo-shadow-isolation.test.ts
@@ -73,6 +73,14 @@ describe('shadow demo isolation guards', () => {
     expect(deploy).toContain('DEMO_POLICY');
     expect(deploy).toContain(`DEMO_KEY="${demoSessionKeyPrefix()}\${DEMO_SESSION_ID}"`);
 
+    const deployDockerCommands = deploy
+      .split('\n')
+      .filter((line) => line.includes('docker compose'));
+    expect(deployDockerCommands.length).toBeGreaterThan(0);
+    expect(
+      deployDockerCommands.every((line) => line.includes('sudo docker compose'))
+    ).toBe(true);
+
     const demoCompose = compose.split('demo-redis:')[1];
     const maxmemoryMatch = demoCompose?.match(/--maxmemory\s+(\d+)mb/);
     expect(maxmemoryMatch).toBeDefined();

--- a/tests/demo-shadow-isolation.test.ts
+++ b/tests/demo-shadow-isolation.test.ts
@@ -73,13 +73,7 @@ describe('shadow demo isolation guards', () => {
     expect(deploy).toContain('DEMO_POLICY');
     expect(deploy).toContain(`DEMO_KEY="${demoSessionKeyPrefix()}\${DEMO_SESSION_ID}"`);
 
-    const deployDockerCommands = deploy
-      .split('\n')
-      .filter((line) => line.includes('docker compose'));
-    expect(deployDockerCommands.length).toBeGreaterThan(0);
-    expect(
-      deployDockerCommands.every((line) => line.includes('sudo docker compose'))
-    ).toBe(true);
+    expect(usesOnlySudoDockerComposeCommands(deploy)).toBe(true);
 
     const demoCompose = compose.split('demo-redis:')[1];
     const maxmemoryMatch = demoCompose?.match(/--maxmemory\s+(\d+)mb/);
@@ -88,6 +82,135 @@ describe('shadow demo isolation guards', () => {
     expect(deploy).toContain(`[ "$DEMO_MAXMEMORY" != "${maxmemoryBytes}" ]`);
   });
 });
+
+describe('sudo Docker Compose command matcher', () => {
+  it.each([
+    'sudo docker compose up -d',
+    'if sudo docker compose exec -T demo-redis redis-cli ping; then true; fi',
+    'VALUE=$(sudo docker compose exec -T demo-redis redis-cli ping)',
+    'sudo docker \\\n      compose up -d',
+  ])('accepts privileged invocation: %j', (script) => {
+    expect(usesOnlySudoDockerComposeCommands(script)).toBe(true);
+  });
+
+  it.each([
+    '',
+    'docker compose up -d',
+    'sudo docker compose up -d\ndocker compose ps',
+    '# sudo docker compose up -d',
+    'echo "sudo docker compose up -d"',
+    'echo sudo docker compose up -d',
+    'docker \\\n      compose up -d',
+  ])('rejects missing or non-privileged invocation: %j', (script) => {
+    expect(usesOnlySudoDockerComposeCommands(script)).toBe(false);
+  });
+});
+
+function usesOnlySudoDockerComposeCommands(script: string): boolean {
+  const tokens = tokenizeShellCommands(script);
+  const invocationIndexes = tokens.flatMap((token, index) =>
+    token === 'docker' && tokens[index + 1] === 'compose' ? [index] : []
+  );
+
+  return (
+    invocationIndexes.length > 0 &&
+    invocationIndexes.every((index) => isDirectSudoCommand(tokens, index))
+  );
+}
+
+function isDirectSudoCommand(tokens: string[], dockerIndex: number): boolean {
+  if (tokens[dockerIndex - 1] !== 'sudo') {
+    return false;
+  }
+
+  const boundaries = new Set(['\n', ';', '&', '|', '(', ')']);
+  let commandStart = dockerIndex - 1;
+  while (commandStart > 0 && !boundaries.has(tokens[commandStart - 1])) {
+    commandStart -= 1;
+  }
+
+  const controlWords = new Set(['if', 'then', 'elif', 'while', 'until', '!']);
+  const commandPrefix = tokens
+    .slice(commandStart, dockerIndex)
+    .filter((token) => !controlWords.has(token));
+  return commandPrefix.length === 1 && commandPrefix[0] === 'sudo';
+}
+
+function tokenizeShellCommands(script: string): string[] {
+  const tokens: string[] = [];
+  let word = '';
+  let quote: "'" | '"' | null = null;
+  let index = 0;
+
+  const pushWord = (): void => {
+    if (word.length > 0) {
+      tokens.push(word);
+      word = '';
+    }
+  };
+
+  while (index < script.length) {
+    const char = script[index];
+    const next = script[index + 1];
+
+    if (quote !== null) {
+      if (char === quote) {
+        quote = null;
+      } else if (char === '\\' && quote === '"' && next !== undefined) {
+        word += next;
+        index += 1;
+      } else {
+        word += char;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      index += 1;
+      continue;
+    }
+
+    if (char === '\\' && next === '\n') {
+      index += 2;
+      continue;
+    }
+
+    if (char === '#' && word.length === 0) {
+      while (index < script.length && script[index] !== '\n') {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === '\n') {
+      pushWord();
+      tokens.push('\n');
+      index += 1;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      pushWord();
+      index += 1;
+      continue;
+    }
+
+    if (';&|()'.includes(char)) {
+      pushWord();
+      tokens.push(char);
+      index += 1;
+      continue;
+    }
+
+    word += char;
+    index += 1;
+  }
+
+  pushWord();
+  return tokens;
+}
 
 function demoSourceText(): string {
   return sourceFiles(DEMO_SRC_DIR)


### PR DESCRIPTION
## Summary
- run only the demo Redis deployment and isolation probes through `sudo docker compose`
- preserve all application, systemd, secret, and production Redis behavior
- add a shell-token regression matcher covering direct, conditional, nested, continued, comment, echo, empty, and unprivileged Compose cases

## Verification
- `npx vitest tests/demo-shadow-isolation.test.ts --run` (15 passed)
- `npm run verify` (120 files, 1,158 tests)
- `npm run docs:verify`
- `cd web-next && npm run lint`
- `cd web-next && npx tsc --noEmit`
- `web-next` production build via `npm run verify`

## CodeRabbit Review
- current head: `5efdb996b3e52d5576ba28dbf94828664c8b7ac0`
- exact-head state: APPROVED
- actionable finding fixed with shell-token parsing and boundary fixtures
- unresolved current-head threads: 0
- repository freshness and thread truth gates: passed

## CodeRabbit Audit
- Status: exempt
- Reason: The legacy GitHub freshness workflow token reports a missing CodeRabbit check-suite even though the repository truth wrapper observes an APPROVED review on exact head `5efdb996b3e52d5576ba28dbf94828664c8b7ac0` with zero unresolved threads.
- Follow-up: PROJ-1692
- Expires: 2026-07-12

## Production Context
Deploy run 29137599407 failed before service restart because the CI SSH user could not access `/var/run/docker.sock`. The prior production process stayed live. This hotfix changes no daemon permissions and no runtime contract.