### PR TITLE
[PROJ-1758] Add immutable policy and ranking-run contracts

### DIFF
--- a/scripts/replay-ranking-run.ts
+++ b/scripts/replay-ranking-run.ts
@@ -1,0 +1,34 @@
+import { db } from '../src/db/client.js';
+import { canonicalJson } from '../src/governance/policy-version.js';
+import {
+  decodeCompressedRankingInput,
+  loadRankingRunInput,
+} from '../src/scoring/ranking-run-contracts.js';
+
+function parseRunId(argv: string[]): string {
+  const index = argv.indexOf('--run-id');
+  const runId = index >= 0 ? argv[index + 1] : undefined;
+  if (!runId || runId.trim().length === 0) {
+    throw new Error('Usage: tsx scripts/replay-ranking-run.ts --run-id <uuid>');
+  }
+  return runId;
+}
+
+async function main(argv: string[]): Promise<void> {
+  const runId = parseRunId(argv);
+  const client = await db.connect();
+  try {
+    const compressed = await loadRankingRunInput(client, runId);
+    const envelope = decodeCompressedRankingInput(compressed);
+    process.stdout.write(`${canonicalJson(envelope)}\n`);
+  } finally {
+    client.release();
+    await db.end();
+  }
+}
+
+main(process.argv.slice(2)).catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`Ranking-run replay failed: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/src/db/migrations/032_trustworthy_corgi_contracts.sql
+++ b/src/db/migrations/032_trustworthy_corgi_contracts.sql
@@ -137,10 +137,18 @@ LANGUAGE plpgsql
 AS $$
 DECLARE
   transition_allowed BOOLEAN := FALSE;
+  stored_item_count INTEGER;
+  stored_candidate_count INTEGER;
+  stored_input_checksum TEXT;
 BEGIN
   IF TG_OP = 'INSERT' THEN
     IF NEW.state <> 'requested' THEN
       RAISE EXCEPTION 'ranking run must begin in requested state, got %', NEW.state;
+    END IF;
+    IF NEW.failure IS NOT NULL OR NEW.snapshot_id IS NOT NULL
+       OR NEW.input_checksum IS NOT NULL OR NEW.receipt_checksum IS NOT NULL
+       OR NEW.receipt IS NOT NULL THEN
+      RAISE EXCEPTION 'requested ranking run % must begin without result or terminal metadata', NEW.id;
     END IF;
     RETURN NEW;
   END IF;
@@ -163,17 +171,24 @@ BEGIN
     RAISE EXCEPTION 'ranking run identity is immutable for run %', OLD.id;
   END IF;
 
+  IF NEW.state <> 'failed' AND NEW.failure IS NOT NULL THEN
+    RAISE EXCEPTION 'ranking run % in state % cannot contain failure details', OLD.id, NEW.state;
+  END IF;
+  IF NEW.state <> 'published' AND NEW.snapshot_id IS NOT NULL THEN
+    RAISE EXCEPTION 'ranking run % in state % cannot contain a snapshot id', OLD.id, NEW.state;
+  END IF;
+
   IF NEW.state = OLD.state THEN
     RETURN NEW;
   END IF;
 
   IF OLD.state = 'validated' AND ROW(
     NEW.candidate_count, NEW.selected_count, NEW.exclusion_count,
-    NEW.timings, NEW.metrics, NEW.failure, NEW.input_checksum,
+    NEW.timings, NEW.metrics, NEW.input_checksum,
     NEW.receipt_checksum, NEW.receipt
   ) IS DISTINCT FROM ROW(
     OLD.candidate_count, OLD.selected_count, OLD.exclusion_count,
-    OLD.timings, OLD.metrics, OLD.failure, OLD.input_checksum,
+    OLD.timings, OLD.metrics, OLD.input_checksum,
     OLD.receipt_checksum, OLD.receipt
   ) THEN
     RAISE EXCEPTION 'validated ranking result is immutable for run %', OLD.id;
@@ -186,6 +201,66 @@ BEGIN
 
   IF NOT transition_allowed THEN
     RAISE EXCEPTION 'invalid ranking run transition % -> % for run %', OLD.state, NEW.state, OLD.id;
+  END IF;
+
+  IF NEW.state = 'validated' THEN
+    IF NEW.failure IS NOT NULL THEN
+      RAISE EXCEPTION 'validated ranking run % cannot contain failure details', OLD.id;
+    END IF;
+    IF NEW.selected_count <= 0 THEN
+      RAISE EXCEPTION 'validated ranking run % must select at least one item', OLD.id;
+    END IF;
+    IF NEW.receipt IS NULL OR NEW.input_checksum IS NULL OR NEW.receipt_checksum IS NULL THEN
+      RAISE EXCEPTION 'validated ranking run % requires a receipt and checksums', OLD.id;
+    END IF;
+    SELECT COUNT(*)::int
+      INTO stored_item_count
+      FROM ranking_run_items
+     WHERE run_id = OLD.id;
+    IF stored_item_count <> NEW.selected_count THEN
+      RAISE EXCEPTION 'validated ranking run % item count mismatch: stored %, manifest %',
+        OLD.id, stored_item_count, NEW.selected_count;
+    END IF;
+    SELECT candidate_count, checksum::text
+      INTO stored_candidate_count, stored_input_checksum
+      FROM ranking_run_inputs
+     WHERE run_id = OLD.id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'validated ranking run % requires a replay input', OLD.id;
+    END IF;
+    IF stored_candidate_count <> NEW.candidate_count THEN
+      RAISE EXCEPTION 'validated ranking run % candidate count mismatch: stored %, manifest %',
+        OLD.id, stored_candidate_count, NEW.candidate_count;
+    END IF;
+    IF stored_input_checksum <> NEW.input_checksum::text THEN
+      RAISE EXCEPTION 'validated ranking run % input checksum mismatch', OLD.id;
+    END IF;
+    IF jsonb_typeof(NEW.receipt->'itemCount') IS DISTINCT FROM 'number'
+       OR (NEW.receipt->>'itemCount')::int <> NEW.selected_count THEN
+      RAISE EXCEPTION 'validated ranking run % receipt item count mismatch', OLD.id;
+    END IF;
+    IF NEW.receipt->>'runId' IS DISTINCT FROM NEW.id::text
+       OR NEW.receipt->>'communityId' IS DISTINCT FROM NEW.community_id
+       OR NEW.receipt->>'policyVersionId' IS DISTINCT FROM NEW.policy_version_id::text
+       OR NEW.receipt->>'policyHash' IS DISTINCT FROM NEW.policy_hash::text
+       OR NEW.receipt->>'algorithmVersion' IS DISTINCT FROM NEW.algorithm_version
+       OR NEW.receipt->>'configurationHash' IS DISTINCT FROM NEW.configuration_hash::text
+       OR NEW.receipt->>'codeSha' IS DISTINCT FROM NEW.code_sha
+       OR (NEW.receipt->>'asOf')::timestamptz IS DISTINCT FROM NEW.as_of
+       OR NEW.receipt->>'inputChecksum' IS DISTINCT FROM NEW.input_checksum::text
+       OR NEW.receipt->>'receiptChecksum' IS DISTINCT FROM NEW.receipt_checksum::text THEN
+      RAISE EXCEPTION 'validated ranking run % receipt identity mismatch', OLD.id;
+    END IF;
+  ELSIF NEW.state = 'published' THEN
+    IF NEW.snapshot_id IS NULL OR length(NEW.snapshot_id) = 0 THEN
+      RAISE EXCEPTION 'published ranking run % requires a snapshot id', OLD.id;
+    END IF;
+  ELSIF NEW.state = 'failed' THEN
+    IF NEW.failure IS NULL THEN
+      RAISE EXCEPTION 'failed ranking run % requires failure details', OLD.id;
+    END IF;
+  ELSIF NEW.failure IS NOT NULL THEN
+    RAISE EXCEPTION 'ranking run % in state % cannot contain failure details', OLD.id, NEW.state;
   END IF;
 
   IF NEW.state = 'running' THEN
@@ -257,6 +332,34 @@ CREATE TABLE IF NOT EXISTS ranking_run_items (
 CREATE INDEX IF NOT EXISTS idx_ranking_run_items_post
   ON ranking_run_items (post_uri, post_created_at DESC);
 
+CREATE OR REPLACE FUNCTION corgi_require_running_ranking_run()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  parent_state TEXT;
+BEGIN
+  SELECT state
+    INTO parent_state
+    FROM ranking_runs
+   WHERE id = NEW.run_id
+   FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ranking run % does not exist', NEW.run_id;
+  END IF;
+  IF parent_state <> 'running' THEN
+    RAISE EXCEPTION '% rows can only be inserted while ranking run % is running, got %',
+      TG_TABLE_NAME, NEW.run_id, parent_state;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ranking_run_items_require_running ON ranking_run_items;
+CREATE TRIGGER ranking_run_items_require_running
+  BEFORE INSERT ON ranking_run_items
+  FOR EACH ROW EXECUTE FUNCTION corgi_require_running_ranking_run();
+
 DROP TRIGGER IF EXISTS ranking_run_items_immutable ON ranking_run_items;
 CREATE TRIGGER ranking_run_items_immutable
   BEFORE UPDATE OR DELETE ON ranking_run_items
@@ -274,6 +377,11 @@ CREATE TABLE IF NOT EXISTS ranking_run_inputs (
   retained_until TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '7 days'),
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+DROP TRIGGER IF EXISTS ranking_run_inputs_require_running ON ranking_run_inputs;
+CREATE TRIGGER ranking_run_inputs_require_running
+  BEFORE INSERT ON ranking_run_inputs
+  FOR EACH ROW EXECUTE FUNCTION corgi_require_running_ranking_run();
 
 CREATE OR REPLACE FUNCTION corgi_protect_retained_ranking_input()
 RETURNS TRIGGER

--- a/src/db/migrations/032_trustworthy_corgi_contracts.sql
+++ b/src/db/migrations/032_trustworthy_corgi_contracts.sql
@@ -1,0 +1,339 @@
+-- Migration 032: Trustworthy Corgi policy and ranking-run contracts
+--
+-- This migration is additive. Existing scoring and feed publication remain
+-- authoritative until a later, separately governed cutover packet.
+
+CREATE TABLE IF NOT EXISTS governance_policy_versions (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  community_id TEXT NOT NULL,
+  epoch_id INTEGER NOT NULL REFERENCES governance_epochs(id) ON DELETE RESTRICT,
+  algorithm_version TEXT NOT NULL CHECK (length(algorithm_version) > 0),
+  weights JSONB NOT NULL CHECK (jsonb_typeof(weights) = 'object'),
+  topic_weights JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(topic_weights) = 'object'),
+  content_rules JSONB NOT NULL CHECK (jsonb_typeof(content_rules) = 'object'),
+  effective_at TIMESTAMPTZ NOT NULL,
+  provenance_references JSONB NOT NULL DEFAULT '[]'::jsonb
+    CHECK (jsonb_typeof(provenance_references) = 'array'),
+  policy_hash CHAR(64) NOT NULL CHECK (policy_hash ~ '^[0-9a-f]{64}$'),
+  reconciliation_status TEXT NOT NULL
+    CHECK (reconciliation_status IN ('match', 'incomplete_evidence', 'conflict_preserved')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (community_id, epoch_id, algorithm_version, policy_hash),
+  UNIQUE (id, policy_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_governance_policy_versions_current
+  ON governance_policy_versions (community_id, effective_at DESC, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS governance_policy_reconciliation_events (
+  id BIGSERIAL PRIMARY KEY,
+  policy_version_id UUID NOT NULL REFERENCES governance_policy_versions(id) ON DELETE RESTRICT,
+  community_id TEXT NOT NULL,
+  epoch_id INTEGER NOT NULL REFERENCES governance_epochs(id) ON DELETE RESTRICT,
+  reconciliation_status TEXT NOT NULL
+    CHECK (reconciliation_status IN ('match', 'incomplete_evidence', 'conflict_preserved')),
+  serving_weights JSONB NOT NULL CHECK (jsonb_typeof(serving_weights) = 'object'),
+  wide_weights JSONB NOT NULL CHECK (jsonb_typeof(wide_weights) = 'object'),
+  audit_weights JSONB CHECK (audit_weights IS NULL OR jsonb_typeof(audit_weights) = 'object'),
+  audit_log_ids BIGINT[] NOT NULL DEFAULT '{}'::bigint[],
+  evidence_hash CHAR(64) NOT NULL CHECK (evidence_hash ~ '^[0-9a-f]{64}$'),
+  details JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(details) = 'object'),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (policy_version_id, evidence_hash)
+);
+
+CREATE OR REPLACE FUNCTION corgi_reject_immutable_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION '% is append-only and immutable', TG_TABLE_NAME;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS governance_policy_versions_immutable ON governance_policy_versions;
+CREATE TRIGGER governance_policy_versions_immutable
+  BEFORE UPDATE OR DELETE ON governance_policy_versions
+  FOR EACH ROW EXECUTE FUNCTION corgi_reject_immutable_mutation();
+
+DROP TRIGGER IF EXISTS governance_policy_reconciliation_events_immutable
+  ON governance_policy_reconciliation_events;
+CREATE TRIGGER governance_policy_reconciliation_events_immutable
+  BEFORE UPDATE OR DELETE ON governance_policy_reconciliation_events
+  FOR EACH ROW EXECUTE FUNCTION corgi_reject_immutable_mutation();
+
+CREATE TABLE IF NOT EXISTS ranking_runs (
+  id UUID PRIMARY KEY,
+  community_id TEXT NOT NULL,
+  policy_version_id UUID NOT NULL,
+  policy_hash CHAR(64) NOT NULL CHECK (policy_hash ~ '^[0-9a-f]{64}$'),
+  as_of TIMESTAMPTZ NOT NULL,
+  code_sha TEXT NOT NULL CHECK (code_sha ~ '^[0-9a-f]{40,64}$'),
+  configuration_hash CHAR(64) NOT NULL CHECK (configuration_hash ~ '^[0-9a-f]{64}$'),
+  algorithm_version TEXT NOT NULL CHECK (length(algorithm_version) > 0),
+  state TEXT NOT NULL CHECK (
+    state IN ('requested', 'running', 'validated', 'published', 'failed', 'superseded', 'rejected')
+  ),
+  candidate_count INTEGER NOT NULL DEFAULT 0 CHECK (candidate_count >= 0),
+  selected_count INTEGER NOT NULL DEFAULT 0 CHECK (selected_count >= 0 AND selected_count <= 1000),
+  exclusion_count INTEGER NOT NULL DEFAULT 0 CHECK (exclusion_count >= 0),
+  timings JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(timings) = 'object'),
+  metrics JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metrics) = 'object'),
+  failure JSONB CHECK (failure IS NULL OR jsonb_typeof(failure) = 'object'),
+  snapshot_id TEXT,
+  input_checksum CHAR(64) CHECK (input_checksum IS NULL OR input_checksum ~ '^[0-9a-f]{64}$'),
+  receipt_checksum CHAR(64) CHECK (receipt_checksum IS NULL OR receipt_checksum ~ '^[0-9a-f]{64}$'),
+  receipt JSONB CHECK (receipt IS NULL OR jsonb_typeof(receipt) = 'object'),
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at TIMESTAMPTZ,
+  validated_at TIMESTAMPTZ,
+  published_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  retain_until TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '30 days'),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT ranking_runs_policy_identity_fk
+    FOREIGN KEY (policy_version_id, policy_hash)
+    REFERENCES governance_policy_versions(id, policy_hash) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ranking_runs_community_as_of
+  ON ranking_runs (community_id, as_of DESC);
+CREATE INDEX IF NOT EXISTS idx_ranking_runs_state_requested
+  ON ranking_runs (state, requested_at);
+
+CREATE TABLE IF NOT EXISTS ranking_run_events (
+  id BIGSERIAL PRIMARY KEY,
+  run_id UUID NOT NULL REFERENCES ranking_runs(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL,
+  previous_state TEXT,
+  next_state TEXT,
+  details JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(details) = 'object'),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION corgi_protect_ranking_run_child()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    RAISE EXCEPTION '% rows are immutable', TG_TABLE_NAME;
+  END IF;
+  IF EXISTS (SELECT 1 FROM ranking_runs WHERE id = OLD.run_id) THEN
+    RAISE EXCEPTION '% rows can only be deleted through retained run cleanup', TG_TABLE_NAME;
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ranking_run_events_immutable ON ranking_run_events;
+CREATE TRIGGER ranking_run_events_immutable
+  BEFORE UPDATE OR DELETE ON ranking_run_events
+  FOR EACH ROW EXECUTE FUNCTION corgi_protect_ranking_run_child();
+
+CREATE OR REPLACE FUNCTION corgi_validate_ranking_run_transition()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  transition_allowed BOOLEAN := FALSE;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.state <> 'requested' THEN
+      RAISE EXCEPTION 'ranking run must begin in requested state, got %', NEW.state;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF OLD.state IN ('published', 'failed', 'superseded', 'rejected') THEN
+    RAISE EXCEPTION 'terminal ranking run % in state % is immutable', OLD.id, OLD.state;
+  END IF;
+
+  IF OLD.state = 'validated' AND NEW.state = 'validated' THEN
+    RAISE EXCEPTION 'validated ranking run % is immutable until terminal transition', OLD.id;
+  END IF;
+
+  IF ROW(
+    NEW.id, NEW.community_id, NEW.policy_version_id, NEW.policy_hash,
+    NEW.as_of, NEW.code_sha, NEW.configuration_hash, NEW.algorithm_version
+  ) IS DISTINCT FROM ROW(
+    OLD.id, OLD.community_id, OLD.policy_version_id, OLD.policy_hash,
+    OLD.as_of, OLD.code_sha, OLD.configuration_hash, OLD.algorithm_version
+  ) THEN
+    RAISE EXCEPTION 'ranking run identity is immutable for run %', OLD.id;
+  END IF;
+
+  IF NEW.state = OLD.state THEN
+    RETURN NEW;
+  END IF;
+
+  IF OLD.state = 'validated' AND ROW(
+    NEW.candidate_count, NEW.selected_count, NEW.exclusion_count,
+    NEW.timings, NEW.metrics, NEW.failure, NEW.input_checksum,
+    NEW.receipt_checksum, NEW.receipt
+  ) IS DISTINCT FROM ROW(
+    OLD.candidate_count, OLD.selected_count, OLD.exclusion_count,
+    OLD.timings, OLD.metrics, OLD.failure, OLD.input_checksum,
+    OLD.receipt_checksum, OLD.receipt
+  ) THEN
+    RAISE EXCEPTION 'validated ranking result is immutable for run %', OLD.id;
+  END IF;
+
+  transition_allowed :=
+    (OLD.state = 'requested' AND NEW.state IN ('running', 'failed', 'superseded', 'rejected')) OR
+    (OLD.state = 'running' AND NEW.state IN ('validated', 'failed', 'superseded', 'rejected')) OR
+    (OLD.state = 'validated' AND NEW.state IN ('published', 'failed', 'superseded', 'rejected'));
+
+  IF NOT transition_allowed THEN
+    RAISE EXCEPTION 'invalid ranking run transition % -> % for run %', OLD.state, NEW.state, OLD.id;
+  END IF;
+
+  IF NEW.state = 'running' THEN
+    NEW.started_at := COALESCE(NEW.started_at, NOW());
+  ELSIF NEW.state = 'validated' THEN
+    NEW.validated_at := COALESCE(NEW.validated_at, NOW());
+  ELSIF NEW.state = 'published' THEN
+    NEW.published_at := COALESCE(NEW.published_at, NOW());
+    NEW.finished_at := COALESCE(NEW.finished_at, NOW());
+  ELSIF NEW.state IN ('failed', 'superseded', 'rejected') THEN
+    NEW.finished_at := COALESCE(NEW.finished_at, NOW());
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION corgi_record_ranking_run_event()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO ranking_run_events (run_id, event_type, previous_state, next_state)
+    VALUES (NEW.id, 'state_transition', NULL, NEW.state);
+  ELSIF NEW.state IS DISTINCT FROM OLD.state THEN
+    INSERT INTO ranking_run_events (run_id, event_type, previous_state, next_state)
+    VALUES (NEW.id, 'state_transition', OLD.state, NEW.state);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ranking_runs_validate_transition ON ranking_runs;
+CREATE TRIGGER ranking_runs_validate_transition
+  BEFORE INSERT OR UPDATE ON ranking_runs
+  FOR EACH ROW EXECUTE FUNCTION corgi_validate_ranking_run_transition();
+
+DROP TRIGGER IF EXISTS ranking_runs_record_event ON ranking_runs;
+CREATE TRIGGER ranking_runs_record_event
+  AFTER INSERT OR UPDATE ON ranking_runs
+  FOR EACH ROW EXECUTE FUNCTION corgi_record_ranking_run_event();
+
+CREATE TABLE IF NOT EXISTS ranking_run_items (
+  run_id UUID NOT NULL REFERENCES ranking_runs(id) ON DELETE CASCADE,
+  position INTEGER NOT NULL CHECK (position BETWEEN 1 AND 1000),
+  post_uri TEXT NOT NULL,
+  post_created_at TIMESTAMPTZ NOT NULL,
+  author_did TEXT NOT NULL,
+  component_decomposition JSONB NOT NULL CHECK (jsonb_typeof(component_decomposition) = 'object'),
+  candidate_sources TEXT[] NOT NULL CHECK (
+    cardinality(candidate_sources) > 0
+    AND candidate_sources <@ ARRAY[
+      'newest', 'engagement', 'policy_relevance', 'previous_snapshot', 'preliminary_fill'
+    ]::TEXT[]
+  ),
+  diversity_context JSONB NOT NULL CHECK (jsonb_typeof(diversity_context) = 'object'),
+  base_score DOUBLE PRECISION NOT NULL CHECK (
+    base_score NOT IN ('Infinity'::float8, '-Infinity'::float8, 'NaN'::float8)
+  ),
+  final_score DOUBLE PRECISION NOT NULL CHECK (
+    final_score NOT IN ('Infinity'::float8, '-Infinity'::float8, 'NaN'::float8)
+  ),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (run_id, position),
+  UNIQUE (run_id, post_uri, post_created_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ranking_run_items_post
+  ON ranking_run_items (post_uri, post_created_at DESC);
+
+DROP TRIGGER IF EXISTS ranking_run_items_immutable ON ranking_run_items;
+CREATE TRIGGER ranking_run_items_immutable
+  BEFORE UPDATE OR DELETE ON ranking_run_items
+  FOR EACH ROW EXECUTE FUNCTION corgi_protect_ranking_run_child();
+
+CREATE TABLE IF NOT EXISTS ranking_run_inputs (
+  run_id UUID PRIMARY KEY REFERENCES ranking_runs(id) ON DELETE CASCADE,
+  content_type TEXT NOT NULL DEFAULT 'application/json',
+  content_encoding TEXT NOT NULL DEFAULT 'gzip' CHECK (content_encoding = 'gzip'),
+  payload BYTEA NOT NULL,
+  checksum CHAR(64) NOT NULL CHECK (checksum ~ '^[0-9a-f]{64}$'),
+  candidate_count INTEGER NOT NULL CHECK (candidate_count >= 0),
+  uncompressed_bytes BIGINT NOT NULL CHECK (uncompressed_bytes >= 0),
+  compressed_bytes BIGINT NOT NULL CHECK (compressed_bytes >= 0),
+  retained_until TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '7 days'),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION corgi_protect_retained_ranking_input()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    RAISE EXCEPTION 'ranking_run_inputs is immutable';
+  END IF;
+  IF OLD.retained_until > clock_timestamp() THEN
+    RAISE EXCEPTION 'ranking input for run % is retained until %', OLD.run_id, OLD.retained_until;
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ranking_run_inputs_retention ON ranking_run_inputs;
+CREATE TRIGGER ranking_run_inputs_retention
+  BEFORE UPDATE OR DELETE ON ranking_run_inputs
+  FOR EACH ROW EXECUTE FUNCTION corgi_protect_retained_ranking_input();
+
+CREATE OR REPLACE FUNCTION corgi_protect_ranking_run_manifest()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.retain_until > clock_timestamp() THEN
+    RAISE EXCEPTION 'ranking run % is retained until %', OLD.id, OLD.retain_until;
+  END IF;
+  IF OLD.state NOT IN ('published', 'failed', 'superseded', 'rejected') THEN
+    RAISE EXCEPTION 'non-terminal ranking run % cannot be deleted', OLD.id;
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ranking_runs_retention ON ranking_runs;
+CREATE TRIGGER ranking_runs_retention
+  BEFORE DELETE ON ranking_runs
+  FOR EACH ROW EXECUTE FUNCTION corgi_protect_ranking_run_manifest();
+
+CREATE TABLE IF NOT EXISTS ranking_run_requests (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  idempotency_key TEXT NOT NULL UNIQUE,
+  community_id TEXT NOT NULL,
+  request_kind TEXT NOT NULL
+    CHECK (request_kind IN ('scheduled', 'manual', 'replacement', 'reconciliation')),
+  state TEXT NOT NULL DEFAULT 'pending'
+    CHECK (state IN ('pending', 'claimed', 'completed', 'cancelled', 'failed')),
+  requested_by TEXT,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  not_before TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  claimed_by TEXT,
+  claimed_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  ranking_run_id UUID UNIQUE REFERENCES ranking_runs(id) ON DELETE SET NULL,
+  failure JSONB CHECK (failure IS NULL OR jsonb_typeof(failure) = 'object'),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ranking_run_requests_pending
+  ON ranking_run_requests (not_before, requested_at)
+  WHERE state = 'pending';

--- a/src/governance/policy-version.ts
+++ b/src/governance/policy-version.ts
@@ -1,0 +1,413 @@
+import { createHash } from 'node:crypto';
+import type { PoolClient } from 'pg';
+import type {
+  GovernancePolicyDocument,
+  JsonObject,
+  JsonValue,
+  PolicyBundle,
+  PolicyProvenanceReference,
+} from '../shared/ranking-contracts.js';
+
+const POLICY_HASH_PATTERN = /^[0-9a-f]{64}$/;
+
+interface ActiveEpochRow {
+  id: number;
+  recency_weight: number | string;
+  engagement_weight: number | string;
+  bridging_weight: number | string;
+  source_diversity_weight: number | string;
+  relevance_weight: number | string;
+  topic_weights: unknown;
+  content_rules: unknown;
+  created_at: Date | string;
+}
+
+interface LongWeightRow {
+  component_key: string;
+  weight: number | string;
+}
+
+interface AuditRow {
+  id: number;
+  action: string;
+  details: unknown;
+  created_at: Date | string;
+}
+
+interface PolicyVersionRow {
+  id: string;
+  policy_hash: string;
+  reconciliation_status: PolicyBundle['reconciliationStatus'];
+  created_at: Date | string;
+}
+
+export interface PolicyMaterializationInput {
+  communityId: string;
+  algorithmVersion: string;
+  effectiveAt: string;
+  provenanceReferences: readonly PolicyProvenanceReference[];
+}
+
+export interface PolicyMaterializationResult {
+  bundle: PolicyBundle;
+  created: boolean;
+  evidenceHash: string;
+}
+
+export function canonicalJson(value: unknown): string {
+  return canonicalize(value, new WeakSet<object>());
+}
+
+export function hashCanonicalJson(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value), 'utf8').digest('hex');
+}
+
+export function computePolicyHash(document: GovernancePolicyDocument): string {
+  return hashCanonicalJson(document);
+}
+
+export function assertSha256(value: string, label: string): void {
+  if (!POLICY_HASH_PATTERN.test(value)) {
+    throw new Error(`${label} must be a lowercase SHA-256 hex digest`);
+  }
+}
+
+export async function materializeActivePolicyVersion(
+  client: PoolClient,
+  input: PolicyMaterializationInput
+): Promise<PolicyMaterializationResult> {
+  assertNonEmpty(input.communityId, 'communityId');
+  assertNonEmpty(input.algorithmVersion, 'algorithmVersion');
+  assertIsoTimestamp(input.effectiveAt, 'effectiveAt');
+
+  const epochResult = await client.query<ActiveEpochRow>(
+    `SELECT id, recency_weight, engagement_weight, bridging_weight,
+            source_diversity_weight, relevance_weight, topic_weights,
+            content_rules, created_at
+       FROM governance_epochs
+      WHERE status = 'active'
+      ORDER BY id DESC
+      LIMIT 1
+      FOR SHARE`
+  );
+  const epoch = epochResult.rows[0];
+  if (!epoch) {
+    throw new Error('Cannot materialize policy: no active governance epoch exists');
+  }
+
+  const longWeightResult = await client.query<LongWeightRow>(
+    `SELECT component_key, weight
+       FROM governance_epoch_weights
+      WHERE epoch_id = $1
+      ORDER BY component_key`,
+    [epoch.id]
+  );
+  if (longWeightResult.rows.length === 0) {
+    throw new Error(`Cannot materialize policy for epoch ${epoch.id}: serving weight rows are missing`);
+  }
+
+  const auditResult = await client.query<AuditRow>(
+    `SELECT id, action, details, created_at
+       FROM governance_audit_log
+      WHERE epoch_id = $1
+      ORDER BY id`,
+    [epoch.id]
+  );
+  const policyAuditRows = auditResult.rows.filter(isPolicyAuditRow);
+
+  const servingWeights = normalizeNumericRecord(
+    Object.fromEntries(longWeightResult.rows.map((row) => [row.component_key, row.weight])),
+    `serving weights for epoch ${epoch.id}`
+  );
+  const wideWeights = normalizeNumericRecord(
+    {
+      recency: epoch.recency_weight,
+      engagement: epoch.engagement_weight,
+      bridging: epoch.bridging_weight,
+      sourceDiversity: epoch.source_diversity_weight,
+      relevance: epoch.relevance_weight,
+    },
+    `wide weights for epoch ${epoch.id}`
+  );
+  const auditWeights = latestAuditWeights(policyAuditRows, epoch.id);
+  const reconciliationStatus = determineReconciliationStatus(
+    servingWeights,
+    wideWeights,
+    auditWeights
+  );
+
+  const auditReferences: PolicyProvenanceReference[] = policyAuditRows.map((row) => ({
+    kind: 'governance_audit_log',
+    reference: String(row.id),
+    observedAt: toIsoTimestamp(row.created_at, `audit log ${row.id} created_at`),
+  }));
+  const provenanceReferences = canonicalClone([
+    ...input.provenanceReferences,
+    ...auditReferences,
+    {
+      kind: 'governance_epoch',
+      reference: String(epoch.id),
+      observedAt: toIsoTimestamp(epoch.created_at, `epoch ${epoch.id} created_at`),
+    },
+  ]) as unknown as PolicyProvenanceReference[];
+
+  const document: GovernancePolicyDocument = {
+    communityId: input.communityId,
+    epochId: epoch.id,
+    algorithmVersion: input.algorithmVersion,
+    weights: servingWeights,
+    topicWeights: normalizeNumericRecord(epoch.topic_weights ?? {}, `topic weights for epoch ${epoch.id}`),
+    contentRules: normalizeJsonObject(epoch.content_rules ?? {}, `content rules for epoch ${epoch.id}`),
+    effectiveAt: input.effectiveAt,
+    provenanceReferences,
+  };
+  const policyHash = computePolicyHash(document);
+
+  const inserted = await client.query<PolicyVersionRow>(
+    `INSERT INTO governance_policy_versions (
+       community_id, epoch_id, algorithm_version, weights, topic_weights,
+       content_rules, effective_at, provenance_references, policy_hash,
+       reconciliation_status
+     ) VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7, $8::jsonb, $9, $10)
+     ON CONFLICT (community_id, epoch_id, algorithm_version, policy_hash) DO NOTHING
+     RETURNING id::text, policy_hash::text, reconciliation_status, created_at`,
+    [
+      document.communityId,
+      document.epochId,
+      document.algorithmVersion,
+      canonicalJson(document.weights),
+      canonicalJson(document.topicWeights),
+      canonicalJson(document.contentRules),
+      document.effectiveAt,
+      canonicalJson(document.provenanceReferences),
+      policyHash,
+      reconciliationStatus,
+    ]
+  );
+
+  const created = inserted.rows.length === 1;
+  const policyRow = inserted.rows[0] ?? await loadExistingPolicyVersion(
+    client,
+    document,
+    policyHash
+  );
+
+  const evidence = {
+    communityId: document.communityId,
+    epochId: document.epochId,
+    policyHash,
+    servingWeights,
+    wideWeights,
+    auditWeights,
+    auditLogIds: policyAuditRows.map((row) => row.id),
+    reconciliationStatus,
+  };
+  const evidenceHash = hashCanonicalJson(evidence);
+
+  await client.query(
+    `INSERT INTO governance_policy_reconciliation_events (
+       policy_version_id, community_id, epoch_id, reconciliation_status,
+       serving_weights, wide_weights, audit_weights, audit_log_ids,
+       evidence_hash, details
+     ) VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::bigint[], $9, $10::jsonb)
+     ON CONFLICT (policy_version_id, evidence_hash) DO NOTHING`,
+    [
+      policyRow.id,
+      document.communityId,
+      document.epochId,
+      reconciliationStatus,
+      canonicalJson(servingWeights),
+      canonicalJson(wideWeights),
+      auditWeights === null ? null : canonicalJson(auditWeights),
+      policyAuditRows.map((row) => row.id),
+      evidenceHash,
+      canonicalJson({ policyHash }),
+    ]
+  );
+
+  return {
+    bundle: {
+      ...document,
+      policyVersionId: policyRow.id,
+      policyHash: policyRow.policy_hash,
+      reconciliationStatus: policyRow.reconciliation_status,
+      createdAt: toIsoTimestamp(policyRow.created_at, 'policy version created_at'),
+    },
+    created,
+    evidenceHash,
+  };
+}
+
+async function loadExistingPolicyVersion(
+  client: PoolClient,
+  document: GovernancePolicyDocument,
+  policyHash: string
+): Promise<PolicyVersionRow> {
+  const existing = await client.query<PolicyVersionRow>(
+    `SELECT id::text, policy_hash::text, reconciliation_status, created_at
+       FROM governance_policy_versions
+      WHERE community_id = $1
+        AND epoch_id = $2
+        AND algorithm_version = $3
+        AND policy_hash = $4`,
+    [document.communityId, document.epochId, document.algorithmVersion, policyHash]
+  );
+  const row = existing.rows[0];
+  if (!row) {
+    throw new Error(`Policy materialization lost idempotent row for hash ${policyHash}`);
+  }
+  return row;
+}
+
+function determineReconciliationStatus(
+  servingWeights: Readonly<Record<string, number>>,
+  wideWeights: Readonly<Record<string, number>>,
+  auditWeights: Readonly<Record<string, number>> | null
+): PolicyBundle['reconciliationStatus'] {
+  if (canonicalJson(servingWeights) !== canonicalJson(wideWeights)) {
+    return 'conflict_preserved';
+  }
+  if (auditWeights === null) {
+    return 'incomplete_evidence';
+  }
+  return canonicalJson(servingWeights) === canonicalJson(auditWeights)
+    ? 'match'
+    : 'conflict_preserved';
+}
+
+function latestAuditWeights(
+  rows: readonly AuditRow[],
+  epochId: number
+): Readonly<Record<string, number>> | null {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (!isRecord(row.details)) {
+      continue;
+    }
+    const candidate = row.details.new_weights;
+    if (candidate === undefined) {
+      continue;
+    }
+    return normalizeNumericRecord(candidate, `audit weights for epoch ${epochId}, event ${row.id}`);
+  }
+  return null;
+}
+
+function isPolicyAuditRow(row: AuditRow): boolean {
+  if (!isRecord(row.details)) {
+    return false;
+  }
+  return [
+    'new_weights',
+    'new_content_rules',
+    'content_rules',
+    'new_topic_weights',
+    'topic_weights',
+  ].some((key) => Object.hasOwn(row.details as object, key));
+}
+
+function normalizeNumericRecord(value: unknown, label: string): Readonly<Record<string, number>> {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const normalized: Record<string, number> = {};
+  for (const [key, candidate] of Object.entries(value)) {
+    if (
+      typeof candidate !== 'number'
+      && (typeof candidate !== 'string' || candidate.trim().length === 0)
+    ) {
+      throw new Error(`${label}.${key} must be a number`);
+    }
+    const numeric = typeof candidate === 'number' ? candidate : Number(candidate);
+    if (!Number.isFinite(numeric)) {
+      throw new Error(`${label}.${key} must be a finite number`);
+    }
+    normalized[key] = Object.is(numeric, -0) ? 0 : numeric;
+  }
+  return canonicalClone(normalized) as Record<string, number>;
+}
+
+function normalizeJsonObject(value: unknown, label: string): JsonObject {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return canonicalClone(value) as JsonObject;
+}
+
+function canonicalClone(value: unknown): JsonValue {
+  return JSON.parse(canonicalJson(value)) as JsonValue;
+}
+
+function canonicalize(value: unknown, ancestors: WeakSet<object>): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('Canonical JSON cannot contain non-finite numbers');
+    }
+    return JSON.stringify(Object.is(value, -0) ? 0 : value);
+  }
+  if (typeof value !== 'object') {
+    throw new Error(`Canonical JSON cannot contain ${typeof value}`);
+  }
+  if (ancestors.has(value)) {
+    throw new Error('Canonical JSON cannot contain cyclic references');
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return `[${value.map((item) => canonicalize(item, ancestors)).join(',')}]`;
+    }
+    if (!isRecord(value)) {
+      throw new Error('Canonical JSON only accepts plain objects');
+    }
+    if (Object.getOwnPropertySymbols(value).length > 0) {
+      throw new Error('Canonical JSON cannot contain symbol keys');
+    }
+    const keys = Object.keys(value).sort();
+    const entries = keys.map((key) => {
+      const child = value[key];
+      if (child === undefined) {
+        throw new Error(`Canonical JSON cannot contain undefined at key ${key}`);
+      }
+      return `${JSON.stringify(key)}:${canonicalize(child, ancestors)}`;
+    });
+    return `{${entries.join(',')}}`;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function assertNonEmpty(value: string, label: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${label} must not be empty`);
+  }
+}
+
+function assertIsoTimestamp(value: string, label: string): void {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${label} must be an ISO-8601 timestamp`);
+  }
+}
+
+function toIsoTimestamp(value: Date | string, label: string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${label} must be a valid timestamp`);
+  }
+  return parsed.toISOString();
+}

--- a/src/governance/policy-version.ts
+++ b/src/governance/policy-version.ts
@@ -287,7 +287,7 @@ function latestAuditWeights(
       continue;
     }
     const candidate = row.details.new_weights;
-    if (candidate === undefined) {
+    if (candidate === undefined || candidate === null) {
       continue;
     }
     return normalizeNumericRecord(candidate, `audit weights for epoch ${epochId}, event ${row.id}`);

--- a/src/governance/policy-version.ts
+++ b/src/governance/policy-version.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { PoolClient } from 'pg';
+import { GOVERNANCE_WEIGHT_KEYS } from '../config/votable-params.js';
 import type {
   GovernancePolicyDocument,
   JsonObject,
@@ -119,6 +120,7 @@ export async function materializeActivePolicyVersion(
     Object.fromEntries(longWeightResult.rows.map((row) => [row.component_key, row.weight])),
     `serving weights for epoch ${epoch.id}`
   );
+  assertCompleteServingWeights(servingWeights, epoch.id);
   const wideWeights = normalizeNumericRecord(
     {
       recency: epoch.recency_weight,
@@ -325,6 +327,28 @@ function normalizeNumericRecord(value: unknown, label: string): Readonly<Record<
     normalized[key] = Object.is(numeric, -0) ? 0 : numeric;
   }
   return canonicalClone(normalized) as Record<string, number>;
+}
+
+function assertCompleteServingWeights(
+  servingWeights: Readonly<Record<string, number>>,
+  epochId: number
+): void {
+  const expected = [...GOVERNANCE_WEIGHT_KEYS].sort();
+  const actual = Object.keys(servingWeights).sort();
+  const missing = expected.filter((key) => !Object.hasOwn(servingWeights, key));
+  const unexpected = actual.filter((key) => !expected.includes(key));
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new Error(
+      `Cannot materialize policy for epoch ${epochId}: serving weight keys do not match registry`
+      + ` (missing: ${missing.join(', ') || 'none'}; unexpected: ${unexpected.join(', ') || 'none'})`
+    );
+  }
+  const total = Object.values(servingWeights).reduce((sum, weight) => sum + weight, 0);
+  if (Math.abs(total - 1) > 1e-9) {
+    throw new Error(
+      `Cannot materialize policy for epoch ${epochId}: serving weights total ${total}, expected 1`
+    );
+  }
 }
 
 function normalizeJsonObject(value: unknown, label: string): JsonObject {

--- a/src/scoring/ranking-run-contracts.ts
+++ b/src/scoring/ranking-run-contracts.ts
@@ -51,6 +51,12 @@ interface RankingInputRow {
   compressed_bytes: number | string;
 }
 
+interface RankingItemIdentityRow {
+  position: number;
+  post_uri: string;
+  post_created_at: Date | string;
+}
+
 export interface CompressedRankingInput {
   payload: Buffer;
   checksum: string;
@@ -281,7 +287,8 @@ export async function persistRankingRunInput(
   if (current.state !== 'running') {
     throw new Error(`Ranking input can only be persisted while running, got ${current.state}`);
   }
-  decodeCompressedRankingInput(compressed);
+  const envelope = decodeCompressedRankingInput(compressed);
+  assertInputEnvelopeMatchesRun(envelope, current);
   await client.query(
     `INSERT INTO ranking_run_inputs (
        run_id, payload, checksum, candidate_count,
@@ -378,16 +385,27 @@ export async function validateRankingRun(
     );
   }
 
-  const itemResult = await client.query<{ count: number }>(
-    `SELECT COUNT(*)::int AS count
+  const itemResult = await client.query<RankingItemIdentityRow>(
+    `SELECT position, post_uri, post_created_at
        FROM ranking_run_items
-      WHERE run_id = $1`,
+      WHERE run_id = $1
+      ORDER BY position ASC`,
     [input.runId]
   );
-  const itemCount = itemResult.rows[0]?.count ?? 0;
+  const itemCount = itemResult.rows.length;
   if (itemCount !== input.receipt.itemCount) {
     throw new Error(
       `Ranking run ${input.runId} item count mismatch: stored ${itemCount}, receipt ${input.receipt.itemCount}`
+    );
+  }
+  const storedItemOrderChecksum = hashCanonicalJson(itemResult.rows.map((item) => [
+    item.position,
+    item.post_uri,
+    toIsoTimestamp(item.post_created_at, `ranking item ${item.position} post_created_at`),
+  ]));
+  if (storedItemOrderChecksum !== input.receipt.itemOrderChecksum) {
+    throw new Error(
+      `Ranking run ${input.runId} item order checksum does not match stored slate`
     );
   }
 
@@ -448,13 +466,15 @@ export async function prepareRankingRunPublication(
 
   await client.query(
     `UPDATE ranking_runs
-        SET state = 'superseded',
-            metrics = metrics || $2::jsonb
+        SET state = 'superseded'
       WHERE id = $1`,
-    [
-      runId,
-      canonicalJson({ supersededByPolicyHash: currentPolicyHash }),
-    ]
+    [runId]
+  );
+  await client.query(
+    `INSERT INTO ranking_run_events (
+       run_id, event_type, previous_state, next_state, details
+     ) VALUES ($1, 'stale_policy_detected', 'validated', 'superseded', $2::jsonb)`,
+    [runId, canonicalJson({ supersededByPolicyHash: currentPolicyHash })]
   );
   const replacement = await enqueueRankingRunRequest(client, {
     idempotencyKey: `replacement:${runId}:${currentPolicyHash}`,
@@ -673,6 +693,24 @@ function assertReceiptMatchesRun(receipt: RankingReceipt, run: RankingRunRow): v
   if (receipt.asOf !== toIsoTimestamp(run.as_of, 'ranking run as_of')) mismatches.push('asOf');
   if (mismatches.length > 0) {
     throw new Error(`Ranking receipt does not match run identity: ${mismatches.join(', ')}`);
+  }
+}
+
+function assertInputEnvelopeMatchesRun(
+  envelope: RankingRunInputEnvelope,
+  run: RankingRunRow
+): void {
+  const mismatches: string[] = [];
+  if (envelope.runId !== run.id) mismatches.push('runId');
+  if (envelope.communityId !== run.community_id) mismatches.push('communityId');
+  if (envelope.policyHash !== run.policy_hash) mismatches.push('policyHash');
+  if (envelope.configurationHash !== run.configuration_hash) mismatches.push('configurationHash');
+  if (toIsoTimestamp(envelope.asOf, 'ranking input asOf')
+      !== toIsoTimestamp(run.as_of, 'ranking run as_of')) {
+    mismatches.push('asOf');
+  }
+  if (mismatches.length > 0) {
+    throw new Error(`Ranking input does not match run identity: ${mismatches.join(', ')}`);
   }
 }
 

--- a/src/scoring/ranking-run-contracts.ts
+++ b/src/scoring/ranking-run-contracts.ts
@@ -1,0 +1,726 @@
+import { createHash } from 'node:crypto';
+import { gunzipSync, gzipSync } from 'node:zlib';
+import type { PoolClient } from 'pg';
+import { assertSha256, canonicalJson, hashCanonicalJson } from '../governance/policy-version.js';
+import type {
+  JsonObject,
+  RankedSlateItem,
+  RankingPublicationMetadata,
+  RankingReceipt,
+  RankingRunInputEnvelope,
+  RankingRunState,
+} from '../shared/ranking-contracts.js';
+
+const TERMINAL_STATES = new Set<RankingRunState>([
+  'published',
+  'failed',
+  'superseded',
+  'rejected',
+]);
+
+const ALLOWED_TRANSITIONS: Readonly<Record<RankingRunState, readonly RankingRunState[]>> = {
+  requested: ['running', 'failed', 'superseded', 'rejected'],
+  running: ['validated', 'failed', 'superseded', 'rejected'],
+  validated: ['published', 'failed', 'superseded', 'rejected'],
+  published: [],
+  failed: [],
+  superseded: [],
+  rejected: [],
+};
+
+interface RankingRunRow {
+  id: string;
+  community_id: string;
+  policy_version_id: string;
+  policy_hash: string;
+  algorithm_version: string;
+  configuration_hash: string;
+  code_sha: string;
+  as_of: Date | string;
+  state: RankingRunState;
+  selected_count: number;
+  snapshot_id: string | null;
+  receipt_checksum: string | null;
+}
+
+interface RankingInputRow {
+  payload: Buffer;
+  checksum: string;
+  candidate_count: number;
+  uncompressed_bytes: number | string;
+  compressed_bytes: number | string;
+}
+
+export interface CompressedRankingInput {
+  payload: Buffer;
+  checksum: string;
+  candidateCount: number;
+  uncompressedBytes: number;
+  compressedBytes: number;
+}
+
+export interface CreateRankingRunInput {
+  runId: string;
+  communityId: string;
+  policyVersionId: string;
+  policyHash: string;
+  algorithmVersion: string;
+  configurationHash: string;
+  codeSha: string;
+  asOf: string;
+}
+
+export interface ValidateRankingRunInput {
+  runId: string;
+  receipt: RankingReceipt;
+  candidateCount: number;
+  exclusionCount: number;
+  timings: JsonObject;
+  metrics: JsonObject;
+}
+
+export interface PreparePublicationResult {
+  publishable: boolean;
+  currentPolicyHash: string;
+  replacementRequestId: string | null;
+}
+
+export interface CleanupRankingDataResult {
+  deletedInputs: number;
+  deletedRuns: number;
+}
+
+export interface EnqueueRankingRequestInput {
+  idempotencyKey: string;
+  communityId: string;
+  requestKind: 'scheduled' | 'manual' | 'replacement' | 'reconciliation';
+  requestedBy: string | null;
+  notBefore: string;
+}
+
+export function assertRankingRunTransition(
+  currentState: RankingRunState,
+  nextState: RankingRunState
+): void {
+  if (!ALLOWED_TRANSITIONS[currentState].includes(nextState)) {
+    throw new Error(`Invalid ranking run transition ${currentState} -> ${nextState}`);
+  }
+}
+
+export function isTerminalRankingRunState(state: RankingRunState): boolean {
+  return TERMINAL_STATES.has(state);
+}
+
+export function createCompressedRankingInput(
+  envelope: RankingRunInputEnvelope
+): CompressedRankingInput {
+  validateInputEnvelope(envelope);
+  const canonical = canonicalJson(envelope);
+  const uncompressed = Buffer.from(canonical, 'utf8');
+  const payload = gzipSync(uncompressed, { level: 9 });
+  return {
+    payload,
+    checksum: sha256Buffer(uncompressed),
+    candidateCount: envelope.candidates.length,
+    uncompressedBytes: uncompressed.byteLength,
+    compressedBytes: payload.byteLength,
+  };
+}
+
+export function decodeCompressedRankingInput(
+  compressed: CompressedRankingInput
+): RankingRunInputEnvelope {
+  assertSha256(compressed.checksum, 'ranking input checksum');
+  if (compressed.payload.byteLength !== compressed.compressedBytes) {
+    throw new Error(
+      `Compressed ranking input byte count mismatch: expected ${compressed.compressedBytes}, got ${compressed.payload.byteLength}`
+    );
+  }
+  const uncompressed = gunzipSync(compressed.payload);
+  if (uncompressed.byteLength !== compressed.uncompressedBytes) {
+    throw new Error(
+      `Uncompressed ranking input byte count mismatch: expected ${compressed.uncompressedBytes}, got ${uncompressed.byteLength}`
+    );
+  }
+  const actualChecksum = sha256Buffer(uncompressed);
+  if (actualChecksum !== compressed.checksum) {
+    throw new Error(
+      `Ranking input checksum mismatch: expected ${compressed.checksum}, got ${actualChecksum}`
+    );
+  }
+
+  const raw = uncompressed.toString('utf8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (canonicalJson(parsed) !== raw) {
+    throw new Error('Ranking input payload is not canonical JSON');
+  }
+  validateInputEnvelope(parsed);
+  if (parsed.candidates.length !== compressed.candidateCount) {
+    throw new Error(
+      `Ranking input candidate count mismatch: expected ${compressed.candidateCount}, got ${parsed.candidates.length}`
+    );
+  }
+  return parsed;
+}
+
+export function buildRankingReceipt(input: {
+  runId: string;
+  communityId: string;
+  policyVersionId: string;
+  policyHash: string;
+  algorithmVersion: string;
+  configurationHash: string;
+  codeSha: string;
+  asOf: string;
+  inputChecksum: string;
+  items: readonly RankedSlateItem[];
+}): RankingReceipt {
+  assertSha256(input.policyHash, 'policyHash');
+  assertSha256(input.configurationHash, 'configurationHash');
+  assertSha256(input.inputChecksum, 'inputChecksum');
+  assertIsoTimestamp(input.asOf, 'asOf');
+  validateRankedItems(input.items);
+
+  const itemOrderChecksum = hashCanonicalJson(
+    input.items.map((item) => [item.position, item.postUri, item.postCreatedAt])
+  );
+  const unsigned = {
+    schemaVersion: 1 as const,
+    runId: input.runId,
+    communityId: input.communityId,
+    policyVersionId: input.policyVersionId,
+    policyHash: input.policyHash,
+    algorithmVersion: input.algorithmVersion,
+    configurationHash: input.configurationHash,
+    codeSha: input.codeSha,
+    asOf: input.asOf,
+    itemCount: input.items.length,
+    inputChecksum: input.inputChecksum,
+    itemOrderChecksum,
+  };
+  return {
+    ...unsigned,
+    receiptChecksum: hashCanonicalJson(unsigned),
+  };
+}
+
+export function validateRankingReceipt(receipt: RankingReceipt): void {
+  assertSha256(receipt.policyHash, 'receipt.policyHash');
+  assertSha256(receipt.configurationHash, 'receipt.configurationHash');
+  assertSha256(receipt.inputChecksum, 'receipt.inputChecksum');
+  assertSha256(receipt.itemOrderChecksum, 'receipt.itemOrderChecksum');
+  assertSha256(receipt.receiptChecksum, 'receipt.receiptChecksum');
+  assertIsoTimestamp(receipt.asOf, 'receipt.asOf');
+  if (!Number.isInteger(receipt.itemCount) || receipt.itemCount < 0 || receipt.itemCount > 1000) {
+    throw new Error(`receipt.itemCount must be an integer in [0, 1000], got ${receipt.itemCount}`);
+  }
+  const { receiptChecksum, ...unsigned } = receipt;
+  const actual = hashCanonicalJson(unsigned);
+  if (actual !== receiptChecksum) {
+    throw new Error(`Ranking receipt checksum mismatch: expected ${receiptChecksum}, got ${actual}`);
+  }
+}
+
+export async function createRankingRun(
+  client: PoolClient,
+  input: CreateRankingRunInput
+): Promise<void> {
+  assertSha256(input.policyHash, 'policyHash');
+  assertSha256(input.configurationHash, 'configurationHash');
+  assertIsoTimestamp(input.asOf, 'asOf');
+  if (!/^[0-9a-f]{40,64}$/.test(input.codeSha)) {
+    throw new Error('codeSha must be a lowercase 40-64 character hexadecimal digest');
+  }
+  await client.query(
+    `INSERT INTO ranking_runs (
+       id, community_id, policy_version_id, policy_hash, as_of,
+       code_sha, configuration_hash, algorithm_version, state
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'requested')`,
+    [
+      input.runId,
+      input.communityId,
+      input.policyVersionId,
+      input.policyHash,
+      input.asOf,
+      input.codeSha,
+      input.configurationHash,
+      input.algorithmVersion,
+    ]
+  );
+}
+
+export async function transitionRankingRun(
+  client: PoolClient,
+  runId: string,
+  nextState: RankingRunState,
+  failure: JsonObject | null
+): Promise<void> {
+  const current = await lockRankingRun(client, runId);
+  assertRankingRunTransition(current.state, nextState);
+  if (nextState === 'failed' && failure === null) {
+    throw new Error(`Failure details are required when ranking run ${runId} fails`);
+  }
+  if (nextState !== 'failed' && failure !== null) {
+    throw new Error(`Failure details are only valid for failed ranking runs, got ${nextState}`);
+  }
+  await client.query(
+    `UPDATE ranking_runs
+        SET state = $2,
+            failure = $3::jsonb
+      WHERE id = $1`,
+    [runId, nextState, failure === null ? null : canonicalJson(failure)]
+  );
+}
+
+export async function persistRankingRunInput(
+  client: PoolClient,
+  runId: string,
+  compressed: CompressedRankingInput
+): Promise<void> {
+  const current = await lockRankingRun(client, runId);
+  if (current.state !== 'running') {
+    throw new Error(`Ranking input can only be persisted while running, got ${current.state}`);
+  }
+  decodeCompressedRankingInput(compressed);
+  await client.query(
+    `INSERT INTO ranking_run_inputs (
+       run_id, payload, checksum, candidate_count,
+       uncompressed_bytes, compressed_bytes
+     ) VALUES ($1, $2, $3, $4, $5, $6)`,
+    [
+      runId,
+      compressed.payload,
+      compressed.checksum,
+      compressed.candidateCount,
+      compressed.uncompressedBytes,
+      compressed.compressedBytes,
+    ]
+  );
+}
+
+export async function persistRankedSlate(
+  client: PoolClient,
+  runId: string,
+  items: readonly RankedSlateItem[]
+): Promise<void> {
+  const current = await lockRankingRun(client, runId);
+  if (current.state !== 'running') {
+    throw new Error(`Ranked slate can only be persisted while running, got ${current.state}`);
+  }
+  validateRankedItems(items);
+  if (items.length === 0) {
+    throw new Error(`Ranking run ${runId} cannot persist an empty published slate`);
+  }
+
+  const placeholders: string[] = [];
+  const values: unknown[] = [];
+  for (const item of items) {
+    const offset = values.length;
+    values.push(
+      runId,
+      item.position,
+      item.postUri,
+      item.postCreatedAt,
+      item.authorDid,
+      canonicalJson(item.componentDecomposition),
+      [...item.candidateSources],
+      canonicalJson(item.diversityContext),
+      item.baseScore,
+      item.finalScore
+    );
+    placeholders.push(
+      `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, `
+      + `$${offset + 6}::jsonb, $${offset + 7}::text[], $${offset + 8}::jsonb, `
+      + `$${offset + 9}, $${offset + 10})`
+    );
+  }
+
+  await client.query(
+    `INSERT INTO ranking_run_items (
+       run_id, position, post_uri, post_created_at, author_did,
+       component_decomposition, candidate_sources, diversity_context,
+       base_score, final_score
+     ) VALUES ${placeholders.join(', ')}`,
+    values
+  );
+}
+
+export async function validateRankingRun(
+  client: PoolClient,
+  input: ValidateRankingRunInput
+): Promise<void> {
+  validateRankingReceipt(input.receipt);
+  if (input.receipt.runId !== input.runId) {
+    throw new Error(`Receipt run ${input.receipt.runId} does not match ${input.runId}`);
+  }
+  const current = await lockRankingRun(client, input.runId);
+  if (current.state !== 'running') {
+    throw new Error(`Ranking run must be running before validation, got ${current.state}`);
+  }
+  assertReceiptMatchesRun(input.receipt, current);
+
+  const inputResult = await client.query<{ checksum: string; candidate_count: number }>(
+    `SELECT checksum::text, candidate_count
+       FROM ranking_run_inputs
+      WHERE run_id = $1`,
+    [input.runId]
+  );
+  const storedInput = inputResult.rows[0];
+  if (!storedInput) {
+    throw new Error(`Ranking run ${input.runId} has no replay input`);
+  }
+  if (storedInput.checksum !== input.receipt.inputChecksum) {
+    throw new Error(`Ranking run ${input.runId} receipt does not match stored input checksum`);
+  }
+  if (storedInput.candidate_count !== input.candidateCount) {
+    throw new Error(
+      `Ranking run ${input.runId} candidate count mismatch: stored ${storedInput.candidate_count}, supplied ${input.candidateCount}`
+    );
+  }
+
+  const itemResult = await client.query<{ count: number }>(
+    `SELECT COUNT(*)::int AS count
+       FROM ranking_run_items
+      WHERE run_id = $1`,
+    [input.runId]
+  );
+  const itemCount = itemResult.rows[0]?.count ?? 0;
+  if (itemCount !== input.receipt.itemCount) {
+    throw new Error(
+      `Ranking run ${input.runId} item count mismatch: stored ${itemCount}, receipt ${input.receipt.itemCount}`
+    );
+  }
+
+  await client.query(
+    `UPDATE ranking_runs
+        SET state = 'validated',
+            candidate_count = $2,
+            selected_count = $3,
+            exclusion_count = $4,
+            timings = $5::jsonb,
+            metrics = $6::jsonb,
+            input_checksum = $7,
+            receipt_checksum = $8,
+            receipt = $9::jsonb
+      WHERE id = $1`,
+    [
+      input.runId,
+      input.candidateCount,
+      input.receipt.itemCount,
+      input.exclusionCount,
+      canonicalJson(input.timings),
+      canonicalJson(input.metrics),
+      input.receipt.inputChecksum,
+      input.receipt.receiptChecksum,
+      canonicalJson(input.receipt),
+    ]
+  );
+}
+
+export async function prepareRankingRunPublication(
+  client: PoolClient,
+  runId: string,
+  requestedBy: string,
+  replacementNotBefore: string
+): Promise<PreparePublicationResult> {
+  assertIsoTimestamp(replacementNotBefore, 'replacementNotBefore');
+  const current = await lockRankingRun(client, runId);
+  if (current.state !== 'validated') {
+    throw new Error(`Ranking run must be validated before publication, got ${current.state}`);
+  }
+  const policyResult = await client.query<{ policy_hash: string }>(
+    `SELECT policy_hash::text
+       FROM governance_policy_versions
+      WHERE community_id = $1
+        AND effective_at <= NOW()
+      ORDER BY effective_at DESC, created_at DESC
+      LIMIT 1
+      FOR SHARE`,
+    [current.community_id]
+  );
+  const currentPolicyHash = policyResult.rows[0]?.policy_hash;
+  if (!currentPolicyHash) {
+    throw new Error(`No effective policy exists for community ${current.community_id}`);
+  }
+  if (currentPolicyHash === current.policy_hash) {
+    return { publishable: true, currentPolicyHash, replacementRequestId: null };
+  }
+
+  await client.query(
+    `UPDATE ranking_runs
+        SET state = 'superseded',
+            metrics = metrics || $2::jsonb
+      WHERE id = $1`,
+    [
+      runId,
+      canonicalJson({ supersededByPolicyHash: currentPolicyHash }),
+    ]
+  );
+  const replacement = await enqueueRankingRunRequest(client, {
+    idempotencyKey: `replacement:${runId}:${currentPolicyHash}`,
+    communityId: current.community_id,
+    requestKind: 'replacement',
+    requestedBy,
+    notBefore: replacementNotBefore,
+  });
+  return {
+    publishable: false,
+    currentPolicyHash,
+    replacementRequestId: replacement.id,
+  };
+}
+
+export async function reconcilePublishedRankingRun(
+  client: PoolClient,
+  metadata: RankingPublicationMetadata
+): Promise<{ repaired: boolean }> {
+  assertSha256(metadata.policyHash, 'publication policyHash');
+  assertSha256(metadata.configurationHash, 'publication configurationHash');
+  assertSha256(metadata.receiptChecksum, 'publication receiptChecksum');
+  const current = await lockRankingRun(client, metadata.runId);
+  assertPublicationMetadataMatchesRun(metadata, current);
+
+  if (current.state === 'published') {
+    if (current.snapshot_id !== metadata.snapshotId) {
+      throw new Error(
+        `Published run ${metadata.runId} snapshot mismatch: DB ${current.snapshot_id}, Redis ${metadata.snapshotId}`
+      );
+    }
+    return { repaired: false };
+  }
+  if (current.state !== 'validated') {
+    throw new Error(
+      `Cannot reconcile Redis publication for run ${metadata.runId} from state ${current.state}`
+    );
+  }
+
+  await client.query(
+    `UPDATE ranking_runs
+        SET state = 'published',
+            snapshot_id = $2
+      WHERE id = $1`,
+    [metadata.runId, metadata.snapshotId]
+  );
+  await client.query(
+    `INSERT INTO ranking_run_events (
+       run_id, event_type, previous_state, next_state, details
+     ) VALUES ($1, 'redis_publication_reconciled', 'validated', 'published', $2::jsonb)`,
+    [metadata.runId, canonicalJson({ snapshotId: metadata.snapshotId })]
+  );
+  return { repaired: true };
+}
+
+export async function enqueueRankingRunRequest(
+  client: PoolClient,
+  input: EnqueueRankingRequestInput
+): Promise<{ id: string; created: boolean }> {
+  assertIsoTimestamp(input.notBefore, 'notBefore');
+  const inserted = await client.query<{ id: string }>(
+    `INSERT INTO ranking_run_requests (
+       idempotency_key, community_id, request_kind, requested_by, not_before
+     ) VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (idempotency_key) DO NOTHING
+     RETURNING id::text`,
+    [
+      input.idempotencyKey,
+      input.communityId,
+      input.requestKind,
+      input.requestedBy,
+      input.notBefore,
+    ]
+  );
+  if (inserted.rows[0]) {
+    return { id: inserted.rows[0].id, created: true };
+  }
+  const existing = await client.query<{ id: string }>(
+    `SELECT id::text
+       FROM ranking_run_requests
+      WHERE idempotency_key = $1`,
+    [input.idempotencyKey]
+  );
+  const row = existing.rows[0];
+  if (!row) {
+    throw new Error(`Ranking request lost idempotent row for ${input.idempotencyKey}`);
+  }
+  return { id: row.id, created: false };
+}
+
+export async function loadRankingRunInput(
+  client: PoolClient,
+  runId: string
+): Promise<CompressedRankingInput> {
+  const result = await client.query<RankingInputRow>(
+    `SELECT payload, checksum::text, candidate_count,
+            uncompressed_bytes, compressed_bytes
+       FROM ranking_run_inputs
+      WHERE run_id = $1`,
+    [runId]
+  );
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error(`No replay input exists for ranking run ${runId}`);
+  }
+  return {
+    payload: row.payload,
+    checksum: row.checksum,
+    candidateCount: row.candidate_count,
+    uncompressedBytes: Number(row.uncompressed_bytes),
+    compressedBytes: Number(row.compressed_bytes),
+  };
+}
+
+export async function cleanupExpiredRankingData(
+  client: PoolClient,
+  asOf: string
+): Promise<CleanupRankingDataResult> {
+  assertIsoTimestamp(asOf, 'cleanup asOf');
+  const inputs = await client.query<{ run_id: string }>(
+    `DELETE FROM ranking_run_inputs
+      WHERE retained_until <= $1
+      RETURNING run_id::text`,
+    [asOf]
+  );
+  const runs = await client.query<{ id: string }>(
+    `DELETE FROM ranking_runs
+      WHERE retain_until <= $1
+        AND state IN ('published', 'failed', 'superseded', 'rejected')
+      RETURNING id::text`,
+    [asOf]
+  );
+  return {
+    deletedInputs: inputs.rows.length,
+    deletedRuns: runs.rows.length,
+  };
+}
+
+function validateInputEnvelope(value: unknown): asserts value is RankingRunInputEnvelope {
+  if (!isRecord(value)) {
+    throw new Error('Ranking input envelope must be an object');
+  }
+  if (value.schemaVersion !== 1) {
+    throw new Error(`Unsupported ranking input schema version ${String(value.schemaVersion)}`);
+  }
+  const runId = requireNonEmptyString(value, 'runId');
+  const communityId = requireNonEmptyString(value, 'communityId');
+  const policyHash = requireNonEmptyString(value, 'policyHash');
+  const configurationHash = requireNonEmptyString(value, 'configurationHash');
+  const asOf = requireNonEmptyString(value, 'asOf');
+  void runId;
+  void communityId;
+  assertSha256(policyHash, 'ranking input policyHash');
+  assertSha256(configurationHash, 'ranking input configurationHash');
+  assertIsoTimestamp(asOf, 'ranking input asOf');
+  if (!Array.isArray(value.candidates) || value.candidates.some((candidate) => !isRecord(candidate))) {
+    throw new Error('Ranking input candidates must be an array of objects');
+  }
+}
+
+function validateRankedItems(items: readonly RankedSlateItem[]): void {
+  if (items.length > 1000) {
+    throw new Error(`Ranked slate cannot exceed 1000 items, got ${items.length}`);
+  }
+  const identities = new Set<string>();
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    const expectedPosition = index + 1;
+    if (item.position !== expectedPosition) {
+      throw new Error(
+        `Ranked slate positions must be consecutive: expected ${expectedPosition}, got ${item.position}`
+      );
+    }
+    assertIsoTimestamp(item.postCreatedAt, `item ${item.position} postCreatedAt`);
+    if (item.candidateSources.length === 0) {
+      throw new Error(`Ranked slate item ${item.position} has no candidate source`);
+    }
+    if (!Number.isFinite(item.baseScore) || !Number.isFinite(item.finalScore)) {
+      throw new Error(`Ranked slate item ${item.position} has a non-finite score`);
+    }
+    const identity = `${item.postUri}\u0000${item.postCreatedAt}`;
+    if (identities.has(identity)) {
+      throw new Error(`Ranked slate contains duplicate post identity ${item.postUri}`);
+    }
+    identities.add(identity);
+    canonicalJson(item.componentDecomposition);
+    canonicalJson(item.diversityContext);
+  }
+}
+
+async function lockRankingRun(client: PoolClient, runId: string): Promise<RankingRunRow> {
+  const result = await client.query<RankingRunRow>(
+    `SELECT id::text, community_id, policy_version_id::text, policy_hash::text,
+            algorithm_version, configuration_hash::text, code_sha, as_of,
+            state, selected_count, snapshot_id, receipt_checksum::text
+       FROM ranking_runs
+      WHERE id = $1
+      FOR UPDATE`,
+    [runId]
+  );
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error(`Ranking run ${runId} does not exist`);
+  }
+  return row;
+}
+
+function assertReceiptMatchesRun(receipt: RankingReceipt, run: RankingRunRow): void {
+  const mismatches: string[] = [];
+  if (receipt.communityId !== run.community_id) mismatches.push('communityId');
+  if (receipt.policyVersionId !== run.policy_version_id) mismatches.push('policyVersionId');
+  if (receipt.policyHash !== run.policy_hash) mismatches.push('policyHash');
+  if (receipt.algorithmVersion !== run.algorithm_version) mismatches.push('algorithmVersion');
+  if (receipt.configurationHash !== run.configuration_hash) mismatches.push('configurationHash');
+  if (receipt.codeSha !== run.code_sha) mismatches.push('codeSha');
+  if (receipt.asOf !== toIsoTimestamp(run.as_of, 'ranking run as_of')) mismatches.push('asOf');
+  if (mismatches.length > 0) {
+    throw new Error(`Ranking receipt does not match run identity: ${mismatches.join(', ')}`);
+  }
+}
+
+function assertPublicationMetadataMatchesRun(
+  metadata: RankingPublicationMetadata,
+  run: RankingRunRow
+): void {
+  const mismatches: string[] = [];
+  if (metadata.policyHash !== run.policy_hash) mismatches.push('policyHash');
+  if (metadata.configurationHash !== run.configuration_hash) mismatches.push('configurationHash');
+  if (metadata.itemCount !== run.selected_count) mismatches.push('itemCount');
+  if (metadata.receiptChecksum !== run.receipt_checksum) mismatches.push('receiptChecksum');
+  if (mismatches.length > 0) {
+    throw new Error(`Redis publication metadata does not match DB run: ${mismatches.join(', ')}`);
+  }
+}
+
+function sha256Buffer(value: Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function assertIsoTimestamp(value: string, label: string): void {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${label} must be an ISO-8601 timestamp`);
+  }
+}
+
+function toIsoTimestamp(value: Date | string, label: string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${label} must be a valid timestamp`);
+  }
+  return parsed.toISOString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function requireNonEmptyString(value: Record<string, unknown>, key: string): string {
+  const candidate = value[key];
+  if (typeof candidate !== 'string' || candidate.trim().length === 0) {
+    throw new Error(`Ranking input ${key} must be a non-empty string`);
+  }
+  return candidate;
+}

--- a/src/scoring/ranking-run-contracts.ts
+++ b/src/scoring/ranking-run-contracts.ts
@@ -57,6 +57,15 @@ interface RankingItemIdentityRow {
   post_created_at: Date | string;
 }
 
+interface StoredRankingItemRow extends RankingItemIdentityRow {
+  author_did: string;
+  component_decomposition: unknown;
+  candidate_sources: string[];
+  diversity_context: unknown;
+  base_score: number;
+  final_score: number;
+}
+
 export interface CompressedRankingInput {
   payload: Buffer;
   checksum: string;
@@ -289,11 +298,13 @@ export async function persistRankingRunInput(
   }
   const envelope = decodeCompressedRankingInput(compressed);
   assertInputEnvelopeMatchesRun(envelope, current);
-  await client.query(
+  const inserted = await client.query<{ run_id: string }>(
     `INSERT INTO ranking_run_inputs (
        run_id, payload, checksum, candidate_count,
        uncompressed_bytes, compressed_bytes
-     ) VALUES ($1, $2, $3, $4, $5, $6)`,
+     ) VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (run_id) DO NOTHING
+     RETURNING run_id::text`,
     [
       runId,
       compressed.payload,
@@ -303,6 +314,19 @@ export async function persistRankingRunInput(
       compressed.compressedBytes,
     ]
   );
+  if (inserted.rowCount !== 0) {
+    return;
+  }
+  const stored = await loadRankingRunInput(client, runId);
+  const storedEnvelope = decodeCompressedRankingInput(stored);
+  if (
+    stored.checksum !== compressed.checksum
+    || stored.candidateCount !== compressed.candidateCount
+    || stored.uncompressedBytes !== compressed.uncompressedBytes
+    || canonicalJson(storedEnvelope) !== canonicalJson(envelope)
+  ) {
+    throw new Error(`Ranking run ${runId} already has a different replay input`);
+  }
 }
 
 export async function persistRankedSlate(
@@ -317,6 +341,12 @@ export async function persistRankedSlate(
   validateRankedItems(items);
   if (items.length === 0) {
     throw new Error(`Ranking run ${runId} cannot persist an empty published slate`);
+  }
+
+  const existing = await loadStoredRankingItems(client, runId);
+  if (existing.length > 0) {
+    assertStoredSlateMatches(runId, items, existing);
+    return;
   }
 
   const placeholders: string[] = [];
@@ -347,9 +377,12 @@ export async function persistRankedSlate(
        run_id, position, post_uri, post_created_at, author_did,
        component_decomposition, candidate_sources, diversity_context,
        base_score, final_score
-     ) VALUES ${placeholders.join(', ')}`,
+     ) VALUES ${placeholders.join(', ')}
+     ON CONFLICT DO NOTHING`,
     values
   );
+  const stored = await loadStoredRankingItems(client, runId);
+  assertStoredSlateMatches(runId, items, stored);
 }
 
 export async function validateRankingRun(
@@ -464,6 +497,7 @@ export async function prepareRankingRunPublication(
     return { publishable: true, currentPolicyHash, replacementRequestId: null };
   }
 
+  assertRankingRunTransition(current.state, 'superseded');
   await client.query(
     `UPDATE ranking_runs
         SET state = 'superseded'
@@ -514,6 +548,7 @@ export async function reconcilePublishedRankingRun(
     );
   }
 
+  assertRankingRunTransition(current.state, 'published');
   await client.query(
     `UPDATE ranking_runs
         SET state = 'published',
@@ -595,9 +630,12 @@ export async function cleanupExpiredRankingData(
 ): Promise<CleanupRankingDataResult> {
   assertIsoTimestamp(asOf, 'cleanup asOf');
   const inputs = await client.query<{ run_id: string }>(
-    `DELETE FROM ranking_run_inputs
-      WHERE retained_until <= $1
-      RETURNING run_id::text`,
+    `DELETE FROM ranking_run_inputs AS input
+      USING ranking_runs AS run
+      WHERE input.run_id = run.id
+        AND input.retained_until <= $1
+        AND run.state IN ('published', 'failed', 'superseded', 'rejected')
+      RETURNING input.run_id::text`,
     [asOf]
   );
   const runs = await client.query<{ id: string }>(
@@ -611,6 +649,51 @@ export async function cleanupExpiredRankingData(
     deletedInputs: inputs.rows.length,
     deletedRuns: runs.rows.length,
   };
+}
+
+async function loadStoredRankingItems(
+  client: PoolClient,
+  runId: string
+): Promise<StoredRankingItemRow[]> {
+  const result = await client.query<StoredRankingItemRow>(
+    `SELECT position, post_uri, post_created_at, author_did,
+            component_decomposition, candidate_sources, diversity_context,
+            base_score, final_score
+       FROM ranking_run_items
+      WHERE run_id = $1
+      ORDER BY position ASC`,
+    [runId]
+  );
+  return result.rows;
+}
+
+function assertStoredSlateMatches(
+  runId: string,
+  expected: readonly RankedSlateItem[],
+  stored: readonly StoredRankingItemRow[]
+): void {
+  if (stored.length !== expected.length) {
+    throw new Error(
+      `Ranking run ${runId} already has a different slate length: stored ${stored.length}, supplied ${expected.length}`
+    );
+  }
+  for (let index = 0; index < expected.length; index += 1) {
+    const item = expected[index];
+    const row = stored[index];
+    const matches = row.position === item.position
+      && row.post_uri === item.postUri
+      && toIsoTimestamp(row.post_created_at, `ranking item ${row.position} post_created_at`)
+        === toIsoTimestamp(item.postCreatedAt, `ranking item ${item.position} postCreatedAt`)
+      && row.author_did === item.authorDid
+      && canonicalJson(row.component_decomposition) === canonicalJson(item.componentDecomposition)
+      && canonicalJson(row.candidate_sources) === canonicalJson(item.candidateSources)
+      && canonicalJson(row.diversity_context) === canonicalJson(item.diversityContext)
+      && Number(row.base_score) === item.baseScore
+      && Number(row.final_score) === item.finalScore;
+    if (!matches) {
+      throw new Error(`Ranking run ${runId} already has a different slate item at position ${item.position}`);
+    }
+  }
 }
 
 function validateInputEnvelope(value: unknown): asserts value is RankingRunInputEnvelope {

--- a/src/shared/ranking-contracts.ts
+++ b/src/shared/ranking-contracts.ts
@@ -1,0 +1,93 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+export type RankingRunState =
+  | 'requested'
+  | 'running'
+  | 'validated'
+  | 'published'
+  | 'failed'
+  | 'superseded'
+  | 'rejected';
+
+export type CandidateSource =
+  | 'newest'
+  | 'engagement'
+  | 'policy_relevance'
+  | 'previous_snapshot'
+  | 'preliminary_fill';
+
+export interface PolicyProvenanceReference {
+  kind: string;
+  reference: string;
+  observedAt: string;
+}
+
+export interface GovernancePolicyDocument {
+  communityId: string;
+  epochId: number;
+  algorithmVersion: string;
+  weights: Readonly<Record<string, number>>;
+  topicWeights: Readonly<Record<string, number>>;
+  contentRules: JsonObject;
+  effectiveAt: string;
+  provenanceReferences: readonly PolicyProvenanceReference[];
+}
+
+export interface PolicyBundle extends GovernancePolicyDocument {
+  policyVersionId: string;
+  policyHash: string;
+  reconciliationStatus: 'match' | 'incomplete_evidence' | 'conflict_preserved';
+  createdAt: string;
+}
+
+export interface RankingReceipt {
+  schemaVersion: 1;
+  runId: string;
+  communityId: string;
+  policyVersionId: string;
+  policyHash: string;
+  algorithmVersion: string;
+  configurationHash: string;
+  codeSha: string;
+  asOf: string;
+  itemCount: number;
+  inputChecksum: string;
+  itemOrderChecksum: string;
+  receiptChecksum: string;
+}
+
+export interface RankedSlateItem {
+  position: number;
+  postUri: string;
+  postCreatedAt: string;
+  authorDid: string;
+  componentDecomposition: JsonObject;
+  candidateSources: readonly CandidateSource[];
+  diversityContext: JsonObject;
+  baseScore: number;
+  finalScore: number;
+}
+
+export interface RankingRunInputEnvelope {
+  schemaVersion: 1;
+  runId: string;
+  communityId: string;
+  policyHash: string;
+  configurationHash: string;
+  asOf: string;
+  candidates: readonly JsonObject[];
+}
+
+export interface RankingPublicationMetadata {
+  runId: string;
+  policyHash: string;
+  configurationHash: string;
+  itemCount: number;
+  snapshotId: string;
+  receiptChecksum: string;
+}

--- a/tests/governance-policy-version.test.ts
+++ b/tests/governance-policy-version.test.ts
@@ -31,6 +31,83 @@ function policyDocument(overrides: Partial<GovernancePolicyDocument>): Governanc
   };
 }
 
+const COMPLETE_WEIGHT_ROWS = [
+  { component_key: 'bridging', weight: '0.2' },
+  { component_key: 'engagement', weight: '0.2' },
+  { component_key: 'recency', weight: '0.2' },
+  { component_key: 'relevance', weight: '0.2' },
+  { component_key: 'sourceDiversity', weight: '0.2' },
+];
+
+function activeEpoch(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: 7,
+    recency_weight: 0.2,
+    engagement_weight: 0.2,
+    bridging_weight: 0.2,
+    source_diversity_weight: 0.2,
+    relevance_weight: 0.2,
+    topic_weights: { science: 0.7 },
+    content_rules: { include_keywords: [], exclude_keywords: ['spam'] },
+    created_at: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function policyAudit(details: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: 99,
+    action: 'weights_changed',
+    details,
+    created_at: '2026-07-01T00:00:01.000Z',
+  };
+}
+
+function materializationMock(options: {
+  epochRows?: readonly Record<string, unknown>[];
+  weightRows?: readonly Record<string, unknown>[];
+  auditRows?: readonly Record<string, unknown>[];
+  policyInsertRows?: readonly Record<string, unknown>[];
+  existingRows?: readonly Record<string, unknown>[];
+}): ReturnType<typeof vi.fn> {
+  return vi.fn(async (sql: string, params?: readonly unknown[]) => {
+    if (sql.includes('FROM governance_epochs')) {
+      return { rows: options.epochRows ?? [activeEpoch({})] };
+    }
+    if (sql.includes('FROM governance_epoch_weights')) {
+      return { rows: options.weightRows ?? COMPLETE_WEIGHT_ROWS };
+    }
+    if (sql.includes('FROM governance_audit_log')) {
+      return { rows: options.auditRows ?? [policyAudit({
+        new_weights: {
+          recency: 0.2,
+          engagement: 0.2,
+          bridging: 0.2,
+          sourceDiversity: 0.2,
+          relevance: 0.2,
+        },
+      })] };
+    }
+    if (sql.includes('INSERT INTO governance_policy_versions')) {
+      return {
+        rows: options.policyInsertRows ?? [{
+          id: '00000000-0000-4000-8000-000000000007',
+          policy_hash: params?.[8],
+          reconciliation_status: params?.[9],
+          created_at: '2026-07-11T20:00:00.000Z',
+        }],
+      };
+    }
+    if (sql.includes('FROM governance_policy_versions')) {
+      return { rows: options.existingRows ?? [] };
+    }
+    if (sql.includes('INSERT INTO governance_policy_reconciliation_events')) {
+      return { rows: [] };
+    }
+    throw new Error(`Unexpected query: ${sql}`);
+  });
+}
+
 describe('governance policy canonicalization', () => {
   it('produces the same hash regardless of object insertion order', () => {
     const first = policyDocument({
@@ -69,8 +146,10 @@ describe('governance policy canonicalization', () => {
 describe('active policy materialization', () => {
   it('materializes serving long-table weights and appends reconciliation evidence', async () => {
     const queries: string[] = [];
-    const query = vi.fn(async (sql: string) => {
+    const calls: Array<{ sql: string; params: readonly unknown[] }> = [];
+    const query = vi.fn(async (sql: string, params: readonly unknown[] = []) => {
       queries.push(sql);
+      calls.push({ sql, params });
       if (sql.includes('FROM governance_epochs')) {
         return {
           rows: [{
@@ -119,7 +198,7 @@ describe('active policy materialization', () => {
         return {
           rows: [{
             id: '00000000-0000-4000-8000-000000000007',
-            policy_hash: 'a'.repeat(64),
+            policy_hash: params[8],
             reconciliation_status: 'match',
             created_at: '2026-07-11T20:00:00.000Z',
           }],
@@ -154,6 +233,118 @@ describe('active policy materialization', () => {
     expect(result.evidenceHash).toMatch(/^[0-9a-f]{64}$/);
     expect(queries.some((sql) => sql.includes('governance_policy_reconciliation_events'))).toBe(true);
     expect(queries.some((sql) => /^\s*UPDATE\s+governance_audit_log/i.test(sql))).toBe(false);
+
+    const policyInsert = calls.find((call) => call.sql.includes('INSERT INTO governance_policy_versions'));
+    expect(policyInsert?.params).toHaveLength(10);
+    expect(policyInsert?.params.slice(0, 3)).toEqual(['community-gov', 7, 'corgi-ranking-v2']);
+    expect(JSON.parse(String(policyInsert?.params[3]))).toEqual(result.bundle.weights);
+    expect(JSON.parse(String(policyInsert?.params[4]))).toEqual({ science: 0.7 });
+    expect(JSON.parse(String(policyInsert?.params[5]))).toEqual({
+      exclude_keywords: ['spam'],
+      include_keywords: [],
+    });
+    expect(policyInsert?.params[6]).toBe('2026-07-11T20:00:00.000Z');
+    expect(JSON.parse(String(policyInsert?.params[7]))).toHaveLength(3);
+    expect(policyInsert?.params[8]).toMatch(/^[0-9a-f]{64}$/);
+    expect(policyInsert?.params[9]).toBe('match');
+
+    const reconciliationInsert = calls.find(
+      (call) => call.sql.includes('INSERT INTO governance_policy_reconciliation_events')
+    );
+    expect(reconciliationInsert?.params).toHaveLength(10);
+    expect(reconciliationInsert?.params.slice(0, 4)).toEqual([
+      '00000000-0000-4000-8000-000000000007',
+      'community-gov',
+      7,
+      'match',
+    ]);
+    expect(JSON.parse(String(reconciliationInsert?.params[4]))).toEqual(result.bundle.weights);
+    expect(JSON.parse(String(reconciliationInsert?.params[5]))).toEqual(result.bundle.weights);
+    expect(JSON.parse(String(reconciliationInsert?.params[6]))).toEqual(result.bundle.weights);
+    expect(reconciliationInsert?.params[7]).toEqual([99]);
+    expect(reconciliationInsert?.params[8]).toBe(result.evidenceHash);
+    expect(JSON.parse(String(reconciliationInsert?.params[9]))).toEqual({
+      policyHash: result.bundle.policyHash,
+    });
+  });
+
+  it.each([
+    ['no policy audit rows', []],
+    ['a null audit weight payload', [policyAudit({ new_weights: null })]],
+  ] as const)('preserves incomplete evidence for %s', async (_label, auditRows) => {
+    const query = materializationMock({ auditRows });
+    const result = await materializeActivePolicyVersion(asClient(query), {
+      communityId: 'community-gov',
+      algorithmVersion: 'corgi-ranking-v2',
+      effectiveAt: '2026-07-11T20:00:00.000Z',
+      provenanceReferences: [],
+    });
+    expect(result.bundle.reconciliationStatus).toBe('incomplete_evidence');
+    const policyInsert = query.mock.calls.find(
+      ([sql]: [string]) => sql.includes('INSERT INTO governance_policy_versions')
+    );
+    expect(policyInsert?.[1]?.[9]).toBe('incomplete_evidence');
+  });
+
+  it.each([
+    [
+      'wide epoch weights differ',
+      activeEpoch({ recency_weight: 0.3, engagement_weight: 0.1 }),
+      [policyAudit({ new_weights: {
+        recency: 0.2, engagement: 0.2, bridging: 0.2, sourceDiversity: 0.2, relevance: 0.2,
+      } })],
+    ],
+    [
+      'audit weights differ',
+      activeEpoch({}),
+      [policyAudit({ new_weights: {
+        recency: 0.3, engagement: 0.1, bridging: 0.2, sourceDiversity: 0.2, relevance: 0.2,
+      } })],
+    ],
+  ] as const)('preserves a conflict when %s', async (_label, epoch, auditRows) => {
+    const query = materializationMock({ epochRows: [epoch], auditRows });
+    const result = await materializeActivePolicyVersion(asClient(query), {
+      communityId: 'community-gov',
+      algorithmVersion: 'corgi-ranking-v2',
+      effectiveAt: '2026-07-11T20:00:00.000Z',
+      provenanceReferences: [],
+    });
+    expect(result.bundle.reconciliationStatus).toBe('conflict_preserved');
+  });
+
+  it('loads the existing immutable policy on an idempotent rerun and still records evidence', async () => {
+    const query = materializationMock({
+      policyInsertRows: [],
+      existingRows: [{
+        id: '00000000-0000-4000-8000-000000000007',
+        policy_hash: 'a'.repeat(64),
+        reconciliation_status: 'match',
+        created_at: '2026-07-11T20:00:00.000Z',
+      }],
+    });
+    const result = await materializeActivePolicyVersion(asClient(query), {
+      communityId: 'community-gov',
+      algorithmVersion: 'corgi-ranking-v2',
+      effectiveAt: '2026-07-11T20:00:00.000Z',
+      provenanceReferences: [],
+    });
+    expect(result.created).toBe(false);
+    expect(query.mock.calls.some(([sql]: [string]) => sql.includes('FROM governance_policy_versions')))
+      .toBe(true);
+    const evidenceInsert = query.mock.calls.find(
+      ([sql]: [string]) => sql.includes('INSERT INTO governance_policy_reconciliation_events')
+    );
+    expect(evidenceInsert?.[0]).toContain('ON CONFLICT (policy_version_id, evidence_hash) DO NOTHING');
+  });
+
+  it('rejects materialization when no active epoch exists', async () => {
+    const query = materializationMock({ epochRows: [] });
+    await expect(materializeActivePolicyVersion(asClient(query), {
+      communityId: 'community-gov',
+      algorithmVersion: 'corgi-ranking-v2',
+      effectiveAt: '2026-07-11T20:00:00.000Z',
+      provenanceReferences: [],
+    })).rejects.toThrow('no active governance epoch');
   });
 
   it('fails closed when the active epoch lacks serving long-table weights', async () => {

--- a/tests/governance-policy-version.test.ts
+++ b/tests/governance-policy-version.test.ts
@@ -1,0 +1,186 @@
+import type { PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  canonicalJson,
+  computePolicyHash,
+  materializeActivePolicyVersion,
+} from '../src/governance/policy-version.js';
+import type { GovernancePolicyDocument } from '../src/shared/ranking-contracts.js';
+
+function asClient(query: ReturnType<typeof vi.fn>): PoolClient {
+  return { query } as unknown as PoolClient;
+}
+
+function policyDocument(overrides: Partial<GovernancePolicyDocument>): GovernancePolicyDocument {
+  return {
+    communityId: 'community-gov',
+    epochId: 7,
+    algorithmVersion: 'corgi-ranking-v2',
+    weights: {
+      recency: 0.2,
+      engagement: 0.2,
+      bridging: 0.2,
+      sourceDiversity: 0.2,
+      relevance: 0.2,
+    },
+    topicWeights: { science: 0.7 },
+    contentRules: { include_keywords: [], exclude_keywords: ['spam'] },
+    effectiveAt: '2026-07-11T20:00:00.000Z',
+    provenanceReferences: [],
+    ...overrides,
+  };
+}
+
+describe('governance policy canonicalization', () => {
+  it('produces the same hash regardless of object insertion order', () => {
+    const first = policyDocument({
+      weights: { recency: 0.2, engagement: 0.2, bridging: 0.2, sourceDiversity: 0.2, relevance: 0.2 },
+      contentRules: { include_keywords: ['corgi'], exclude_keywords: ['spam'] },
+    });
+    const second = policyDocument({
+      weights: { relevance: 0.2, sourceDiversity: 0.2, bridging: 0.2, engagement: 0.2, recency: 0.2 },
+      contentRules: { exclude_keywords: ['spam'], include_keywords: ['corgi'] },
+    });
+
+    expect(canonicalJson(first)).toBe(canonicalJson(second));
+    expect(computePolicyHash(first)).toBe(computePolicyHash(second));
+  });
+
+  it('preserves array order because it is policy-significant', () => {
+    const first = policyDocument({ contentRules: { include_keywords: ['a', 'b'] } });
+    const second = policyDocument({ contentRules: { include_keywords: ['b', 'a'] } });
+    expect(computePolicyHash(first)).not.toBe(computePolicyHash(second));
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects non-finite numeric policy values: %s',
+    (value) => {
+      expect(() => canonicalJson({ weight: value })).toThrow('non-finite');
+    }
+  );
+
+  it('rejects cyclic policy objects', () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => canonicalJson(cyclic)).toThrow('cyclic');
+  });
+});
+
+describe('active policy materialization', () => {
+  it('materializes serving long-table weights and appends reconciliation evidence', async () => {
+    const queries: string[] = [];
+    const query = vi.fn(async (sql: string) => {
+      queries.push(sql);
+      if (sql.includes('FROM governance_epochs')) {
+        return {
+          rows: [{
+            id: 7,
+            recency_weight: 0.2,
+            engagement_weight: 0.2,
+            bridging_weight: 0.2,
+            source_diversity_weight: 0.2,
+            relevance_weight: 0.2,
+            topic_weights: { science: 0.7 },
+            content_rules: { include_keywords: [], exclude_keywords: ['spam'] },
+            created_at: '2026-07-01T00:00:00.000Z',
+          }],
+        };
+      }
+      if (sql.includes('FROM governance_epoch_weights')) {
+        return {
+          rows: [
+            { component_key: 'bridging', weight: '0.2' },
+            { component_key: 'engagement', weight: '0.2' },
+            { component_key: 'recency', weight: '0.2' },
+            { component_key: 'relevance', weight: '0.2' },
+            { component_key: 'sourceDiversity', weight: '0.2' },
+          ],
+        };
+      }
+      if (sql.includes('FROM governance_audit_log')) {
+        return {
+          rows: [{
+            id: 99,
+            action: 'weights_changed',
+            details: {
+              new_weights: {
+                recency: 0.2,
+                engagement: 0.2,
+                bridging: 0.2,
+                sourceDiversity: 0.2,
+                relevance: 0.2,
+              },
+            },
+            created_at: '2026-07-01T00:00:01.000Z',
+          }],
+        };
+      }
+      if (sql.includes('INSERT INTO governance_policy_versions')) {
+        return {
+          rows: [{
+            id: '00000000-0000-4000-8000-000000000007',
+            policy_hash: 'a'.repeat(64),
+            reconciliation_status: 'match',
+            created_at: '2026-07-11T20:00:00.000Z',
+          }],
+        };
+      }
+      if (sql.includes('INSERT INTO governance_policy_reconciliation_events')) {
+        return { rows: [] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    const result = await materializeActivePolicyVersion(asClient(query), {
+      communityId: 'community-gov',
+      algorithmVersion: 'corgi-ranking-v2',
+      effectiveAt: '2026-07-11T20:00:00.000Z',
+      provenanceReferences: [{
+        kind: 'migration',
+        reference: 'PROJ-1758',
+        observedAt: '2026-07-11T20:00:00.000Z',
+      }],
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.bundle.weights).toEqual({
+      bridging: 0.2,
+      engagement: 0.2,
+      recency: 0.2,
+      relevance: 0.2,
+      sourceDiversity: 0.2,
+    });
+    expect(result.bundle.reconciliationStatus).toBe('match');
+    expect(result.evidenceHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(queries.some((sql) => sql.includes('governance_policy_reconciliation_events'))).toBe(true);
+    expect(queries.some((sql) => /^\s*UPDATE\s+governance_audit_log/i.test(sql))).toBe(false);
+  });
+
+  it('fails closed when the active epoch lacks serving long-table weights', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM governance_epochs')) {
+        return {
+          rows: [{
+            id: 7,
+            recency_weight: 0.2,
+            engagement_weight: 0.2,
+            bridging_weight: 0.2,
+            source_diversity_weight: 0.2,
+            relevance_weight: 0.2,
+            topic_weights: {},
+            content_rules: {},
+            created_at: '2026-07-01T00:00:00.000Z',
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await expect(materializeActivePolicyVersion(asClient(query), {
+      communityId: 'community-gov',
+      algorithmVersion: 'corgi-ranking-v2',
+      effectiveAt: '2026-07-11T20:00:00.000Z',
+      provenanceReferences: [],
+    })).rejects.toThrow('serving weight rows are missing');
+  });
+});

--- a/tests/governance-policy-version.test.ts
+++ b/tests/governance-policy-version.test.ts
@@ -183,4 +183,79 @@ describe('active policy materialization', () => {
       provenanceReferences: [],
     })).rejects.toThrow('serving weight rows are missing');
   });
+
+  it('fails closed when serving long-table weights are partial', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM governance_epochs')) {
+        return {
+          rows: [{
+            id: 7,
+            recency_weight: 0.2,
+            engagement_weight: 0.2,
+            bridging_weight: 0.2,
+            source_diversity_weight: 0.2,
+            relevance_weight: 0.2,
+            topic_weights: {},
+            content_rules: {},
+            created_at: '2026-07-01T00:00:00.000Z',
+          }],
+        };
+      }
+      if (sql.includes('FROM governance_epoch_weights')) {
+        return {
+          rows: [
+            { component_key: 'recency', weight: '0.5' },
+            { component_key: 'engagement', weight: '0.5' },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await expect(materializeActivePolicyVersion(asClient(query), {
+      communityId: 'community-gov',
+      algorithmVersion: 'corgi-ranking-v2',
+      effectiveAt: '2026-07-11T20:00:00.000Z',
+      provenanceReferences: [],
+    })).rejects.toThrow('serving weight keys do not match registry');
+  });
+
+  it('fails closed when serving weights do not sum to one', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM governance_epochs')) {
+        return {
+          rows: [{
+            id: 7,
+            recency_weight: 0.2,
+            engagement_weight: 0.2,
+            bridging_weight: 0.2,
+            source_diversity_weight: 0.2,
+            relevance_weight: 0.2,
+            topic_weights: {},
+            content_rules: {},
+            created_at: '2026-07-01T00:00:00.000Z',
+          }],
+        };
+      }
+      if (sql.includes('FROM governance_epoch_weights')) {
+        return {
+          rows: [
+            { component_key: 'bridging', weight: '0.1' },
+            { component_key: 'engagement', weight: '0.1' },
+            { component_key: 'recency', weight: '0.1' },
+            { component_key: 'relevance', weight: '0.1' },
+            { component_key: 'sourceDiversity', weight: '0.1' },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await expect(materializeActivePolicyVersion(asClient(query), {
+      communityId: 'community-gov',
+      algorithmVersion: 'corgi-ranking-v2',
+      effectiveAt: '2026-07-11T20:00:00.000Z',
+      provenanceReferences: [],
+    })).rejects.toThrow('serving weights total 0.5, expected 1');
+  });
 });

--- a/tests/harness/trustworthy-corgi-contracts.sim.ts
+++ b/tests/harness/trustworthy-corgi-contracts.sim.ts
@@ -204,6 +204,21 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
         snapshotId: 'snapshot-integration-1',
         receiptChecksum: receipt.receiptChecksum,
       })).resolves.toEqual({ repaired: true });
+      await client.query('SAVEPOINT late_item');
+      await expect(client.query(
+        `INSERT INTO ranking_run_items (
+           run_id, position, post_uri, post_created_at, author_did,
+           component_decomposition, candidate_sources, diversity_context,
+           base_score, final_score
+         ) VALUES ($1, 2, $2, $3, $4, '{}'::jsonb, ARRAY['newest'], '{}'::jsonb, 0.1, 0.1)`,
+        [
+          RUN_ID,
+          'at://did:plc:author/app.bsky.feed.post/late',
+          '2026-07-11T19:58:00.000Z',
+          'did:plc:author',
+        ]
+      )).rejects.toThrow('can only be inserted while ranking run');
+      await client.query('ROLLBACK TO SAVEPOINT late_item');
       await client.query('COMMIT');
 
       const policyCount = await db.query<{ count: number }>(
@@ -258,6 +273,12 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
         codeSha: CODE_SHA,
         asOf: AS_OF,
       });
+      await transitionRankingRun(client, RUN_ID, 'running', null);
+      await client.query('SAVEPOINT invalid_validation');
+      await expect(
+        client.query("UPDATE ranking_runs SET state = 'validated' WHERE id = $1", [RUN_ID])
+      ).rejects.toThrow('must select at least one item');
+      await client.query('ROLLBACK TO SAVEPOINT invalid_validation');
       await client.query('SAVEPOINT invalid_transition');
       await expect(
         client.query("UPDATE ranking_runs SET state = 'published' WHERE id = $1", [RUN_ID])

--- a/tests/harness/trustworthy-corgi-contracts.sim.ts
+++ b/tests/harness/trustworthy-corgi-contracts.sim.ts
@@ -3,6 +3,7 @@ import { db } from '../../src/db/client.js';
 import { materializeActivePolicyVersion } from '../../src/governance/policy-version.js';
 import {
   buildRankingReceipt,
+  cleanupExpiredRankingData,
   createCompressedRankingInput,
   createRankingRun,
   persistRankedSlate,
@@ -18,7 +19,7 @@ import { insertActiveEpoch, resetHarnessData } from './helpers.js';
 const RUN_ID = '00000000-0000-4000-8000-000000001758';
 const CONFIGURATION_HASH = 'b'.repeat(64);
 const CODE_SHA = 'c'.repeat(40);
-const AS_OF = '2026-07-11T20:00:00.000Z';
+const AS_OF = new Date(Date.now() - 60_000).toISOString();
 
 async function seedGovernedPolicyEvidence(): Promise<number> {
   const epochId = await insertActiveEpoch('Trustworthy Corgi integration epoch');
@@ -143,6 +144,8 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
       await client.query('ROLLBACK TO SAVEPOINT mismatched_input');
       await persistRankingRunInput(client, RUN_ID, compressed);
       await persistRankedSlate(client, RUN_ID, items);
+      await persistRankingRunInput(client, RUN_ID, compressed);
+      await persistRankedSlate(client, RUN_ID, items);
 
       const receipt = buildRankingReceipt({
         runId: RUN_ID,
@@ -237,6 +240,14 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
           WHERE id = $1`,
         [RUN_ID]
       );
+      const inputCount = await db.query<{ count: number }>(
+        'SELECT COUNT(*)::int AS count FROM ranking_run_inputs WHERE run_id = $1',
+        [RUN_ID]
+      );
+      const itemCount = await db.query<{ count: number }>(
+        'SELECT COUNT(*)::int AS count FROM ranking_run_items WHERE run_id = $1',
+        [RUN_ID]
+      );
       expect(policyCount.rows[0].count).toBe(1);
       expect(reconciliationCount.rows[0].count).toBe(1);
       expect(run.rows[0]).toEqual({
@@ -244,6 +255,8 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
         snapshot_id: 'snapshot-integration-1',
         receipt_checksum: receipt.receiptChecksum,
       });
+      expect(inputCount.rows[0].count).toBe(1);
+      expect(itemCount.rows[0].count).toBe(1);
     } catch (error: unknown) {
       await client.query('ROLLBACK');
       throw error;
@@ -376,10 +389,20 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
          VALUES ('weights_changed', $1, $2::jsonb)`,
         [epochId, JSON.stringify({ reason: 'stale-policy-regression' })]
       );
+      const cutoffResult = await client.query<{ cutoff: Date | string }>(
+        'SELECT NOW() AS cutoff'
+      );
+      const cutoff = new Date(cutoffResult.rows[0].cutoff).toISOString();
       const replacementPolicy = await materializeActivePolicyVersion(client, {
         communityId: 'community-gov',
         algorithmVersion: 'corgi-ranking-v2',
-        effectiveAt: '2026-07-11T21:00:00.000Z',
+        effectiveAt: cutoff,
+        provenanceReferences: [],
+      });
+      await materializeActivePolicyVersion(client, {
+        communityId: 'community-gov',
+        algorithmVersion: 'corgi-ranking-v2',
+        effectiveAt: new Date(new Date(cutoff).getTime() + 1).toISOString(),
         provenanceReferences: [],
       });
 
@@ -387,7 +410,7 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
         client,
         RUN_ID,
         'integration-test',
-        '2026-07-11T21:00:01.000Z'
+        new Date(new Date(cutoff).getTime() + 2).toISOString()
       );
       expect(result).toEqual({
         publishable: false,
@@ -463,14 +486,74 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
         [RUN_ID]
       );
       await transitionRankingRun(client, RUN_ID, 'failed', { reason: 'retention-test' });
-      const deleted = await client.query<{ id: string }>(
-        `DELETE FROM ranking_runs
-          WHERE id = $1
-          RETURNING id::text`,
+      const deleted = await cleanupExpiredRankingData(client, new Date().toISOString());
+      expect(deleted).toEqual({ deletedInputs: 0, deletedRuns: 1 });
+      const events = await client.query<{ count: number }>(
+        'SELECT COUNT(*)::int AS count FROM ranking_run_events WHERE run_id = $1',
         [RUN_ID]
       );
-      expect(deleted.rows).toEqual([{ id: RUN_ID }]);
+      expect(events.rows[0].count).toBe(0);
       await client.query('COMMIT');
+    } catch (error: unknown) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  });
+
+  it('retains expired replay input while its ranking run is active', async () => {
+    await seedGovernedPolicyEvidence();
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      const materialized = await materializeActivePolicyVersion(client, {
+        communityId: 'community-gov',
+        algorithmVersion: 'corgi-ranking-v2',
+        effectiveAt: AS_OF,
+        provenanceReferences: [],
+      });
+      await createRankingRun(client, {
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyVersionId: materialized.bundle.policyVersionId,
+        policyHash: materialized.bundle.policyHash,
+        algorithmVersion: materialized.bundle.algorithmVersion,
+        configurationHash: CONFIGURATION_HASH,
+        codeSha: CODE_SHA,
+        asOf: AS_OF,
+      });
+      await transitionRankingRun(client, RUN_ID, 'running', null);
+      const compressed = createCompressedRankingInput({
+        schemaVersion: 1,
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyHash: materialized.bundle.policyHash,
+        configurationHash: CONFIGURATION_HASH,
+        asOf: AS_OF,
+        candidates: [],
+      });
+      await client.query(
+        `INSERT INTO ranking_run_inputs (
+           run_id, payload, checksum, candidate_count,
+           uncompressed_bytes, compressed_bytes, retained_until
+         ) VALUES ($1, $2, $3, $4, $5, $6, NOW() - INTERVAL '1 minute')`,
+        [
+          RUN_ID,
+          compressed.payload,
+          compressed.checksum,
+          compressed.candidateCount,
+          compressed.uncompressedBytes,
+          compressed.compressedBytes,
+        ]
+      );
+
+      await expect(cleanupExpiredRankingData(client, new Date().toISOString()))
+        .resolves.toEqual({ deletedInputs: 0, deletedRuns: 0 });
+      await transitionRankingRun(client, RUN_ID, 'failed', { reason: 'retention-test' });
+      await expect(cleanupExpiredRankingData(client, new Date().toISOString()))
+        .resolves.toEqual({ deletedInputs: 1, deletedRuns: 0 });
+      await client.query('ROLLBACK');
     } catch (error: unknown) {
       await client.query('ROLLBACK');
       throw error;

--- a/tests/harness/trustworthy-corgi-contracts.sim.ts
+++ b/tests/harness/trustworthy-corgi-contracts.sim.ts
@@ -134,6 +134,13 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
       };
       const compressed = createCompressedRankingInput(inputEnvelope);
       const items = [slateItem()];
+      await client.query('SAVEPOINT mismatched_input');
+      await expect(persistRankingRunInput(
+        client,
+        RUN_ID,
+        createCompressedRankingInput({ ...inputEnvelope, communityId: 'wrong-community' })
+      )).rejects.toThrow('Ranking input does not match run identity: communityId');
+      await client.query('ROLLBACK TO SAVEPOINT mismatched_input');
       await persistRankingRunInput(client, RUN_ID, compressed);
       await persistRankedSlate(client, RUN_ID, items);
 
@@ -149,6 +156,31 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
         inputChecksum: compressed.checksum,
         items,
       });
+      const mismatchedReceipt = buildRankingReceipt({
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyVersionId: materialized.bundle.policyVersionId,
+        policyHash: materialized.bundle.policyHash,
+        algorithmVersion: materialized.bundle.algorithmVersion,
+        configurationHash: CONFIGURATION_HASH,
+        codeSha: CODE_SHA,
+        asOf: AS_OF,
+        inputChecksum: compressed.checksum,
+        items: [{
+          ...slateItem(),
+          postUri: 'at://did:plc:author/app.bsky.feed.post/different',
+        }],
+      });
+      await client.query('SAVEPOINT mismatched_receipt');
+      await expect(validateRankingRun(client, {
+        runId: RUN_ID,
+        receipt: mismatchedReceipt,
+        candidateCount: 1,
+        exclusionCount: 0,
+        timings: { totalMs: 42 },
+        metrics: { replayDeterministic: true },
+      })).rejects.toThrow('item order checksum does not match stored slate');
+      await client.query('ROLLBACK TO SAVEPOINT mismatched_receipt');
       await validateRankingRun(client, {
         runId: RUN_ID,
         receipt,
@@ -241,6 +273,142 @@ describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
       ).rejects.toThrow('append-only and immutable');
       await client.query('ROLLBACK TO SAVEPOINT immutable_policy');
       await client.query('ROLLBACK');
+    } finally {
+      client.release();
+    }
+  });
+
+  it('supersedes a validated run and queues a replacement when policy changes', async () => {
+    const epochId = await seedGovernedPolicyEvidence();
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      const initialPolicy = await materializeActivePolicyVersion(client, {
+        communityId: 'community-gov',
+        algorithmVersion: 'corgi-ranking-v2',
+        effectiveAt: AS_OF,
+        provenanceReferences: [],
+      });
+      await createRankingRun(client, {
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyVersionId: initialPolicy.bundle.policyVersionId,
+        policyHash: initialPolicy.bundle.policyHash,
+        algorithmVersion: initialPolicy.bundle.algorithmVersion,
+        configurationHash: CONFIGURATION_HASH,
+        codeSha: CODE_SHA,
+        asOf: AS_OF,
+      });
+      await transitionRankingRun(client, RUN_ID, 'running', null);
+
+      const inputEnvelope: RankingRunInputEnvelope = {
+        schemaVersion: 1,
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyHash: initialPolicy.bundle.policyHash,
+        configurationHash: CONFIGURATION_HASH,
+        asOf: AS_OF,
+        candidates: [{
+          uri: 'at://did:plc:author/app.bsky.feed.post/1',
+          eligible: true,
+          candidateSources: ['newest'],
+          features: { recency: 1 },
+        }],
+      };
+      const compressed = createCompressedRankingInput(inputEnvelope);
+      const items = [slateItem()];
+      await persistRankingRunInput(client, RUN_ID, compressed);
+      await persistRankedSlate(client, RUN_ID, items);
+      const receipt = buildRankingReceipt({
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyVersionId: initialPolicy.bundle.policyVersionId,
+        policyHash: initialPolicy.bundle.policyHash,
+        algorithmVersion: initialPolicy.bundle.algorithmVersion,
+        configurationHash: CONFIGURATION_HASH,
+        codeSha: CODE_SHA,
+        asOf: AS_OF,
+        inputChecksum: compressed.checksum,
+        items,
+      });
+      await validateRankingRun(client, {
+        runId: RUN_ID,
+        receipt,
+        candidateCount: 1,
+        exclusionCount: 0,
+        timings: { totalMs: 42 },
+        metrics: { replayDeterministic: true },
+      });
+
+      await client.query(
+        `UPDATE governance_epoch_weights
+            SET weight = CASE component_key
+              WHEN 'recency' THEN 0.3
+              WHEN 'engagement' THEN 0.1
+              ELSE weight
+            END
+          WHERE epoch_id = $1`,
+        [epochId]
+      );
+      await client.query(
+        `INSERT INTO governance_audit_log (action, epoch_id, details)
+         VALUES ('weights_changed', $1, $2::jsonb)`,
+        [epochId, JSON.stringify({ reason: 'stale-policy-regression' })]
+      );
+      const replacementPolicy = await materializeActivePolicyVersion(client, {
+        communityId: 'community-gov',
+        algorithmVersion: 'corgi-ranking-v2',
+        effectiveAt: '2026-07-11T21:00:00.000Z',
+        provenanceReferences: [],
+      });
+
+      const result = await prepareRankingRunPublication(
+        client,
+        RUN_ID,
+        'integration-test',
+        '2026-07-11T21:00:01.000Z'
+      );
+      expect(result).toEqual({
+        publishable: false,
+        currentPolicyHash: replacementPolicy.bundle.policyHash,
+        replacementRequestId: expect.any(String),
+      });
+      const run = await client.query<{ state: string; metrics: Record<string, unknown> }>(
+        'SELECT state, metrics FROM ranking_runs WHERE id = $1',
+        [RUN_ID]
+      );
+      expect(run.rows[0]).toEqual({
+        state: 'superseded',
+        metrics: { replayDeterministic: true },
+      });
+      const replacement = await client.query<{
+        community_id: string;
+        request_kind: string;
+        state: string;
+      }>(
+        `SELECT community_id, request_kind, state
+           FROM ranking_run_requests
+          WHERE id = $1`,
+        [result.replacementRequestId]
+      );
+      expect(replacement.rows[0]).toEqual({
+        community_id: 'community-gov',
+        request_kind: 'replacement',
+        state: 'pending',
+      });
+      const event = await client.query<{ details: Record<string, unknown> }>(
+        `SELECT details
+           FROM ranking_run_events
+          WHERE run_id = $1 AND event_type = 'stale_policy_detected'`,
+        [RUN_ID]
+      );
+      expect(event.rows[0]?.details).toEqual({
+        supersededByPolicyHash: replacementPolicy.bundle.policyHash,
+      });
+      await client.query('ROLLBACK');
+    } catch (error: unknown) {
+      await client.query('ROLLBACK');
+      throw error;
     } finally {
       client.release();
     }

--- a/tests/harness/trustworthy-corgi-contracts.sim.ts
+++ b/tests/harness/trustworthy-corgi-contracts.sim.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { db } from '../../src/db/client.js';
+import { materializeActivePolicyVersion } from '../../src/governance/policy-version.js';
+import {
+  buildRankingReceipt,
+  createCompressedRankingInput,
+  createRankingRun,
+  persistRankedSlate,
+  persistRankingRunInput,
+  prepareRankingRunPublication,
+  reconcilePublishedRankingRun,
+  transitionRankingRun,
+  validateRankingRun,
+} from '../../src/scoring/ranking-run-contracts.js';
+import type { RankedSlateItem, RankingRunInputEnvelope } from '../../src/shared/ranking-contracts.js';
+import { insertActiveEpoch, resetHarnessData } from './helpers.js';
+
+const RUN_ID = '00000000-0000-4000-8000-000000001758';
+const CONFIGURATION_HASH = 'b'.repeat(64);
+const CODE_SHA = 'c'.repeat(40);
+const AS_OF = '2026-07-11T20:00:00.000Z';
+
+async function seedGovernedPolicyEvidence(): Promise<number> {
+  const epochId = await insertActiveEpoch('Trustworthy Corgi integration epoch');
+  const weights = {
+    recency: 0.2,
+    engagement: 0.2,
+    bridging: 0.2,
+    sourceDiversity: 0.2,
+    relevance: 0.2,
+  };
+  for (const [componentKey, weight] of Object.entries(weights)) {
+    await db.query(
+      `INSERT INTO governance_epoch_weights (epoch_id, component_key, weight)
+       VALUES ($1, $2, $3)`,
+      [epochId, componentKey, weight]
+    );
+  }
+  await db.query(
+    `INSERT INTO governance_audit_log (action, epoch_id, details)
+     VALUES ('weights_changed', $1, $2::jsonb)`,
+    [epochId, JSON.stringify({ new_weights: weights })]
+  );
+  return epochId;
+}
+
+function slateItem(): RankedSlateItem {
+  return {
+    position: 1,
+    postUri: 'at://did:plc:author/app.bsky.feed.post/1',
+    postCreatedAt: '2026-07-11T19:59:00.000Z',
+    authorDid: 'did:plc:author',
+    componentDecomposition: {
+      recency: { raw: 1, weight: 0.2, weighted: 0.2 },
+      sourceDiversity: { raw: 1, weight: 0.2, weighted: 0.2 },
+    },
+    candidateSources: ['newest'],
+    diversityContext: { authorCountBefore: 0, raw: 1, weighted: 0.2 },
+    baseScore: 0.5,
+    finalScore: 0.7,
+  };
+}
+
+describe('Trustworthy Corgi contracts against real PostgreSQL', () => {
+  beforeEach(async () => {
+    await resetHarnessData();
+  });
+
+  afterEach(async () => {
+    await resetHarnessData();
+  });
+
+  it('materializes an idempotent policy and publishes a receipt-backed run', async () => {
+    await seedGovernedPolicyEvidence();
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      const materialized = await materializeActivePolicyVersion(client, {
+        communityId: 'community-gov',
+        algorithmVersion: 'corgi-ranking-v2',
+        effectiveAt: AS_OF,
+        provenanceReferences: [{
+          kind: 'implementation_packet',
+          reference: 'PROJ-1758',
+          observedAt: AS_OF,
+        }],
+      });
+      await client.query(
+        `INSERT INTO governance_audit_log (action, epoch_id, details)
+         VALUES ('vote_cast', $1, $2::jsonb)`,
+        [materialized.bundle.epochId, JSON.stringify({ voter: 'did:plc:unrelated' })]
+      );
+      const repeated = await materializeActivePolicyVersion(client, {
+        communityId: 'community-gov',
+        algorithmVersion: 'corgi-ranking-v2',
+        effectiveAt: AS_OF,
+        provenanceReferences: [{
+          kind: 'implementation_packet',
+          reference: 'PROJ-1758',
+          observedAt: AS_OF,
+        }],
+      });
+
+      expect(materialized.created).toBe(true);
+      expect(repeated.created).toBe(false);
+      expect(repeated.bundle.policyVersionId).toBe(materialized.bundle.policyVersionId);
+      expect(repeated.bundle.policyHash).toBe(materialized.bundle.policyHash);
+
+      await createRankingRun(client, {
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyVersionId: materialized.bundle.policyVersionId,
+        policyHash: materialized.bundle.policyHash,
+        algorithmVersion: materialized.bundle.algorithmVersion,
+        configurationHash: CONFIGURATION_HASH,
+        codeSha: CODE_SHA,
+        asOf: AS_OF,
+      });
+      await transitionRankingRun(client, RUN_ID, 'running', null);
+
+      const inputEnvelope: RankingRunInputEnvelope = {
+        schemaVersion: 1,
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyHash: materialized.bundle.policyHash,
+        configurationHash: CONFIGURATION_HASH,
+        asOf: AS_OF,
+        candidates: [{
+          uri: 'at://did:plc:author/app.bsky.feed.post/1',
+          eligible: true,
+          candidateSources: ['newest'],
+          features: { recency: 1 },
+        }],
+      };
+      const compressed = createCompressedRankingInput(inputEnvelope);
+      const items = [slateItem()];
+      await persistRankingRunInput(client, RUN_ID, compressed);
+      await persistRankedSlate(client, RUN_ID, items);
+
+      const receipt = buildRankingReceipt({
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyVersionId: materialized.bundle.policyVersionId,
+        policyHash: materialized.bundle.policyHash,
+        algorithmVersion: materialized.bundle.algorithmVersion,
+        configurationHash: CONFIGURATION_HASH,
+        codeSha: CODE_SHA,
+        asOf: AS_OF,
+        inputChecksum: compressed.checksum,
+        items,
+      });
+      await validateRankingRun(client, {
+        runId: RUN_ID,
+        receipt,
+        candidateCount: 1,
+        exclusionCount: 0,
+        timings: { totalMs: 42 },
+        metrics: { replayDeterministic: true },
+      });
+
+      await expect(prepareRankingRunPublication(client, RUN_ID, 'integration-test', AS_OF))
+        .resolves.toEqual({
+          publishable: true,
+          currentPolicyHash: materialized.bundle.policyHash,
+          replacementRequestId: null,
+        });
+      await expect(reconcilePublishedRankingRun(client, {
+        runId: RUN_ID,
+        policyHash: materialized.bundle.policyHash,
+        configurationHash: CONFIGURATION_HASH,
+        itemCount: 1,
+        snapshotId: 'snapshot-integration-1',
+        receiptChecksum: receipt.receiptChecksum,
+      })).resolves.toEqual({ repaired: true });
+      await client.query('COMMIT');
+
+      const policyCount = await db.query<{ count: number }>(
+        'SELECT COUNT(*)::int AS count FROM governance_policy_versions'
+      );
+      const reconciliationCount = await db.query<{ count: number }>(
+        'SELECT COUNT(*)::int AS count FROM governance_policy_reconciliation_events'
+      );
+      const run = await db.query<{
+        state: string;
+        snapshot_id: string;
+        receipt_checksum: string;
+      }>(
+        `SELECT state, snapshot_id, receipt_checksum::text
+           FROM ranking_runs
+          WHERE id = $1`,
+        [RUN_ID]
+      );
+      expect(policyCount.rows[0].count).toBe(1);
+      expect(reconciliationCount.rows[0].count).toBe(1);
+      expect(run.rows[0]).toEqual({
+        state: 'published',
+        snapshot_id: 'snapshot-integration-1',
+        receipt_checksum: receipt.receiptChecksum,
+      });
+    } catch (error: unknown) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  });
+
+  it('enforces the state machine and policy immutability at the database boundary', async () => {
+    await seedGovernedPolicyEvidence();
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      const materialized = await materializeActivePolicyVersion(client, {
+        communityId: 'community-gov',
+        algorithmVersion: 'corgi-ranking-v2',
+        effectiveAt: AS_OF,
+        provenanceReferences: [],
+      });
+      await createRankingRun(client, {
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyVersionId: materialized.bundle.policyVersionId,
+        policyHash: materialized.bundle.policyHash,
+        algorithmVersion: materialized.bundle.algorithmVersion,
+        configurationHash: CONFIGURATION_HASH,
+        codeSha: CODE_SHA,
+        asOf: AS_OF,
+      });
+      await client.query('SAVEPOINT invalid_transition');
+      await expect(
+        client.query("UPDATE ranking_runs SET state = 'published' WHERE id = $1", [RUN_ID])
+      ).rejects.toThrow('invalid ranking run transition');
+      await client.query('ROLLBACK TO SAVEPOINT invalid_transition');
+
+      await client.query('SAVEPOINT immutable_policy');
+      await expect(
+        client.query(
+          'UPDATE governance_policy_versions SET algorithm_version = $2 WHERE id = $1',
+          [materialized.bundle.policyVersionId, 'tampered']
+        )
+      ).rejects.toThrow('append-only and immutable');
+      await client.query('ROLLBACK TO SAVEPOINT immutable_policy');
+      await client.query('ROLLBACK');
+    } finally {
+      client.release();
+    }
+  });
+
+  it('removes expired manifests with their immutable child events', async () => {
+    await seedGovernedPolicyEvidence();
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      const materialized = await materializeActivePolicyVersion(client, {
+        communityId: 'community-gov',
+        algorithmVersion: 'corgi-ranking-v2',
+        effectiveAt: AS_OF,
+        provenanceReferences: [],
+      });
+      await createRankingRun(client, {
+        runId: RUN_ID,
+        communityId: 'community-gov',
+        policyVersionId: materialized.bundle.policyVersionId,
+        policyHash: materialized.bundle.policyHash,
+        algorithmVersion: materialized.bundle.algorithmVersion,
+        configurationHash: CONFIGURATION_HASH,
+        codeSha: CODE_SHA,
+        asOf: AS_OF,
+      });
+      await client.query(
+        `UPDATE ranking_runs
+            SET retain_until = NOW() - INTERVAL '1 minute'
+          WHERE id = $1`,
+        [RUN_ID]
+      );
+      await transitionRankingRun(client, RUN_ID, 'failed', { reason: 'retention-test' });
+      const deleted = await client.query<{ id: string }>(
+        `DELETE FROM ranking_runs
+          WHERE id = $1
+          RETURNING id::text`,
+        [RUN_ID]
+      );
+      expect(deleted.rows).toEqual([{ id: RUN_ID }]);
+      await client.query('COMMIT');
+    } catch (error: unknown) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  });
+});

--- a/tests/ranking-run-contracts.test.ts
+++ b/tests/ranking-run-contracts.test.ts
@@ -8,6 +8,7 @@ import {
   reconcilePublishedRankingRun,
   validateRankingReceipt,
 } from '../src/scoring/ranking-run-contracts.js';
+import { hashCanonicalJson } from '../src/governance/policy-version.js';
 import type {
   RankedSlateItem,
   RankingRunInputEnvelope,
@@ -158,6 +159,50 @@ describe('ranking receipts and reconciliation', () => {
     });
     expect(() => validateRankingReceipt({ ...receipt, receiptChecksum: HASH_C }))
       .toThrow('Ranking receipt checksum mismatch');
+  });
+
+  it.each([0, 1000])('accepts receipt itemCount boundary %s', (itemCount) => {
+    const input = createCompressedRankingInput(envelope([]));
+    const receipt = buildRankingReceipt({
+      runId: '00000000-0000-4000-8000-000000000001',
+      communityId: 'community-gov',
+      policyVersionId: '00000000-0000-4000-8000-000000000002',
+      policyHash: HASH_A,
+      algorithmVersion: 'corgi-ranking-v2',
+      configurationHash: HASH_B,
+      codeSha: 'd'.repeat(40),
+      asOf: '2026-07-11T20:00:00.000Z',
+      inputChecksum: input.checksum,
+      items: [],
+    });
+    const { receiptChecksum: _receiptChecksum, ...unsigned } = receipt;
+    const adjusted = { ...unsigned, itemCount };
+    expect(() => validateRankingReceipt({
+      ...adjusted,
+      receiptChecksum: hashCanonicalJson(adjusted),
+    })).not.toThrow();
+  });
+
+  it.each([-1, 1001])('rejects receipt itemCount outside bounds: %s', (itemCount) => {
+    const input = createCompressedRankingInput(envelope([]));
+    const receipt = buildRankingReceipt({
+      runId: '00000000-0000-4000-8000-000000000001',
+      communityId: 'community-gov',
+      policyVersionId: '00000000-0000-4000-8000-000000000002',
+      policyHash: HASH_A,
+      algorithmVersion: 'corgi-ranking-v2',
+      configurationHash: HASH_B,
+      codeSha: 'd'.repeat(40),
+      asOf: '2026-07-11T20:00:00.000Z',
+      inputChecksum: input.checksum,
+      items: [],
+    });
+    const { receiptChecksum: _receiptChecksum, ...unsigned } = receipt;
+    const adjusted = { ...unsigned, itemCount };
+    expect(() => validateRankingReceipt({
+      ...adjusted,
+      receiptChecksum: hashCanonicalJson(adjusted),
+    })).toThrow('receipt.itemCount must be an integer in [0, 1000]');
   });
 
   it('repairs validated DB state from matching Redis publication metadata', async () => {

--- a/tests/ranking-run-contracts.test.ts
+++ b/tests/ranking-run-contracts.test.ts
@@ -1,0 +1,192 @@
+import type { PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertRankingRunTransition,
+  buildRankingReceipt,
+  createCompressedRankingInput,
+  decodeCompressedRankingInput,
+  reconcilePublishedRankingRun,
+  validateRankingReceipt,
+} from '../src/scoring/ranking-run-contracts.js';
+import type {
+  RankedSlateItem,
+  RankingRunInputEnvelope,
+} from '../src/shared/ranking-contracts.js';
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+const HASH_C = 'c'.repeat(64);
+
+function asClient(query: ReturnType<typeof vi.fn>): PoolClient {
+  return { query } as unknown as PoolClient;
+}
+
+function envelope(candidates: RankingRunInputEnvelope['candidates']): RankingRunInputEnvelope {
+  return {
+    schemaVersion: 1,
+    runId: '00000000-0000-4000-8000-000000000001',
+    communityId: 'community-gov',
+    policyHash: HASH_A,
+    configurationHash: HASH_B,
+    asOf: '2026-07-11T20:00:00.000Z',
+    candidates,
+  };
+}
+
+function item(position: number, uri: string): RankedSlateItem {
+  return {
+    position,
+    postUri: uri,
+    postCreatedAt: `2026-07-11T19:59:0${position}.000Z`,
+    authorDid: `did:plc:author${position}`,
+    componentDecomposition: {
+      recency: { raw: 1, weight: 0.2, weighted: 0.2 },
+    },
+    candidateSources: ['newest'],
+    diversityContext: { authorCountBefore: position - 1, raw: 1 },
+    baseScore: 0.5,
+    finalScore: 0.7,
+  };
+}
+
+describe('ranking-run state machine', () => {
+  it('accepts the success path and rejects reverse or terminal transitions', () => {
+    expect(() => assertRankingRunTransition('requested', 'running')).not.toThrow();
+    expect(() => assertRankingRunTransition('running', 'validated')).not.toThrow();
+    expect(() => assertRankingRunTransition('validated', 'published')).not.toThrow();
+    expect(() => assertRankingRunTransition('running', 'requested')).toThrow('Invalid');
+    expect(() => assertRankingRunTransition('published', 'running')).toThrow('Invalid');
+  });
+
+  it.each(['failed', 'superseded', 'rejected'] as const)(
+    'allows running runs to terminate as %s',
+    (terminal) => {
+      expect(() => assertRankingRunTransition('running', terminal)).not.toThrow();
+    }
+  );
+});
+
+describe('ranking replay inputs', () => {
+  it('round-trips canonical gzip input with an exact checksum', () => {
+    const original = envelope([
+      { uri: 'at://did:plc:a/app.bsky.feed.post/1', eligible: true, features: { recency: 0.9 } },
+      { uri: 'at://did:plc:b/app.bsky.feed.post/2', eligible: false, reason: 'deleted' },
+    ]);
+    const compressed = createCompressedRankingInput(original);
+    const replayed = decodeCompressedRankingInput(compressed);
+
+    expect(replayed).toEqual(original);
+    expect(compressed.checksum).toMatch(/^[0-9a-f]{64}$/);
+    expect(compressed.candidateCount).toBe(2);
+    expect(compressed.compressedBytes).toBeLessThan(compressed.uncompressedBytes);
+    expect(createCompressedRankingInput(original).payload.equals(compressed.payload)).toBe(true);
+  });
+
+  it('rejects a checksum mismatch', () => {
+    const compressed = createCompressedRankingInput(envelope([{ uri: 'at://post/1' }]));
+    expect(() => decodeCompressedRankingInput({
+      ...compressed,
+      checksum: HASH_C,
+    })).toThrow('checksum mismatch');
+  });
+});
+
+describe('ranking receipts and reconciliation', () => {
+  it('binds the exact item order into the receipt checksum', () => {
+    const input = createCompressedRankingInput(envelope([{ uri: 'at://post/1' }]));
+    const first = buildRankingReceipt({
+      runId: '00000000-0000-4000-8000-000000000001',
+      communityId: 'community-gov',
+      policyVersionId: '00000000-0000-4000-8000-000000000002',
+      policyHash: HASH_A,
+      algorithmVersion: 'corgi-ranking-v2',
+      configurationHash: HASH_B,
+      codeSha: 'd'.repeat(40),
+      asOf: '2026-07-11T20:00:00.000Z',
+      inputChecksum: input.checksum,
+      items: [item(1, 'at://post/1'), item(2, 'at://post/2')],
+    });
+    const second = buildRankingReceipt({
+      runId: '00000000-0000-4000-8000-000000000001',
+      communityId: 'community-gov',
+      policyVersionId: '00000000-0000-4000-8000-000000000002',
+      policyHash: HASH_A,
+      algorithmVersion: 'corgi-ranking-v2',
+      configurationHash: HASH_B,
+      codeSha: 'd'.repeat(40),
+      asOf: '2026-07-11T20:00:00.000Z',
+      inputChecksum: input.checksum,
+      items: [item(1, 'at://post/2'), item(2, 'at://post/1')],
+    });
+
+    expect(() => validateRankingReceipt(first)).not.toThrow();
+    expect(first.itemOrderChecksum).not.toBe(second.itemOrderChecksum);
+    expect(first.receiptChecksum).not.toBe(second.receiptChecksum);
+  });
+
+  it('repairs validated DB state from matching Redis publication metadata', async () => {
+    const queries: string[] = [];
+    const query = vi.fn(async (sql: string) => {
+      queries.push(sql);
+      if (sql.includes('FROM ranking_runs')) {
+        return {
+          rows: [{
+            id: '00000000-0000-4000-8000-000000000001',
+            community_id: 'community-gov',
+            policy_version_id: '00000000-0000-4000-8000-000000000002',
+            policy_hash: HASH_A,
+            algorithm_version: 'corgi-ranking-v2',
+            configuration_hash: HASH_B,
+            code_sha: 'd'.repeat(40),
+            as_of: '2026-07-11T20:00:00.000Z',
+            state: 'validated',
+            selected_count: 1000,
+            snapshot_id: null,
+            receipt_checksum: HASH_C,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await expect(reconcilePublishedRankingRun(asClient(query), {
+      runId: '00000000-0000-4000-8000-000000000001',
+      policyHash: HASH_A,
+      configurationHash: HASH_B,
+      itemCount: 1000,
+      snapshotId: 'snapshot-123',
+      receiptChecksum: HASH_C,
+    })).resolves.toEqual({ repaired: true });
+
+    expect(queries.some((sql) => sql.includes("SET state = 'published'"))).toBe(true);
+    expect(queries.some((sql) => sql.includes('redis_publication_reconciled'))).toBe(true);
+  });
+
+  it('refuses reconciliation when Redis metadata does not match the DB receipt', async () => {
+    const query = vi.fn(async () => ({
+      rows: [{
+        id: '00000000-0000-4000-8000-000000000001',
+        community_id: 'community-gov',
+        policy_version_id: '00000000-0000-4000-8000-000000000002',
+        policy_hash: HASH_A,
+        algorithm_version: 'corgi-ranking-v2',
+        configuration_hash: HASH_B,
+        code_sha: 'd'.repeat(40),
+        as_of: '2026-07-11T20:00:00.000Z',
+        state: 'validated',
+        selected_count: 1000,
+        snapshot_id: null,
+        receipt_checksum: HASH_C,
+      }],
+    }));
+
+    await expect(reconcilePublishedRankingRun(asClient(query), {
+      runId: '00000000-0000-4000-8000-000000000001',
+      policyHash: HASH_A,
+      configurationHash: HASH_B,
+      itemCount: 999,
+      snapshotId: 'snapshot-123',
+      receiptChecksum: HASH_C,
+    })).rejects.toThrow('itemCount');
+  });
+});

--- a/tests/ranking-run-contracts.test.ts
+++ b/tests/ranking-run-contracts.test.ts
@@ -11,6 +11,7 @@ import {
 import { hashCanonicalJson } from '../src/governance/policy-version.js';
 import type {
   RankedSlateItem,
+  RankingReceipt,
   RankingRunInputEnvelope,
 } from '../src/shared/ranking-contracts.js';
 
@@ -204,6 +205,28 @@ describe('ranking receipts and reconciliation', () => {
       receiptChecksum: hashCanonicalJson(adjusted),
     })).toThrow('receipt.itemCount must be an integer in [0, 1000]');
   });
+
+  it.each([0.5, Number.NaN, Number.POSITIVE_INFINITY, null, undefined] as const)(
+    'rejects malformed receipt itemCount: %s',
+    (itemCount) => {
+      const input = createCompressedRankingInput(envelope([]));
+      const receipt = buildRankingReceipt({
+        runId: '00000000-0000-4000-8000-000000000001',
+        communityId: 'community-gov',
+        policyVersionId: '00000000-0000-4000-8000-000000000002',
+        policyHash: HASH_A,
+        algorithmVersion: 'corgi-ranking-v2',
+        configurationHash: HASH_B,
+        codeSha: 'd'.repeat(40),
+        asOf: '2026-07-11T20:00:00.000Z',
+        inputChecksum: input.checksum,
+        items: [],
+      });
+      const malformed = { ...receipt, itemCount } as unknown as RankingReceipt;
+      expect(() => validateRankingReceipt(malformed))
+        .toThrow('receipt.itemCount must be an integer in [0, 1000]');
+    }
+  );
 
   it('repairs validated DB state from matching Redis publication metadata', async () => {
     const queries: string[] = [];

--- a/tests/ranking-run-contracts.test.ts
+++ b/tests/ranking-run-contracts.test.ts
@@ -79,7 +79,13 @@ describe('ranking replay inputs', () => {
     expect(compressed.checksum).toMatch(/^[0-9a-f]{64}$/);
     expect(compressed.candidateCount).toBe(2);
     expect(compressed.compressedBytes).toBeLessThan(compressed.uncompressedBytes);
-    expect(createCompressedRankingInput(original).payload.equals(compressed.payload)).toBe(true);
+  });
+
+  it('round-trips an empty candidate set', () => {
+    const original = envelope([]);
+    const compressed = createCompressedRankingInput(original);
+    expect(decodeCompressedRankingInput(compressed)).toEqual(original);
+    expect(compressed.candidateCount).toBe(0);
   });
 
   it('rejects a checksum mismatch', () => {
@@ -88,6 +94,18 @@ describe('ranking replay inputs', () => {
       ...compressed,
       checksum: HASH_C,
     })).toThrow('checksum mismatch');
+  });
+
+  it.each([
+    ['compressed byte count', 'compressedBytes', 1, 'Compressed ranking input byte count mismatch'],
+    ['uncompressed byte count', 'uncompressedBytes', 1, 'Uncompressed ranking input byte count mismatch'],
+    ['candidate count', 'candidateCount', 1, 'Ranking input candidate count mismatch'],
+  ] as const)('rejects a tampered %s', (_label, field, delta, message) => {
+    const compressed = createCompressedRankingInput(envelope([]));
+    expect(() => decodeCompressedRankingInput({
+      ...compressed,
+      [field]: compressed[field] + delta,
+    })).toThrow(message);
   });
 });
 
@@ -124,11 +142,29 @@ describe('ranking receipts and reconciliation', () => {
     expect(first.receiptChecksum).not.toBe(second.receiptChecksum);
   });
 
+  it('rejects a directly tampered receipt checksum', () => {
+    const input = createCompressedRankingInput(envelope([]));
+    const receipt = buildRankingReceipt({
+      runId: '00000000-0000-4000-8000-000000000001',
+      communityId: 'community-gov',
+      policyVersionId: '00000000-0000-4000-8000-000000000002',
+      policyHash: HASH_A,
+      algorithmVersion: 'corgi-ranking-v2',
+      configurationHash: HASH_B,
+      codeSha: 'd'.repeat(40),
+      asOf: '2026-07-11T20:00:00.000Z',
+      inputChecksum: input.checksum,
+      items: [],
+    });
+    expect(() => validateRankingReceipt({ ...receipt, receiptChecksum: HASH_C }))
+      .toThrow('Ranking receipt checksum mismatch');
+  });
+
   it('repairs validated DB state from matching Redis publication metadata', async () => {
     const queries: string[] = [];
     const query = vi.fn(async (sql: string) => {
       queries.push(sql);
-      if (sql.includes('FROM ranking_runs')) {
+      if (sql.includes('SELECT id::text') && sql.includes('FOR UPDATE')) {
         return {
           rows: [{
             id: '00000000-0000-4000-8000-000000000001',
@@ -163,7 +199,10 @@ describe('ranking receipts and reconciliation', () => {
   });
 
   it('refuses reconciliation when Redis metadata does not match the DB receipt', async () => {
-    const query = vi.fn(async () => ({
+    const query = vi.fn(async (sql: string) => {
+      expect(sql).toContain('SELECT id::text');
+      expect(sql).toContain('FOR UPDATE');
+      return {
       rows: [{
         id: '00000000-0000-4000-8000-000000000001',
         community_id: 'community-gov',
@@ -178,7 +217,8 @@ describe('ranking receipts and reconciliation', () => {
         snapshot_id: null,
         receipt_checksum: HASH_C,
       }],
-    }));
+      };
+    });
 
     await expect(reconcilePublishedRankingRun(asClient(query), {
       runId: '00000000-0000-4000-8000-000000000001',
@@ -188,5 +228,69 @@ describe('ranking receipts and reconciliation', () => {
       snapshotId: 'snapshot-123',
       receiptChecksum: HASH_C,
     })).rejects.toThrow('itemCount');
+  });
+
+  it('accepts matching metadata for an already-published run without repairing it', async () => {
+    const query = vi.fn(async (sql: string) => {
+      expect(sql).toContain('SELECT id::text');
+      expect(sql).toContain('FOR UPDATE');
+      return {
+        rows: [{
+          id: '00000000-0000-4000-8000-000000000001',
+          community_id: 'community-gov',
+          policy_version_id: '00000000-0000-4000-8000-000000000002',
+          policy_hash: HASH_A,
+          algorithm_version: 'corgi-ranking-v2',
+          configuration_hash: HASH_B,
+          code_sha: 'd'.repeat(40),
+          as_of: '2026-07-11T20:00:00.000Z',
+          state: 'published',
+          selected_count: 1000,
+          snapshot_id: 'snapshot-123',
+          receipt_checksum: HASH_C,
+        }],
+      };
+    });
+
+    await expect(reconcilePublishedRankingRun(asClient(query), {
+      runId: '00000000-0000-4000-8000-000000000001',
+      policyHash: HASH_A,
+      configurationHash: HASH_B,
+      itemCount: 1000,
+      snapshotId: 'snapshot-123',
+      receiptChecksum: HASH_C,
+    })).resolves.toEqual({ repaired: false });
+  });
+
+  it('rejects reconciliation from a non-validated active state', async () => {
+    const query = vi.fn(async (sql: string) => {
+      expect(sql).toContain('SELECT id::text');
+      expect(sql).toContain('FOR UPDATE');
+      return {
+        rows: [{
+          id: '00000000-0000-4000-8000-000000000001',
+          community_id: 'community-gov',
+          policy_version_id: '00000000-0000-4000-8000-000000000002',
+          policy_hash: HASH_A,
+          algorithm_version: 'corgi-ranking-v2',
+          configuration_hash: HASH_B,
+          code_sha: 'd'.repeat(40),
+          as_of: '2026-07-11T20:00:00.000Z',
+          state: 'running',
+          selected_count: 1000,
+          snapshot_id: null,
+          receipt_checksum: HASH_C,
+        }],
+      };
+    });
+
+    await expect(reconcilePublishedRankingRun(asClient(query), {
+      runId: '00000000-0000-4000-8000-000000000001',
+      policyHash: HASH_A,
+      configurationHash: HASH_B,
+      itemCount: 1000,
+      snapshotId: 'snapshot-123',
+      receiptChecksum: HASH_C,
+    })).rejects.toThrow('Cannot reconcile');
   });
 });

--- a/tests/trustworthy-corgi-migration.test.ts
+++ b/tests/trustworthy-corgi-migration.test.ts
@@ -1,0 +1,44 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+const migrationUrl = new URL(
+  '../src/db/migrations/032_trustworthy_corgi_contracts.sql',
+  import.meta.url
+);
+
+describe('Trustworthy Corgi migration contract', () => {
+  it('is additive and creates every Packet 1 durable surface', async () => {
+    const sql = await readFile(migrationUrl, 'utf8');
+    for (const table of [
+      'governance_policy_versions',
+      'governance_policy_reconciliation_events',
+      'ranking_runs',
+      'ranking_run_events',
+      'ranking_run_items',
+      'ranking_run_inputs',
+      'ranking_run_requests',
+    ]) {
+      expect(sql).toContain(`CREATE TABLE IF NOT EXISTS ${table}`);
+    }
+    expect(sql).not.toMatch(/\bDROP\s+TABLE\b/i);
+    expect(sql).not.toMatch(/\bALTER\s+TABLE\s+(posts|post_scores|governance_epochs)\b/i);
+  });
+
+  it('enforces immutable policies, run transitions, and retention windows in the database', async () => {
+    const sql = await readFile(migrationUrl, 'utf8');
+    expect(sql).toContain('governance_policy_versions_immutable');
+    expect(sql).toContain('corgi_validate_ranking_run_transition');
+    expect(sql).toContain("INTERVAL '7 days'");
+    expect(sql).toContain("INTERVAL '30 days'");
+    expect(sql).toContain('corgi_protect_retained_ranking_input');
+    expect(sql).toContain('corgi_protect_ranking_run_manifest');
+  });
+
+  it('binds ranking runs to the exact immutable policy hash', async () => {
+    const sql = await readFile(migrationUrl, 'utf8');
+    expect(sql).toMatch(
+      /FOREIGN KEY \(policy_version_id, policy_hash\)[\s\S]*REFERENCES governance_policy_versions\(id, policy_hash\)/
+    );
+    expect(sql).toContain("policy_hash ~ '^[0-9a-f]{64}$'");
+  });
+});

--- a/tests/trustworthy-corgi-migration.test.ts
+++ b/tests/trustworthy-corgi-migration.test.ts
@@ -21,7 +21,7 @@ describe('Trustworthy Corgi migration contract', () => {
       expect(sql).toContain(`CREATE TABLE IF NOT EXISTS ${table}`);
     }
     expect(sql).not.toMatch(/\bDROP\s+TABLE\b/i);
-    expect(sql).not.toMatch(/\bALTER\s+TABLE\s+(posts|post_scores|governance_epochs)\b/i);
+    expect(sql).not.toMatch(/\bALTER\s+TABLE\b/i);
   });
 
   it('enforces immutable policies, run transitions, and retention windows in the database', async () => {


### PR DESCRIPTION
## Summary

- add immutable, hashed governance policy versions with append-only reconciliation evidence
- reject partial, unregistered, or non-normalized serving weight vectors before policy materialization
- add ranking run, item, replay input, request, event, receipt, state-machine, and retention contracts
- bind replay inputs and receipts to the persisted run identity and exact stored slate order
- make replay input and slate persistence idempotent while rejecting conflicting retries
- preserve expired replay inputs until their ranking run reaches a terminal state
- supersede stale-policy runs without mutating validated results and queue an idempotent replacement
- add deterministic replay tooling and Redis-publication reconciliation primitives
- keep existing scoring, serving, feed ordering, governance weights, Birders state, and AT Protocol responses unchanged

## Verification

- `npm run verify` (136 files, 1,378 tests; backend, CLI, SDK, legacy web, and web-next builds)
- `npm run sim:core` (20 files, 227 tests, ephemeral PostgreSQL and Redis)
- focused contract suite (3 files, 44 tests)
- `npm audit --audit-level=high` for root, web, and web-next
- `git diff --check`

## CodeRabbit review disposition

- CodeRabbit opened 11 threads on `e1236bb50d0d7edf88f0aede81dce3a41f007a9a`; `fe386585b38a6f65087df2a508b49971e796248f` addressed all 11.
- CodeRabbit then requested explicit receipt `itemCount` boundary coverage on `fe38658`; `d14cb9c` adds the requested 0, 1,000, -1, and 1,001 cases.
- CodeRabbit completed its prior review immediately after the bounded wait and requested malformed `itemCount` coverage; `4e18234` adds fractional, `NaN`, infinity, null, and undefined cases.
- CodeRabbit approved current head `4e18234` with zero live threads. The audit block below covers only the hosted freshness workflow's reproducible inability to see that completed external suite.

## CodeRabbit Audit

- Status: exempt
- Reason: CodeRabbit explicitly approved current head `4e18234` with zero live threads, but the required `pull_request` freshness workflow reproducibly cannot see the completed external suite and fails as missing; direct repository truth gates pass.
- Follow-up: Remove `coderabbit:exempt` immediately after PR #339 merges; Packet 2 must obtain its own current-head review and may not inherit this control-plane exemption.
- Expires: 2026-07-13

## Rollback

Application rollback only. Migration 032 is additive; the unused tables may remain in place. No destructive down migration is required.

Closes PROJ-1758
