### PR TITLE
[PROJ-1742] Fix demo Bluesky post links

### DIFF
--- a/src/demo/public-view.ts
+++ b/src/demo/public-view.ts
@@ -3,7 +3,7 @@ import type { ShadowDemoDisplayPost, ShadowDemoPublicPost } from './types.js';
 
 const HIDDEN_LABELS = new Set(['!no-unauthenticated', '!hide', '!takedown']);
 const ADULT_ONLY_LABELS = new Set(['porn', 'sexual', 'nudity', 'graphic-media']);
-const POST_AT_URI_PATTERN = /^at:\/\/(did:[a-z0-9]+:[A-Za-z0-9._:%-]+)\/app\.bsky\.feed\.post\/([A-Za-z0-9._~:@!$&'()*+,;=-]+)$/;
+const POST_AT_URI_PATTERN = /^at:\/\/(did:[a-z0-9]+:[A-Za-z0-9._:-]+)\/app\.bsky\.feed\.post\/([A-Za-z0-9._~:@!$&'()*+,;=-]+)$/;
 
 const AppViewLabelSchema = z.object({ val: z.string().optional() }).passthrough();
 const AppViewAuthorSchema = z.object({
@@ -144,7 +144,7 @@ export function bskyPostUrlFromAtUri(uri: string): string {
   if (!match) {
     throw new Error(`Cannot build Bluesky URL for non-post AT-URI: ${uri}`);
   }
-  return `https://bsky.app/profile/${encodeURIComponent(match[1])}/post/${encodeURIComponent(match[2])}`;
+  return `https://bsky.app/profile/${match[1]}/post/${encodeURIComponent(match[2])}`;
 }
 
 function labelValuesFrom(labels: AppViewLabel[] | undefined): string[] {

--- a/tests/demo-shadow-public-view.test.ts
+++ b/tests/demo-shadow-public-view.test.ts
@@ -94,7 +94,10 @@ describe('shadow demo public-view filtering', () => {
 
   it('builds Bluesky source URLs from AT Protocol post URIs', () => {
     expect(bskyPostUrlFromAtUri('at://did:plc:author/app.bsky.feed.post/abc123')).toBe(
-      'https://bsky.app/profile/did%3Aplc%3Aauthor/post/abc123'
+      'https://bsky.app/profile/did:plc:author/post/abc123'
+    );
+    expect(bskyPostUrlFromAtUri('at://did:web:example.com:user/app.bsky.feed.post/abc:123')).toBe(
+      'https://bsky.app/profile/did:web:example.com:user/post/abc%3A123'
     );
   });
 
@@ -103,6 +106,7 @@ describe('shadow demo public-view filtering', () => {
       'at://did:plc:author/app.bsky.feed.post/abc?next=1',
       'at://did:plc:author/app.bsky.feed.post/abc#fragment',
       'at://did:plc:author/app.bsky.feed.post/abc 123',
+      'at://did:plc:author%2Fattacker/app.bsky.feed.post/abc123',
     ]) {
       expect(() => bskyPostUrlFromAtUri(uri)).toThrow(/non-post AT-URI/);
     }


### PR DESCRIPTION
## Summary
- preserve DID colon separators in outbound Bluesky post URLs
- continue encoding post record keys
- reject percent-encoded actor path injection and add DID-method regression coverage

## Verification
- focused: 11/11 tests passed
- backend: 1,334/1,334 tests passed
- npm run build passed
- legacy web lint/build passed
- web-next Node 20 production export passed
- docs verification passed

## Production defect
Demo links emitted did%3Aplc%3A... and Bluesky returned Invalid DID or handle. The corrected form is /profile/did:plc:.../post/... .

Linear: PROJ-1742