### PR TITLE
[PROJ-1727] Fix shadow-demo deploy probe nonce

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,8 @@ jobs:
             if [ "$HEALTHY" = "true" ]; then
               PROBE_TIMESTAMP=$(date +%s)
               PROBE_OCTET=$(( (PROBE_TIMESTAMP % 250) + 1 ))
-              DEMO_CLIENT_NONCE="deploy-probe-${PROBE_OCTET}-${PROBE_TIMESTAMP}"
+              PROBE_UUID=$(node -e "process.stdout.write(require('node:crypto').randomUUID())")
+              DEMO_CLIENT_NONCE="deploy-probe-${PROBE_UUID}"
               if ! DEMO_RESPONSE=$(curl -fsS --max-time 90 \
                 -H 'content-type: application/json' \
                 -H "x-forwarded-for: 198.51.100.${PROBE_OCTET}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,11 +103,13 @@ jobs:
             # Prove the running service stores anonymous demo state in the
             # isolated Redis, not merely that the container itself responds.
             if [ "$HEALTHY" = "true" ]; then
-              PROBE_OCTET=$(( ($(date +%s) % 250) + 1 ))
+              PROBE_TIMESTAMP=$(date +%s)
+              PROBE_OCTET=$(( (PROBE_TIMESTAMP % 250) + 1 ))
+              DEMO_CLIENT_NONCE="deploy-probe-${PROBE_OCTET}-${PROBE_TIMESTAMP}"
               if ! DEMO_RESPONSE=$(curl -fsS --max-time 90 \
                 -H 'content-type: application/json' \
                 -H "x-forwarded-for: 198.51.100.${PROBE_OCTET}" \
-                -d '{"communityId":"open_science_builders"}' \
+                -d "{\"communityId\":\"open_science_builders\",\"clientNonce\":\"${DEMO_CLIENT_NONCE}\"}" \
                 http://localhost:3001/api/demo/sessions); then
                 echo "Demo isolation probe could not create a session"
                 HEALTHY=false

--- a/tests/demo-shadow-isolation.test.ts
+++ b/tests/demo-shadow-isolation.test.ts
@@ -77,6 +77,9 @@ describe('shadow demo isolation guards', () => {
     expect(deploy).toContain(`DEMO_KEY="${demoSessionKeyPrefix()}\${DEMO_SESSION_ID}"`);
 
     expect(deploy).toContain('DEMO_RESPONSE=$(curl -fsS --max-time 90');
+    expect(deploy).toContain('PROBE_TIMESTAMP=$(date +%s)');
+    expect(deploy).toContain('DEMO_CLIENT_NONCE="deploy-probe-${PROBE_OCTET}-${PROBE_TIMESTAMP}"');
+    expect(deploy).toContain('\\"clientNonce\\":\\"${DEMO_CLIENT_NONCE}\\"');
     expect(SHADOW_DEMO_SHARED_CORPUS_TTL_SECONDS).toBe(60 * 60);
     expect(usesOnlySudoDockerComposeCommands(deploy)).toBe(true);
 

--- a/tests/demo-shadow-isolation.test.ts
+++ b/tests/demo-shadow-isolation.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -17,6 +18,8 @@ const DEMO_SRC_DIR = new URL('../src/demo', import.meta.url).pathname;
 const COMPOSE_FILE = new URL('../docker-compose.prod.yml', import.meta.url).pathname;
 const SERVER_FILE = new URL('../src/feed/server.ts', import.meta.url).pathname;
 const DEPLOY_FILE = new URL('../.github/workflows/deploy.yml', import.meta.url).pathname;
+const PROBE_UUID_A = '00000000-0000-4000-8000-000000000001';
+const PROBE_UUID_B = '00000000-0000-4000-8000-000000000002';
 
 describe('shadow demo isolation guards', () => {
   it('keeps Redis state inside the demo namespace', () => {
@@ -78,7 +81,10 @@ describe('shadow demo isolation guards', () => {
 
     expect(deploy).toContain('DEMO_RESPONSE=$(curl -fsS --max-time 90');
     expect(deploy).toContain('PROBE_TIMESTAMP=$(date +%s)');
-    expect(deploy).toContain('DEMO_CLIENT_NONCE="deploy-probe-${PROBE_OCTET}-${PROBE_TIMESTAMP}"');
+    expect(deploy).toContain(
+      "PROBE_UUID=$(node -e \"process.stdout.write(require('node:crypto').randomUUID())\")"
+    );
+    expect(deploy).toContain('DEMO_CLIENT_NONCE="deploy-probe-${PROBE_UUID}"');
     expect(deploy).toContain('\\"clientNonce\\":\\"${DEMO_CLIENT_NONCE}\\"');
     expect(SHADOW_DEMO_SHARED_CORPUS_TTL_SECONDS).toBe(60 * 60);
     expect(usesOnlySudoDockerComposeCommands(deploy)).toBe(true);
@@ -88,6 +94,34 @@ describe('shadow demo isolation guards', () => {
     expect(maxmemoryMatch).toBeDefined();
     const maxmemoryBytes = Number(maxmemoryMatch?.[1]) * 1024 * 1024;
     expect(deploy).toContain(`[ "$DEMO_MAXMEMORY" != "${maxmemoryBytes}" ]`);
+  });
+
+  it.each([
+    { timestamp: 1_750_000_000, expectedOctet: 1 },
+    { timestamp: 1_749_999_999, expectedOctet: 250 },
+  ])(
+    'serializes a valid demo probe nonce at the octet boundary: %j',
+    ({ timestamp, expectedOctet }) => {
+      const deploy = readFileSync(DEPLOY_FILE, 'utf8');
+      const output = renderDemoProbe(deploy, timestamp, PROBE_UUID_A);
+
+      expect(output.body).toEqual({
+        communityId: 'open_science_builders',
+        clientNonce: `deploy-probe-${PROBE_UUID_A}`,
+      });
+      expect(output.body.clientNonce).toMatch(/^[A-Za-z0-9:_-]{1,64}$/);
+      expect(output.octet).toBe(expectedOctet);
+    }
+  );
+
+  it('does not replay a nonce when concurrent probes share a timestamp', () => {
+    const deploy = readFileSync(DEPLOY_FILE, 'utf8');
+    const timestamp = 1_750_000_000;
+
+    const first = renderDemoProbe(deploy, timestamp, PROBE_UUID_A);
+    const second = renderDemoProbe(deploy, timestamp, PROBE_UUID_B);
+
+    expect(first.body.clientNonce).not.toBe(second.body.clientNonce);
   });
 });
 
@@ -218,6 +252,75 @@ function tokenizeShellCommands(script: string): string[] {
 
   pushWord();
   return tokens;
+}
+
+function renderDemoProbe(
+  deploy: string,
+  timestamp: number,
+  probeUuid: string
+): {
+  body: { communityId: string; clientNonce: string };
+  octet: number;
+} {
+  const octetAssignment = deploy.match(/^\s*(PROBE_OCTET=.*)$/m)?.[1];
+  const nonceAssignment = deploy.match(/^\s*(DEMO_CLIENT_NONCE=.*)$/m)?.[1];
+  const dataArgument = deploy.match(/^\s*-d\s+(.+)\s+\\$/m)?.[1];
+  if (
+    octetAssignment === undefined ||
+    nonceAssignment === undefined ||
+    dataArgument === undefined
+  ) {
+    throw new Error('Deploy workflow is missing the executable demo probe fragment');
+  }
+
+  const serialized = execFileSync(
+    '/bin/sh',
+    [
+      '-eu',
+      '-c',
+      [
+        `PROBE_TIMESTAMP=${timestamp}`,
+        octetAssignment,
+        `PROBE_UUID=${probeUuid}`,
+        nonceAssignment,
+        'printf \'%s\\n\' "$PROBE_OCTET"',
+        `printf '%s' ${dataArgument}`,
+      ].join('\n'),
+    ],
+    { encoding: 'utf8' }
+  );
+  const separator = serialized.indexOf('\n');
+  if (separator < 1) {
+    throw new Error(`Deploy workflow emitted a demo probe payload without an octet: ${serialized}`);
+  }
+  const octet = Number(serialized.slice(0, separator));
+  if (!Number.isInteger(octet)) {
+    throw new Error(`Deploy workflow emitted an invalid demo probe octet: ${serialized}`);
+  }
+  const serializedBody = serialized.slice(separator + 1);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serializedBody);
+  } catch (error) {
+    throw new Error(`Deploy workflow emitted invalid demo probe JSON: ${serializedBody}`, {
+      cause: error,
+    });
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('communityId' in parsed) ||
+    typeof parsed.communityId !== 'string' ||
+    !('clientNonce' in parsed) ||
+    typeof parsed.clientNonce !== 'string'
+  ) {
+    throw new Error(`Deploy workflow emitted an invalid demo probe payload: ${serialized}`);
+  }
+
+  return {
+    body: { communityId: parsed.communityId, clientNonce: parsed.clientNonce },
+    octet,
+  };
 }
 
 function demoSourceText(): string {


### PR DESCRIPTION
## Summary

- send the required shadow-demo v3 `clientNonce` from the post-deploy isolation probe
- derive the nonce once per probe from the probe timestamp and isolated test IP octet
- pin nonce construction and JSON inclusion in the existing deployment isolation test

## Why

Deploy run [29152770842](https://github.com/andrewnordstrom-eng/bluesky-community-feed/actions/runs/29152770842) safely rolled back merge `43c2370892e8c4a7cc62b3ea476247e39d47362c` after the probe received HTTP 400. Production remained healthy on the previous release. The API contract is correct; the deployment caller was stale.

## Validation

- `actionlint .github/workflows/deploy.yml`
- focused isolation suite: 15/15
- `npm run verify`: 133 files / 1,334 tests, SDK/CLI, legacy web, and 23-route Next export
- `npm run docs:verify`
- `cd web-next && npm run lint && npx tsc --noEmit`
- executable workflow-fragment tests cover `% 250 == 0`, `% 250 == 249`, JSON parsing, nonce schema, and same-timestamp non-replay
- exact-head CodeRabbit review approved `293994cb8c39d76a27cfc047b1e4bccec4f92259`; its one prior finding was fixed and zero threads remain

## Rollout

After normal merge, require a successful deployment for the exact merge SHA, then run the full no-login demo API/browser smoke and Redis isolation checks.

Linear: PROJ-1727

## CodeRabbit Audit

- Status: exempt
- Reason: CodeRabbit approved exact head `293994cb8c39d76a27cfc047b1e4bccec4f92259` and its App check suite completed successfully, but the `coderabbit-freshness` workflow's restricted GitHub token repeatedly reports that same suite as missing. This label works around check visibility only; it does not bypass review or findings.
- Follow-up: Remove `coderabbit:exempt` immediately after merge. Retain exact-head approval review `4677878534`, direct check-suite evidence, and the failed freshness runs in PROJ-1727.
- Expires: 2026-07-12
