### PR TITLE
[PROJ-1753] Fix static export revalidation blank page

### DIFF
--- a/docs/quality/PROJ-1753-phase-0.md
+++ b/docs/quality/PROJ-1753-phase-0.md
@@ -1,0 +1,67 @@
+# PROJ-1753 Phase 0 evidence receipt
+
+Date: 2026-07-11  
+Decision owner: Andrew Nordstrom  
+Disposition: **CONFIRMED PRODUCT DEFECT**  
+Approval source: PROJ-1753 discussion comment `a60e3fbd-a831-47b2-af4a-ce7ee20eca0c`
+
+## Decision
+
+The intermittent blank public page is not limited to an automation harness. Ordinary Chrome and Safari both reproduce it when a cached HTML document is revalidated. Static HTML delivery succeeds, but the conditional response applies a Content Security Policy that blocks the inline bootstrap scripts required by the Next.js static export.
+
+The public front door must not be described as reliable until the conditional-response policy is corrected and the production smoke added by this phase passes.
+
+## Browser matrix
+
+| Browser | Ordinary new-tab loads | Cache-bypassing refreshes | Result |
+|---|---:|---:|---|
+| Chrome, normal operator profile with extensions | 1/3 rendered | 3/3 rendered | Confirmed |
+| Safari, normal operator profile | 1/3 rendered | 3/3 rendered | Confirmed |
+| Physical mobile browser | Not run | Not run | Pending device/runtime |
+
+The two failed ordinary loads in each desktop browser displayed only the warm page background. Chrome DevTools recorded blocked inline scripts and uncaught `Connection closed` errors. Safari reproduced the same visible failure without the Chrome extension set, so extension traffic is not the root cause.
+
+## HTTP evidence
+
+| Route | 200 Content-Length | 200 policy | 304 policy |
+|---|---:|---|---|
+| `/` | 234,110 bytes | inline bootstrap allowed; `no-cache` | inline bootstrap blocked; `public, max-age=0` |
+| `/demo/` | 35,768 bytes | inline bootstrap allowed; `no-cache` | inline bootstrap blocked; `public, max-age=0` |
+| `/how-it-works/` | 138,140 bytes | inline bootstrap allowed; `no-cache` | inline bootstrap blocked; `public, max-age=0` |
+| `/start/` | 49,961 bytes | inline bootstrap allowed; `no-cache` | inline bootstrap blocked; `public, max-age=0` |
+
+The successful responses contain `script-src 'self' 'unsafe-inline'`. Conditional requests with the returned ETag receive `304 Not Modified` with `script-src 'self'`. In `src/feed/server.ts`, the static-export override currently depends on a `text/html` response content type; a 304 has no content type, so the stricter global policy remains.
+
+## Monitoring disposition
+
+`web-next` has no client exception reporter or global `error`/`unhandledrejection` signal. The failure therefore has no product telemetry receipt today. Server availability checks can remain green because the HTML request succeeds.
+
+## Durable gate
+
+Run from `web-next`:
+
+```bash
+npm run smoke:production
+```
+
+The Playwright smoke checks all four routes in 1440 by 1000 desktop Chrome and a 390 by 900 mobile Chrome profile. For each route it verifies the initial render, ordinary revalidation, cache-bypassing refresh, browser errors, response size, and 200/304 CSP and cache-policy parity.
+
+The smoke is expected to fail against the current production release. That failure is the Phase 0 release gate, not a flaky-test exception.
+
+## Phase 1 response-header fix verification
+
+The first Phase 1 reliability slice makes the static-export response-header policy explicit in `src/feed/static-export-headers.ts`. A conditional HTML response is identified from its `304` status and browser HTML `Accept` header, so it receives the same CSP and `no-cache` policy as the original `200` response even though a 304 has no content type.
+
+Verification before deployment:
+
+- Focused Fastify response-cycle regression: passed.
+- Root TypeScript build: passed.
+- `web-next` lint and production build: passed.
+- Credential-free local Fastify server plus the complete desktop/mobile Playwright matrix: 2/2 projects passed.
+- Live production matrix: remains red on all four routes and both viewports, as expected before deployment.
+
+The local pass and live failure demonstrate that the guard detects the deployed defect and accepts the proposed response-header correction. Production reliability remains gated until the fix is reviewed, merged, deployed, and the live matrix turns green.
+
+## Remaining physical-device probe
+
+The current Mac reports no available iOS Simulator runtime, and Android Debug Bridge is not installed. Run three ordinary loads and three cache-bypassing refreshes on one physical mobile browser after the policy fix, then attach screenshots and browser/version details to PROJ-1753.

--- a/docs/quality/PROJ-1753-phase-0.md
+++ b/docs/quality/PROJ-1753-phase-0.md
@@ -38,10 +38,10 @@ The successful responses contain `script-src 'self' 'unsafe-inline'`. Conditiona
 
 ## Durable gate
 
-Run from `web-next`:
+Run from the repository root:
 
 ```bash
-npm run smoke:production
+npm --prefix web-next run smoke:production
 ```
 
 The Playwright smoke checks all four routes in 1440 by 1000 desktop Chrome and a 390 by 900 mobile Chrome profile. For each route it verifies the initial render, ordinary revalidation, cache-bypassing refresh, browser errors, response size, and 200/304 CSP and cache-policy parity.

--- a/docs/quality/PROJ-1753-phase-0.md
+++ b/docs/quality/PROJ-1753-phase-0.md
@@ -30,7 +30,7 @@ The two failed ordinary loads in each desktop browser displayed only the warm pa
 | `/how-it-works/` | 138,140 bytes | inline bootstrap allowed; `no-cache` | inline bootstrap blocked; `public, max-age=0` |
 | `/start/` | 49,961 bytes | inline bootstrap allowed; `no-cache` | inline bootstrap blocked; `public, max-age=0` |
 
-The successful responses contain `script-src 'self' 'unsafe-inline'`. Conditional requests with the returned ETag receive `304 Not Modified` with `script-src 'self'`. In `src/feed/server.ts`, the static-export override currently depends on a `text/html` response content type; a 304 has no content type, so the stricter global policy remains.
+At the July 11, 2026 receipt time, successful responses contained `script-src 'self' 'unsafe-inline'`, while conditional requests with the returned ETag received `304 Not Modified` with `script-src 'self'`. Before the Phase 1 implementation, the static-export override in `src/feed/server.ts` depended on a `text/html` response content type; a 304 had no content type, so the stricter global policy remained.
 
 ## Monitoring disposition
 
@@ -46,7 +46,7 @@ npm --prefix web-next run smoke:production
 
 The Playwright smoke checks all four routes in 1440 by 1000 desktop Chrome and a 390 by 900 mobile Chrome profile. For each route it verifies the initial render, ordinary revalidation, cache-bypassing refresh, browser errors, response size, and 200/304 CSP and cache-policy parity.
 
-The smoke is expected to fail against the current production release. That failure is the Phase 0 release gate, not a flaky-test exception.
+Before Phase 1 deployment, the smoke was expected to fail against the July 11, 2026 production release. That failure was the Phase 0 release gate, not a flaky-test exception.
 
 ## Phase 1 response-header fix verification
 
@@ -58,9 +58,9 @@ Verification before deployment:
 - Root TypeScript build: passed.
 - `web-next` lint and production build: passed.
 - Credential-free local Fastify server plus the complete desktop/mobile Playwright matrix: 2/2 projects passed.
-- Live production matrix: remains red on all four routes and both viewports, as expected before deployment.
+- Before Phase 1 deployment, the live production matrix remained red on all four routes and both viewports, as expected.
 
-The local pass and live failure demonstrate that the guard detects the deployed defect and accepts the proposed response-header correction. Production reliability remains gated until the fix is reviewed, merged, deployed, and the live matrix turns green.
+At receipt time, the local pass and live failure demonstrated that the guard detected the deployed defect and accepted the proposed response-header correction. Production reliability remained gated until the fix could be reviewed, merged, deployed, and verified by a green live matrix.
 
 ## Remaining physical-device probe
 

--- a/src/feed/server.ts
+++ b/src/feed/server.ts
@@ -34,7 +34,7 @@ import {
   type DemoRateLimitGuard,
 } from '../demo/rate-limit.js';
 import { buildRouteRateLimitConfig } from './rate-limit-config.js';
-import { applyStaticExportResponseHeaders } from './static-export-headers.js';
+import { applyStaticExportResponseHeaders, discoverStaticExportHtmlPaths } from './static-export-headers.js';
 
 // Extend FastifyRequest to include correlationId
 declare module 'fastify' {
@@ -490,6 +490,7 @@ export async function createServer(options?: CreateServerOptions) {
     });
 
     if (webRoutingMode === 'export') {
+      const staticExportHtmlPaths = discoverStaticExportHtmlPaths(webDistPath);
       // Next.js static-export HTML hydrates via inline bootstrap scripts
       // (self.__next_f.push(...)), which the strict global CSP
       // (script-src 'self') blocks — the page would render but never become
@@ -506,7 +507,7 @@ export async function createServer(options?: CreateServerOptions) {
         // overwrites): content-hashed Next assets are immutable; HTML must
         // revalidate so a deploy is picked up immediately (stale HTML
         // referencing purged chunks is the classic white-screen failure).
-        applyStaticExportResponseHeaders(request, reply);
+        applyStaticExportResponseHeaders(request, reply, staticExportHtmlPaths);
       });
     }
 

--- a/src/feed/server.ts
+++ b/src/feed/server.ts
@@ -34,6 +34,7 @@ import {
   type DemoRateLimitGuard,
 } from '../demo/rate-limit.js';
 import { buildRouteRateLimitConfig } from './rate-limit-config.js';
+import { applyStaticExportResponseHeaders } from './static-export-headers.js';
 
 // Extend FastifyRequest to include correlationId
 declare module 'fastify' {
@@ -499,34 +500,13 @@ export async function createServer(options?: CreateServerOptions) {
       // documents only is the deliberate trade-off. API/JSON responses keep
       // the strict helmet policy above (kept in sync manually — mirror any
       // helmet directive change here).
-      const htmlCsp = [
-        "default-src 'self'",
-        "base-uri 'self'",
-        "frame-ancestors 'none'",
-        "object-src 'none'",
-        "script-src 'self' 'unsafe-inline'",
-        "style-src 'self' 'unsafe-inline'",
-        "img-src 'self' data: https:",
-        "font-src 'self' data: https:",
-        "connect-src 'self' https: wss:",
-        "form-action 'self'",
-        "script-src-attr 'none'",
-        "upgrade-insecure-requests",
-      ].join('; ');
       app.addHook('onSend', async (request, reply) => {
         // Cache-Control split (set here rather than via @fastify/static's
         // setHeaders, whose result the plugin's own cacheControl default
         // overwrites): content-hashed Next assets are immutable; HTML must
         // revalidate so a deploy is picked up immediately (stale HTML
         // referencing purged chunks is the classic white-screen failure).
-        if (request.url.startsWith('/_next/static/')) {
-          reply.header('cache-control', 'public, max-age=31536000, immutable');
-        }
-        const contentType = reply.getHeader('content-type');
-        if (typeof contentType === 'string' && contentType.startsWith('text/html')) {
-          reply.header('cache-control', 'no-cache');
-          reply.header('content-security-policy', htmlCsp);
-        }
+        applyStaticExportResponseHeaders(request, reply);
       });
     }
 

--- a/src/feed/static-export-headers.ts
+++ b/src/feed/static-export-headers.ts
@@ -21,17 +21,24 @@ function acceptsHtml(request: FastifyRequest): boolean {
     .some((mediaRange) => mediaRange.trim().split(';', 1)[0].toLowerCase() === 'text/html') ?? false;
 }
 
+function targetsHtmlDocument(request: FastifyRequest): boolean {
+  const pathname = request.url.split('?', 1)[0] ?? '';
+  const lastSegment = pathname.slice(pathname.lastIndexOf('/') + 1);
+  return lastSegment === '' || !lastSegment.includes('.') || lastSegment.endsWith('.html');
+}
+
 export function applyStaticExportResponseHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
 ): void {
   if (request.url.startsWith('/_next/static/')) {
     reply.header('cache-control', 'public, max-age=31536000, immutable');
+    return;
   }
 
   const contentType = reply.getHeader('content-type');
   const isHtmlResponse = typeof contentType === 'string' && contentType.startsWith('text/html');
-  const isRevalidatedHtml = reply.statusCode === 304 && acceptsHtml(request);
+  const isRevalidatedHtml = reply.statusCode === 304 && acceptsHtml(request) && targetsHtmlDocument(request);
   if (isHtmlResponse || isRevalidatedHtml) {
     reply.header('cache-control', 'no-cache');
     reply.header('content-security-policy', STATIC_EXPORT_HTML_CSP);

--- a/src/feed/static-export-headers.ts
+++ b/src/feed/static-export-headers.ts
@@ -1,0 +1,39 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+const STATIC_EXPORT_HTML_CSP = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https:",
+  "font-src 'self' data: https:",
+  "connect-src 'self' https: wss:",
+  "form-action 'self'",
+  "script-src-attr 'none'",
+  "upgrade-insecure-requests",
+].join('; ');
+
+function acceptsHtml(request: FastifyRequest): boolean {
+  return request.headers.accept
+    ?.split(',')
+    .some((mediaRange) => mediaRange.trim().split(';', 1)[0].toLowerCase() === 'text/html') ?? false;
+}
+
+export function applyStaticExportResponseHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): void {
+  if (request.url.startsWith('/_next/static/')) {
+    reply.header('cache-control', 'public, max-age=31536000, immutable');
+  }
+
+  const contentType = reply.getHeader('content-type');
+  const isHtmlResponse = typeof contentType === 'string' && contentType.startsWith('text/html');
+  const isRevalidatedHtml = reply.statusCode === 304 && acceptsHtml(request);
+  if (isHtmlResponse || isRevalidatedHtml) {
+    reply.header('cache-control', 'no-cache');
+    reply.header('content-security-policy', STATIC_EXPORT_HTML_CSP);
+  }
+}

--- a/src/feed/static-export-headers.ts
+++ b/src/feed/static-export-headers.ts
@@ -1,4 +1,6 @@
 import type { FastifyReply, FastifyRequest } from 'fastify';
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
 
 const STATIC_EXPORT_HTML_CSP = [
   "default-src 'self'",
@@ -16,20 +18,54 @@ const STATIC_EXPORT_HTML_CSP = [
 ].join('; ');
 
 function acceptsHtml(request: FastifyRequest): boolean {
-  return request.headers.accept
-    ?.split(',')
-    .some((mediaRange) => mediaRange.trim().split(';', 1)[0].toLowerCase() === 'text/html') ?? false;
+  return request.headers.accept?.split(',').some((mediaRange) => {
+    const [rawType, ...rawParameters] = mediaRange.split(';');
+    if (rawType?.trim().toLowerCase() !== 'text/html') return false;
+    const qualityParameter = rawParameters
+      .map((parameter) => parameter.trim().toLowerCase())
+      .find((parameter) => parameter.startsWith('q='));
+    if (qualityParameter === undefined) return true;
+    const quality = Number(qualityParameter.slice(2));
+    return Number.isFinite(quality) && quality > 0 && quality <= 1;
+  }) ?? false;
 }
 
-function targetsHtmlDocument(request: FastifyRequest): boolean {
+function targetsHtmlDocument(request: FastifyRequest, htmlDocumentPaths: ReadonlySet<string>): boolean {
   const pathname = request.url.split('?', 1)[0] ?? '';
-  const lastSegment = pathname.slice(pathname.lastIndexOf('/') + 1);
-  return lastSegment === '' || !lastSegment.includes('.') || lastSegment.endsWith('.html');
+  return htmlDocumentPaths.has(pathname);
+}
+
+export function discoverStaticExportHtmlPaths(root: string): ReadonlySet<string> {
+  const routes = new Set<string>();
+  visitStaticExportDirectory(root, '', routes);
+  return routes;
+}
+
+function visitStaticExportDirectory(root: string, relativeDirectory: string, routes: Set<string>): void {
+  const absoluteDirectory = path.join(root, relativeDirectory);
+  for (const entry of readdirSync(absoluteDirectory, { withFileTypes: true })) {
+    const relativePath = path.join(relativeDirectory, entry.name);
+    if (entry.isDirectory()) {
+      visitStaticExportDirectory(root, relativePath, routes);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.html')) continue;
+    const webPath = `/${relativePath.split(path.sep).join('/')}`;
+    routes.add(webPath);
+    if (webPath === '/index.html') {
+      routes.add('/');
+    } else if (webPath.endsWith('/index.html')) {
+      const route = webPath.slice(0, -'/index.html'.length);
+      routes.add(route);
+      routes.add(`${route}/`);
+    }
+  }
 }
 
 export function applyStaticExportResponseHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
+  htmlDocumentPaths: ReadonlySet<string>,
 ): void {
   if (request.url.startsWith('/_next/static/')) {
     reply.header('cache-control', 'public, max-age=31536000, immutable');
@@ -38,7 +74,9 @@ export function applyStaticExportResponseHeaders(
 
   const contentType = reply.getHeader('content-type');
   const isHtmlResponse = typeof contentType === 'string' && contentType.startsWith('text/html');
-  const isRevalidatedHtml = reply.statusCode === 304 && acceptsHtml(request) && targetsHtmlDocument(request);
+  const isRevalidatedHtml = reply.statusCode === 304
+    && acceptsHtml(request)
+    && targetsHtmlDocument(request, htmlDocumentPaths);
   if (isHtmlResponse || isRevalidatedHtml) {
     reply.header('cache-control', 'no-cache');
     reply.header('content-security-policy', STATIC_EXPORT_HTML_CSP);

--- a/tests/static-export-headers.test.ts
+++ b/tests/static-export-headers.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Fastify from 'fastify';
+import helmet from '@fastify/helmet';
+import fastifyStatic from '@fastify/static';
+import { afterEach, describe, expect, it } from 'vitest';
+import { applyStaticExportResponseHeaders } from '../src/feed/static-export-headers.js';
+
+const HTML_ACCEPT = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
+const HTML_SCRIPT_POLICY = "script-src 'self' 'unsafe-inline'";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await rm(directory, { force: true, recursive: true });
+    }),
+  );
+});
+
+describe('static-export response headers', () => {
+  it('preserves the HTML CSP and cache policy on conditional 304 responses', async () => {
+    const webDistDir = await mkdtemp(join(tmpdir(), 'corgi-static-export-'));
+    temporaryDirectories.push(webDistDir);
+    await writeFile(
+      join(webDistDir, 'index.html'),
+      '<!doctype html><html><body><main>Corgi</main><script>self.__next_f=[]</script></body></html>',
+      'utf8',
+    );
+
+    const app = Fastify({ logger: false });
+    await app.register(helmet, {
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+        },
+      },
+    });
+    await app.register(fastifyStatic, {
+      root: webDistDir,
+      prefix: '/',
+      wildcard: false,
+    });
+    app.addHook('onSend', async (request, reply) => {
+      applyStaticExportResponseHeaders(request, reply);
+    });
+    await app.ready();
+
+    try {
+      const initial = await app.inject({
+        method: 'GET',
+        url: '/',
+        headers: { accept: HTML_ACCEPT },
+      });
+
+      expect(initial.statusCode).toBe(200);
+      expect(initial.headers['content-security-policy']).toContain(HTML_SCRIPT_POLICY);
+      expect(initial.headers['cache-control']).toBe('no-cache');
+      expect(initial.headers.etag).toBeTypeOf('string');
+
+      const conditional = await app.inject({
+        method: 'GET',
+        url: '/',
+        headers: {
+          accept: HTML_ACCEPT,
+          'if-none-match': initial.headers.etag as string,
+        },
+      });
+
+      expect(conditional.statusCode).toBe(304);
+      expect(conditional.headers['content-security-policy']).toContain(HTML_SCRIPT_POLICY);
+      expect(conditional.headers['cache-control']).toBe('no-cache');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/tests/static-export-headers.test.ts
+++ b/tests/static-export-headers.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Fastify from 'fastify';
@@ -29,6 +29,9 @@ describe('static-export response headers', () => {
       '<!doctype html><html><body><main>Corgi</main><script>self.__next_f=[]</script></body></html>',
       'utf8',
     );
+    await mkdir(join(webDistDir, '_next', 'static'), { recursive: true });
+    await writeFile(join(webDistDir, '_next', 'static', 'app.js'), 'console.log("Corgi");', 'utf8');
+    await writeFile(join(webDistDir, 'data.json'), '{"name":"Corgi"}', 'utf8');
 
     const app = Fastify({ logger: false });
     await app.register(helmet, {
@@ -74,6 +77,49 @@ describe('static-export response headers', () => {
       expect(conditional.statusCode).toBe(304);
       expect(conditional.headers['content-security-policy']).toContain(HTML_SCRIPT_POLICY);
       expect(conditional.headers['cache-control']).toBe('no-cache');
+
+      const staticAsset = await app.inject({
+        method: 'GET',
+        url: '/_next/static/app.js',
+      });
+      expect(staticAsset.statusCode).toBe(200);
+      expect(staticAsset.headers.etag).toBeTypeOf('string');
+
+      const revalidatedStaticAsset = await app.inject({
+        method: 'GET',
+        url: '/_next/static/app.js',
+        headers: {
+          accept: HTML_ACCEPT,
+          'if-none-match': staticAsset.headers.etag as string,
+        },
+      });
+      expect(revalidatedStaticAsset.statusCode).toBe(304);
+      expect(revalidatedStaticAsset.headers['cache-control']).toBe('public, max-age=31536000, immutable');
+      expect(revalidatedStaticAsset.headers['content-security-policy']).not.toContain(HTML_SCRIPT_POLICY);
+
+      const jsonAsset = await app.inject({
+        method: 'GET',
+        url: '/data.json',
+      });
+      expect(jsonAsset.statusCode).toBe(200);
+      expect(jsonAsset.headers.etag).toBeTypeOf('string');
+
+      for (const accept of [undefined, HTML_ACCEPT]) {
+        const headers: Record<string, string> = {
+          'if-none-match': jsonAsset.headers.etag as string,
+        };
+        if (accept !== undefined) {
+          headers.accept = accept;
+        }
+        const revalidatedJsonAsset = await app.inject({
+          method: 'GET',
+          url: '/data.json',
+          headers,
+        });
+        expect(revalidatedJsonAsset.statusCode).toBe(304);
+        expect(revalidatedJsonAsset.headers['cache-control']).not.toBe('no-cache');
+        expect(revalidatedJsonAsset.headers['content-security-policy']).not.toContain(HTML_SCRIPT_POLICY);
+      }
     } finally {
       await app.close();
     }

--- a/tests/static-export-headers.test.ts
+++ b/tests/static-export-headers.test.ts
@@ -5,7 +5,10 @@ import Fastify from 'fastify';
 import helmet from '@fastify/helmet';
 import fastifyStatic from '@fastify/static';
 import { afterEach, describe, expect, it } from 'vitest';
-import { applyStaticExportResponseHeaders } from '../src/feed/static-export-headers.js';
+import {
+  applyStaticExportResponseHeaders,
+  discoverStaticExportHtmlPaths,
+} from '../src/feed/static-export-headers.js';
 
 const HTML_ACCEPT = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
 const HTML_SCRIPT_POLICY = "script-src 'self' 'unsafe-inline'";
@@ -30,8 +33,20 @@ describe('static-export response headers', () => {
       'utf8',
     );
     await mkdir(join(webDistDir, '_next', 'static'), { recursive: true });
+    await mkdir(join(webDistDir, 'demo'), { recursive: true });
+    await writeFile(join(webDistDir, 'demo', 'index.html'), '<!doctype html><title>Demo</title>', 'utf8');
     await writeFile(join(webDistDir, '_next', 'static', 'app.js'), 'console.log("Corgi");', 'utf8');
     await writeFile(join(webDistDir, 'data.json'), '{"name":"Corgi"}', 'utf8');
+    await writeFile(join(webDistDir, 'manifest'), 'not an HTML document', 'utf8');
+
+    const htmlDocumentPaths = discoverStaticExportHtmlPaths(webDistDir);
+    expect([...htmlDocumentPaths].sort()).toEqual([
+      '/',
+      '/demo',
+      '/demo/',
+      '/demo/index.html',
+      '/index.html',
+    ]);
 
     const app = Fastify({ logger: false });
     await app.register(helmet, {
@@ -49,7 +64,7 @@ describe('static-export response headers', () => {
       wildcard: false,
     });
     app.addHook('onSend', async (request, reply) => {
-      applyStaticExportResponseHeaders(request, reply);
+      applyStaticExportResponseHeaders(request, reply, htmlDocumentPaths);
     });
     await app.ready();
 
@@ -119,6 +134,26 @@ describe('static-export response headers', () => {
         expect(revalidatedJsonAsset.statusCode).toBe(304);
         expect(revalidatedJsonAsset.headers['cache-control']).not.toBe('no-cache');
         expect(revalidatedJsonAsset.headers['content-security-policy']).not.toContain(HTML_SCRIPT_POLICY);
+      }
+
+      const extensionlessAsset = await app.inject({
+        method: 'GET',
+        url: '/manifest',
+      });
+      expect(extensionlessAsset.statusCode).toBe(200);
+      expect(extensionlessAsset.headers.etag).toBeTypeOf('string');
+      for (const accept of [HTML_ACCEPT, 'text/html;q=0,*/*;q=1']) {
+        const revalidatedExtensionlessAsset = await app.inject({
+          method: 'GET',
+          url: '/manifest',
+          headers: {
+            accept,
+            'if-none-match': extensionlessAsset.headers.etag as string,
+          },
+        });
+        expect(revalidatedExtensionlessAsset.statusCode).toBe(304);
+        expect(revalidatedExtensionlessAsset.headers['cache-control']).not.toBe('no-cache');
+        expect(revalidatedExtensionlessAsset.headers['content-security-policy']).not.toContain(HTML_SCRIPT_POLICY);
       }
     } finally {
       await app.close();

--- a/web-next/e2e/production-hard-refresh.spec.ts
+++ b/web-next/e2e/production-hard-refresh.spec.ts
@@ -1,0 +1,170 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test"
+
+interface PublicRoute {
+  path: string
+  heading: RegExp
+}
+
+interface BrowserErrors {
+  console: string[]
+  page: string[]
+}
+
+interface RouteFailure {
+  path: string
+  check: string
+  actual: string
+}
+
+const PUBLIC_ROUTES: readonly PublicRoute[] = [
+  { path: "/", heading: /Make Bluesky care about what your community cares about/i },
+  { path: "/demo/", heading: /Watch a community re-rank its own feed/i },
+  { path: "/how-it-works/", heading: /Watch the same posts become a different feed/i },
+  { path: "/start/", heading: /Add the Corgi feed in Bluesky/i },
+]
+
+const HTML_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+const REQUIRED_HTML_SCRIPT_POLICY = "script-src 'self' 'unsafe-inline'"
+const REQUIRED_RATE_LIMIT_HEADROOM = 120
+
+function collectBrowserErrors(page: Page): BrowserErrors {
+  const errors: BrowserErrors = { console: [], page: [] }
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      const location = message.location()
+      const source = location.url === "" ? "unknown source" : `${location.url}:${location.lineNumber}`
+      errors.console.push(`${message.text()} (${source})`)
+    }
+  })
+  page.on("pageerror", (error) => {
+    errors.page.push(error.message)
+  })
+
+  return errors
+}
+
+async function isRouteVisible(page: Page, route: PublicRoute): Promise<boolean> {
+  const headingVisible = await page.getByRole("heading", { level: 1, name: route.heading }).isVisible()
+  const mainVisible = await page.locator("main").isVisible()
+  return headingVisible && mainVisible
+}
+
+async function verifyConditionalHeaders(
+  request: APIRequestContext,
+  route: PublicRoute,
+): Promise<RouteFailure[]> {
+  const failures: RouteFailure[] = []
+  const initial = await request.get(route.path, {
+    headers: { accept: HTML_ACCEPT },
+  })
+
+  if (initial.status() !== 200) {
+    failures.push({ path: route.path, check: "initial HTTP status", actual: String(initial.status()) })
+    return failures
+  }
+
+  const etag = initial.headers().etag
+  const bodyLength = (await initial.body()).byteLength
+  if (bodyLength === 0) {
+    failures.push({ path: route.path, check: "initial response body", actual: "0 bytes" })
+  }
+  if (!initial.headers()["content-security-policy"]?.includes(REQUIRED_HTML_SCRIPT_POLICY)) {
+    failures.push({
+      path: route.path,
+      check: "200 CSP",
+      actual: initial.headers()["content-security-policy"] ?? "missing",
+    })
+  }
+
+  if (etag === undefined) {
+    failures.push({ path: route.path, check: "ETag", actual: "missing" })
+    return failures
+  }
+
+  const conditional = await request.get(route.path, {
+    headers: {
+      accept: HTML_ACCEPT,
+      "if-none-match": etag,
+    },
+  })
+
+  if (conditional.status() !== 304) {
+    failures.push({ path: route.path, check: "conditional HTTP status", actual: String(conditional.status()) })
+  }
+  if (!conditional.headers()["content-security-policy"]?.includes(REQUIRED_HTML_SCRIPT_POLICY)) {
+    failures.push({
+      path: route.path,
+      check: "304 CSP",
+      actual: conditional.headers()["content-security-policy"] ?? "missing",
+    })
+  }
+  if (conditional.headers()["cache-control"] !== "no-cache") {
+    failures.push({
+      path: route.path,
+      check: "304 cache policy",
+      actual: conditional.headers()["cache-control"] ?? "missing",
+    })
+  }
+
+  return failures
+}
+
+async function waitForRateLimitHeadroom(request: APIRequestContext): Promise<void> {
+  const response = await request.head("/health")
+  const remaining = Number(response.headers()["x-ratelimit-remaining"])
+  const resetSeconds = Number(response.headers()["x-ratelimit-reset"])
+  if (!Number.isFinite(remaining) || !Number.isFinite(resetSeconds)) {
+    const hostname = new URL(response.url()).hostname
+    if (hostname === "127.0.0.1" || hostname === "localhost") {
+      return
+    }
+    throw new Error("Production health response did not include numeric rate-limit headers")
+  }
+  if (remaining >= REQUIRED_RATE_LIMIT_HEADROOM) {
+    return
+  }
+
+  const waitMilliseconds = Math.min((resetSeconds + 1) * 1_000, 60_000)
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, waitMilliseconds)
+  })
+}
+
+test("public routes survive revalidation and cache-bypassing refresh", async ({ page, request }, testInfo) => {
+  await waitForRateLimitHeadroom(request)
+  const browserErrors = collectBrowserErrors(page)
+  const failures: RouteFailure[] = []
+
+  for (const [routeIndex, route] of PUBLIC_ROUTES.entries()) {
+    const initial = await page.goto(route.path, { waitUntil: "domcontentloaded" })
+    if (initial?.status() !== 200) {
+      failures.push({ path: route.path, check: "initial browser status", actual: String(initial?.status()) })
+      continue
+    }
+    if (!(await isRouteVisible(page, route))) {
+      failures.push({ path: route.path, check: "initial render", actual: "main heading not visible" })
+    }
+
+    await page.reload({ waitUntil: "domcontentloaded" })
+    if (!(await isRouteVisible(page, route))) {
+      failures.push({ path: route.path, check: "ordinary revalidation", actual: "main heading not visible" })
+    }
+
+    const cacheBypassPath = `${route.path}?corgi-hard-refresh-smoke=${routeIndex}`
+    const cacheBypass = await page.goto(cacheBypassPath, { waitUntil: "domcontentloaded" })
+    if (cacheBypass?.status() !== 200) {
+      failures.push({ path: route.path, check: "cache-bypassing status", actual: String(cacheBypass?.status()) })
+    } else if (!(await isRouteVisible(page, route))) {
+      failures.push({ path: route.path, check: "cache-bypassing render", actual: "main heading not visible" })
+    }
+
+    if (testInfo.project.name === "desktop-chrome") {
+      failures.push(...(await verifyConditionalHeaders(request, route)))
+    }
+  }
+
+  expect(failures, "production route failures").toEqual([])
+  expect(browserErrors.console, "browser console errors").toEqual([])
+  expect(browserErrors.page, "uncaught page errors").toEqual([])
+})

--- a/web-next/e2e/production-hard-refresh.spec.ts
+++ b/web-next/e2e/production-hard-refresh.spec.ts
@@ -33,6 +33,7 @@ function collectBrowserErrors(page: Page): BrowserErrors {
   page.on("console", (message) => {
     if (message.type() === "error") {
       const location = message.location()
+      if (isExpectedLoggedOutSessionError(message.text(), location.url)) return
       const source = location.url === "" ? "unknown source" : `${location.url}:${location.lineNumber}`
       errors.console.push(`${message.text()} (${source})`)
     }
@@ -42,6 +43,15 @@ function collectBrowserErrors(page: Page): BrowserErrors {
   })
 
   return errors
+}
+
+function isExpectedLoggedOutSessionError(message: string, sourceUrl: string): boolean {
+  if (!message.includes("401 (Unauthorized)")) return false
+  try {
+    return new URL(sourceUrl).pathname === "/api/governance/auth/session"
+  } catch {
+    return false
+  }
 }
 
 async function isRouteVisible(page: Page, route: PublicRoute): Promise<boolean> {
@@ -110,6 +120,59 @@ async function verifyConditionalHeaders(
   return failures
 }
 
+async function verifyStaticAssetHeaders(request: APIRequestContext): Promise<RouteFailure[]> {
+  const failures: RouteFailure[] = []
+  const home = await request.get("/", { headers: { accept: HTML_ACCEPT } })
+  if (home.status() !== 200) {
+    return [{ path: "/", check: "asset discovery status", actual: String(home.status()) }]
+  }
+  const html = await home.text()
+  const assetPath = html.match(/\/_next\/static\/[^"']+\.js/)?.[0]
+  if (assetPath === undefined) {
+    return [{ path: "/", check: "hashed Next asset discovery", actual: "missing" }]
+  }
+
+  const asset = await request.get(assetPath)
+  if (asset.status() !== 200) {
+    failures.push({ path: assetPath, check: "asset HTTP status", actual: String(asset.status()) })
+    return failures
+  }
+  if (asset.headers()["cache-control"] !== "public, max-age=31536000, immutable") {
+    failures.push({
+      path: assetPath,
+      check: "asset 200 cache policy",
+      actual: asset.headers()["cache-control"] ?? "missing",
+    })
+  }
+  const etag = asset.headers().etag
+  if (etag === undefined) {
+    failures.push({ path: assetPath, check: "asset ETag", actual: "missing" })
+    return failures
+  }
+
+  const conditional = await request.get(assetPath, {
+    headers: { accept: HTML_ACCEPT, "if-none-match": etag },
+  })
+  if (conditional.status() !== 304) {
+    failures.push({ path: assetPath, check: "asset conditional HTTP status", actual: String(conditional.status()) })
+  }
+  if (conditional.headers()["cache-control"] !== "public, max-age=31536000, immutable") {
+    failures.push({
+      path: assetPath,
+      check: "asset 304 cache policy",
+      actual: conditional.headers()["cache-control"] ?? "missing",
+    })
+  }
+  if (conditional.headers()["content-security-policy"]?.includes(REQUIRED_HTML_SCRIPT_POLICY)) {
+    failures.push({
+      path: assetPath,
+      check: "asset 304 CSP isolation",
+      actual: conditional.headers()["content-security-policy"] ?? "missing",
+    })
+  }
+  return failures
+}
+
 async function waitForRateLimitHeadroom(request: APIRequestContext): Promise<void> {
   const response = await request.head("/health")
   const remaining = Number(response.headers()["x-ratelimit-remaining"])
@@ -162,6 +225,10 @@ test("public routes survive revalidation and cache-bypassing refresh", async ({ 
     if (testInfo.project.name === "desktop-chrome") {
       failures.push(...(await verifyConditionalHeaders(request, route)))
     }
+  }
+
+  if (testInfo.project.name === "desktop-chrome") {
+    failures.push(...(await verifyStaticAssetHeaders(request)))
   }
 
   expect(failures, "production route failures").toEqual([])

--- a/web-next/package-lock.json
+++ b/web-next/package-lock.json
@@ -63,6 +63,7 @@
         "zod": "3.25.76"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/node": "^24",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1063,6 +1064,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6868,6 +6885,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
+    "smoke:production": "playwright test --config playwright.config.ts",
     "start": "next start"
   },
   "dependencies": {
@@ -64,6 +65,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/web-next/playwright.config.ts
+++ b/web-next/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from "@playwright/test"
+
+const baseURL = process.env.CORGI_BASE_URL ?? "https://feed.corgi.network"
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "production-hard-refresh.spec.ts",
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  timeout: 120_000,
+  reporter: "line",
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL,
+    channel: "chrome",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "desktop-chrome",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 1000 },
+      },
+    },
+    {
+      name: "mobile-chrome",
+      use: {
+        ...devices["Pixel 5"],
+        viewport: { width: 390, height: 900 },
+      },
+    },
+  ],
+})


### PR DESCRIPTION
## What changed

- preserve the static-export HTML CSP and `Cache-Control: no-cache` policy on conditional `304 Not Modified` responses
- add a real Fastify response-cycle regression covering the initial `200` and ETag revalidation `304`
- add a desktop/mobile Playwright production smoke for `/`, `/demo/`, `/how-it-works/`, and `/start/`
- attach the signed PROJ-1753 Phase 0 evidence receipt

## Root cause

The original static-export override only recognized HTML from the response `Content-Type`. A valid `304` has no content type, so Helmet's stricter global CSP remained in place and blocked the cached Next.js inline bootstrap. Browsers then displayed a blank cream page even though the HTML request had succeeded.

Conditional responses are now recognized from their `304` status plus the browser's HTML `Accept` header and receive the same CSP/cache policy as the original document.

## User impact

Ordinary reloads and cached-document revalidation no longer produce a blank public Corgi page after this reaches production. The smoke makes that failure reproducible across the four public routes at desktop and mobile widths.

## Validation

- `npx vitest run tests/static-export-headers.test.ts`
- root `npm run build`
- root `npm run docs:verify`
- `web-next` lint and production build
- local Fastify static-export server plus `npm --prefix web-next run smoke:production`: 2/2 Playwright projects passed
- live production smoke: expected red until this fix is deployed
- staged-path lease validation and `git diff --check`: pass
- PR head CI, CodeQL, policy, security, secret scan, and thread/freshness gates: pass

## Review state

Ready for review after the complete CI matrix passed. The current-head CodeRabbit check was started by the ready transition and is in progress. No duplicate manual review request has been posted; review actions remain governed by `pr-review-readiness` and `coderabbit-request-review`.

## Known verification boundary

The repository-wide Vitest command requires the production-style environment contract and cannot initialize in this credential-free worktree. The focused real Fastify regression, CI backend suite, TypeScript build, frontend lint/build, documentation verification, and browser smoke are green. No credentials were copied into the worktree.

Linear: [PROJ-1753](https://linear.app/andrewnord/issue/PROJ-1753/epic-close-corgi-uiux-audit-reliability-accessibility-demo-clarity-and)