### PR TITLE
[PROJ-1761] Trust exact-head CodeRabbit approval fallback

### DIFF
--- a/.github/workflows/coderabbit-freshness.yml
+++ b/.github/workflows/coderabbit-freshness.yml
@@ -41,7 +41,7 @@ jobs:
 
             const failWithAction = (reason) => {
               core.setFailed(
-                `[coderabbit-freshness:fail] ${reason}. Next action: run "@coderabbitai review" on this PR and wait for a fresh CodeRabbit update. Temporary bypass requires label "coderabbit:exempt" with audit note.`
+                `[coderabbit-freshness:fail] ${reason}. Next action: run the sanctioned pr-review-readiness wrapper and only request another review when coderabbit-request-review authorizes it. Temporary bypass requires label "coderabbit:exempt" with audit note.`
               );
             };
 
@@ -63,6 +63,59 @@ jobs:
                 return null;
               }
               return resolvedPr;
+            };
+
+            const resolveExactHeadCodeRabbitReview = async (prNumber, headSha) => {
+              const reviews = [];
+              let after = null;
+              for (let pageCount = 0; pageCount < 100; pageCount += 1) {
+                const result = await github.graphql(
+                  `query($owner: String!, $repo: String!, $prNumber: Int!, $after: String) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $prNumber) {
+                        reviews(first: 100, after: $after) {
+                          nodes {
+                            author { login }
+                            commit { oid }
+                            state
+                            submittedAt
+                          }
+                          pageInfo {
+                            hasNextPage
+                            endCursor
+                          }
+                        }
+                      }
+                    }
+                  }`,
+                  { owner, repo, prNumber, after }
+                );
+                const pullRequest = result.repository?.pullRequest;
+                if (!pullRequest) {
+                  throw new Error(`PR #${prNumber} was not returned by the review query`);
+                }
+                const page = pullRequest.reviews;
+                reviews.push(...(page?.nodes || []));
+                if (!page?.pageInfo?.hasNextPage) {
+                  break;
+                }
+                if (!page.pageInfo.endCursor) {
+                  throw new Error("Review pagination is incomplete: missing endCursor");
+                }
+                if (pageCount === 99) {
+                  throw new Error("Review pagination exceeded the 100-page safety bound");
+                }
+                after = page.pageInfo.endCursor;
+              }
+
+              const coderabbitAuthors = new Set(["coderabbitai", "coderabbitai[bot]"]);
+              return reviews
+                .filter((review) => {
+                  const reviewAuthor = (review.author?.login || "").trim().toLowerCase();
+                  const reviewSha = (review.commit?.oid || "").trim();
+                  return coderabbitAuthors.has(reviewAuthor) && reviewSha === headSha;
+                })
+                .sort((a, b) => parseTime(b.submittedAt) - parseTime(a.submittedAt))[0] || null;
             };
 
             const pr = await resolvePullRequest();
@@ -167,7 +220,26 @@ jobs:
               (suite) => (((suite.app || {}).slug || "").trim().toLowerCase() === "coderabbitai")
             );
             if (suites.length === 0) {
-              failWithAction("Missing CodeRabbit status/check-suite for this commit");
+              let exactHeadReview;
+              try {
+                exactHeadReview = await resolveExactHeadCodeRabbitReview(pr.number, sha);
+              } catch (error) {
+                failWithAction(`Could not verify complete exact-head CodeRabbit review truth: ${error?.message || error}`);
+                return;
+              }
+              if (!exactHeadReview) {
+                failWithAction("Missing CodeRabbit status/check-suite and exact-head review for this commit");
+                return;
+              }
+
+              const reviewState = (exactHeadReview.state || "").trim().toUpperCase();
+              if (reviewState !== "APPROVED") {
+                failWithAction(`Latest exact-head CodeRabbit review state is ${reviewState || "unknown"}`);
+                return;
+              }
+              core.notice(
+                `[coderabbit-freshness:ok_review] Exact-head CodeRabbit review is APPROVED at ${exactHeadReview.submittedAt || "unknown time"}; the workflow token returned no CodeRabbit status/check-suite.`
+              );
               return;
             }
 

--- a/.github/workflows/coderabbit-freshness.yml
+++ b/.github/workflows/coderabbit-freshness.yml
@@ -108,7 +108,7 @@ jobs:
                 after = page.pageInfo.endCursor;
               }
 
-              return reviews
+              const exactHeadReviews = reviews
                 .filter((review) => {
                   if (!review) {
                     return false;
@@ -121,14 +121,21 @@ jobs:
                     ? reviewAuthor.slice(0, -"[bot]".length)
                     : reviewAuthor;
                   const reviewSha = (review.commit?.oid || "").trim();
-                  const reviewState = (review.state || "").trim().toUpperCase();
-                  // COMMENTED is non-decisive; the newest approval or change request wins.
                   return reviewAuthorType === "Bot"
                     && normalizedAuthor === "coderabbitai"
-                    && reviewSha === headSha
-                    && (reviewState === "APPROVED" || reviewState === "CHANGES_REQUESTED");
+                    && reviewSha === headSha;
                 })
-                .sort((a, b) => parseTime(b.submittedAt) - parseTime(a.submittedAt))[0] || null;
+                .sort((a, b) => parseTime(b.submittedAt) - parseTime(a.submittedAt));
+              const decisiveReviews = exactHeadReviews.filter((review) => {
+                const reviewState = (review.state || "").trim().toUpperCase();
+                return reviewState === "APPROVED" || reviewState === "CHANGES_REQUESTED";
+              });
+
+              return {
+                latestReview: exactHeadReviews[0] || null,
+                // COMMENTED is non-decisive; the newest approval or change request wins.
+                latestDecisiveReview: decisiveReviews[0] || null,
+              };
             };
 
             const pr = await resolvePullRequest();
@@ -233,14 +240,23 @@ jobs:
               (suite) => (((suite.app || {}).slug || "").trim().toLowerCase() === "coderabbitai")
             );
             if (suites.length === 0) {
-              let exactHeadReview;
+              let exactHeadReviewTruth;
               try {
-                exactHeadReview = await resolveExactHeadCodeRabbitReview(pr.number, sha);
+                exactHeadReviewTruth = await resolveExactHeadCodeRabbitReview(pr.number, sha);
               } catch (error) {
                 failWithAction(`Could not verify complete exact-head CodeRabbit review truth: ${error?.message || error}`);
                 return;
               }
+              const exactHeadReview = exactHeadReviewTruth.latestDecisiveReview;
               if (!exactHeadReview) {
+                const latestReview = exactHeadReviewTruth.latestReview;
+                if (latestReview) {
+                  const latestState = (latestReview.state || "").trim().toUpperCase() || "unknown";
+                  failWithAction(
+                    `Exact-head CodeRabbit review exists but has no decisive APPROVED/CHANGES_REQUESTED state (latest state: ${latestState}); confirm request_changes_workflow is enabled`
+                  );
+                  return;
+                }
                 failWithAction("Missing CodeRabbit status/check-suite and exact-head review for this commit");
                 return;
               }

--- a/.github/workflows/coderabbit-freshness.yml
+++ b/.github/workflows/coderabbit-freshness.yml
@@ -252,14 +252,8 @@ jobs:
                 const latestReview = exactHeadReviewTruth.latestReview;
                 if (latestReview) {
                   const latestState = (latestReview.state || "").trim().toUpperCase() || "unknown";
-                  if (latestState === "COMMENTED") {
-                    core.notice(
-                      `[coderabbit-freshness:ok_review_comment_only] Exact-head CodeRabbit review is COMMENTED at ${latestReview.submittedAt || "unknown time"}; the separately required thread gate remains authoritative for unresolved findings.`
-                    );
-                    return;
-                  }
                   failWithAction(
-                    `Exact-head CodeRabbit review exists but has no acceptable APPROVED/CHANGES_REQUESTED/COMMENTED state (latest state: ${latestState})`
+                    `Exact-head CodeRabbit review exists but has no decisive APPROVED/CHANGES_REQUESTED state (latest state: ${latestState}); confirm request_changes_workflow is enabled`
                   );
                   return;
                 }

--- a/.github/workflows/coderabbit-freshness.yml
+++ b/.github/workflows/coderabbit-freshness.yml
@@ -252,8 +252,14 @@ jobs:
                 const latestReview = exactHeadReviewTruth.latestReview;
                 if (latestReview) {
                   const latestState = (latestReview.state || "").trim().toUpperCase() || "unknown";
+                  if (latestState === "COMMENTED") {
+                    core.notice(
+                      `[coderabbit-freshness:ok_review_comment_only] Exact-head CodeRabbit review is COMMENTED at ${latestReview.submittedAt || "unknown time"}; the separately required thread gate remains authoritative for unresolved findings.`
+                    );
+                    return;
+                  }
                   failWithAction(
-                    `Exact-head CodeRabbit review exists but has no decisive APPROVED/CHANGES_REQUESTED state (latest state: ${latestState}); confirm request_changes_workflow is enabled`
+                    `Exact-head CodeRabbit review exists but has no acceptable APPROVED/CHANGES_REQUESTED/COMMENTED state (latest state: ${latestState})`
                   );
                   return;
                 }

--- a/.github/workflows/coderabbit-freshness.yml
+++ b/.github/workflows/coderabbit-freshness.yml
@@ -226,6 +226,63 @@ jobs:
               return;
             }
 
+            const allCheckRuns = await github.paginate(
+              github.rest.checks.listForRef,
+              {
+                owner,
+                repo,
+                ref: sha,
+                per_page: 100,
+              },
+              (response) => response.data?.check_runs || []
+            );
+            const checkRuns = (allCheckRuns || [])
+              .filter((run) => {
+                const appSlug = (((run.app || {}).slug || "").trim().toLowerCase());
+                const runName = ((run.name || "").trim().toLowerCase());
+                return appSlug === "coderabbitai" && runName === "coderabbit";
+              })
+              .sort((a, b) => {
+                const aTs = parseTime(a.completed_at || a.started_at || a.created_at || "");
+                const bTs = parseTime(b.completed_at || b.started_at || b.created_at || "");
+                return bTs - aTs;
+              });
+
+            if (checkRuns.length > 0) {
+              const latestRun = checkRuns[0];
+              const runStatus = ((latestRun.status || "").trim().toLowerCase());
+              const runConclusion = ((latestRun.conclusion || "").trim().toLowerCase());
+              const runUpdatedAt = parseTime(
+                latestRun.completed_at || latestRun.started_at || latestRun.created_at || ""
+              );
+              const runAgeMinutes = Math.max(0, Math.floor((now - runUpdatedAt) / 60000));
+
+              if (runStatus === "completed") {
+                if (runConclusion !== "success") {
+                  failWithAction(`CodeRabbit check-run conclusion is ${runConclusion || "unknown"}`);
+                  return;
+                }
+                core.notice(
+                  `[coderabbit-freshness:ok_run] Exact-head CodeRabbit check run completed (success); age ${runAgeMinutes}m.`
+                );
+                return;
+              }
+
+              const pendingStates = ["queued", "in_progress", "waiting", "pending"];
+              if (!pendingStates.includes(runStatus)) {
+                failWithAction(`CodeRabbit check-run status is ${runStatus || "unknown"}`);
+                return;
+              }
+              if (runAgeMinutes > staleMinutes) {
+                failWithAction(
+                  `CodeRabbit check-run is pending stale (${runAgeMinutes}m old; SLA ${staleMinutes}m)`
+                );
+                return;
+              }
+              failWithAction(`CodeRabbit check-run is still ${runStatus} (${runAgeMinutes}m old)`);
+              return;
+            }
+
             const allSuites = await github.paginate(
               github.rest.checks.listSuitesForRef,
               {

--- a/.github/workflows/coderabbit-freshness.yml
+++ b/.github/workflows/coderabbit-freshness.yml
@@ -138,6 +138,64 @@ jobs:
               };
             };
 
+            const resolveExactHeadCodeRabbitRollup = async (headSha) => {
+              const runs = [];
+              let after = null;
+              for (let pageCount = 0; pageCount < 100; pageCount += 1) {
+                const result = await github.graphql(
+                  `query($owner: String!, $repo: String!, $headSha: GitObjectID!, $after: String) {
+                    repository(owner: $owner, name: $repo) {
+                      object(oid: $headSha) {
+                        oid
+                        ... on Commit {
+                          statusCheckRollup {
+                            contexts(first: 100, after: $after) {
+                              nodes {
+                                __typename
+                                ... on CheckRun {
+                                  name
+                                  status
+                                  conclusion
+                                  startedAt
+                                  completedAt
+                                  checkSuite { app { slug } }
+                                }
+                              }
+                              pageInfo {
+                                hasNextPage
+                                endCursor
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }`,
+                  { owner, repo, headSha, after }
+                );
+                const commit = result.repository?.object;
+                if (!commit || commit.oid !== headSha) {
+                  throw new Error(`Exact-head commit ${headSha} was not returned by the status rollup query`);
+                }
+                const contexts = commit.statusCheckRollup?.contexts;
+                if (!contexts) {
+                  return [];
+                }
+                runs.push(...(contexts.nodes || []).filter((node) => node?.__typename === "CheckRun"));
+                if (!contexts.pageInfo?.hasNextPage) {
+                  break;
+                }
+                if (!contexts.pageInfo.endCursor) {
+                  throw new Error("Status rollup pagination is incomplete: missing endCursor");
+                }
+                if (pageCount === 99) {
+                  throw new Error("Status rollup pagination exceeded the 100-page safety bound");
+                }
+                after = contexts.pageInfo.endCursor;
+              }
+              return runs;
+            };
+
             const pr = await resolvePullRequest();
             if (!pr) {
               return;
@@ -247,6 +305,39 @@ jobs:
                 const bTs = parseTime(b.completed_at || b.started_at || b.created_at || "");
                 return bTs - aTs;
               });
+
+            if (checkRuns.length === 0) {
+              try {
+                const rollupRuns = await resolveExactHeadCodeRabbitRollup(sha);
+                checkRuns.push(
+                  ...rollupRuns
+                    .filter((run) => {
+                      const appSlug = (((run.checkSuite || {}).app || {}).slug || "")
+                        .trim()
+                        .toLowerCase();
+                      const runName = ((run.name || "").trim().toLowerCase());
+                      return appSlug === "coderabbitai" && runName === "coderabbit";
+                    })
+                    .map((run) => ({
+                      name: run.name,
+                      status: run.status,
+                      conclusion: run.conclusion,
+                      started_at: run.startedAt,
+                      completed_at: run.completedAt,
+                      app: run.checkSuite?.app || null,
+                    }))
+                );
+                checkRuns.sort((a, b) => {
+                  const aTs = parseTime(a.completed_at || a.started_at || a.created_at || "");
+                  const bTs = parseTime(b.completed_at || b.started_at || b.created_at || "");
+                  return bTs - aTs;
+                });
+              } catch (error) {
+                core.info(
+                  `[coderabbit-freshness:rollup_unavailable] ${error?.message || error}; continuing to check-suite and review fallbacks.`
+                );
+              }
+            }
 
             if (checkRuns.length > 0) {
               const latestRun = checkRuns[0];

--- a/.github/workflows/coderabbit-freshness.yml
+++ b/.github/workflows/coderabbit-freshness.yml
@@ -75,7 +75,7 @@ jobs:
                       pullRequest(number: $prNumber) {
                         reviews(first: 100, after: $after) {
                           nodes {
-                            author { login }
+                            author { __typename login }
                             commit { oid }
                             state
                             submittedAt
@@ -108,12 +108,25 @@ jobs:
                 after = page.pageInfo.endCursor;
               }
 
-              const coderabbitAuthors = new Set(["coderabbitai", "coderabbitai[bot]"]);
               return reviews
                 .filter((review) => {
+                  if (!review) {
+                    return false;
+                  }
+                  const reviewAuthorType = (review.author?.__typename || "").trim();
                   const reviewAuthor = (review.author?.login || "").trim().toLowerCase();
+                  // GitHub currently returns the CodeRabbit Bot actor as `coderabbitai`;
+                  // tolerate the documented bot suffix without trusting a User actor.
+                  const normalizedAuthor = reviewAuthor.endsWith("[bot]")
+                    ? reviewAuthor.slice(0, -"[bot]".length)
+                    : reviewAuthor;
                   const reviewSha = (review.commit?.oid || "").trim();
-                  return coderabbitAuthors.has(reviewAuthor) && reviewSha === headSha;
+                  const reviewState = (review.state || "").trim().toUpperCase();
+                  // COMMENTED is non-decisive; the newest approval or change request wins.
+                  return reviewAuthorType === "Bot"
+                    && normalizedAuthor === "coderabbitai"
+                    && reviewSha === headSha
+                    && (reviewState === "APPROVED" || reviewState === "CHANGES_REQUESTED");
                 })
                 .sort((a, b) => parseTime(b.submittedAt) - parseTime(a.submittedAt))[0] || null;
             };

--- a/ops/receipts/2026-07-11/PROJ-1761/validation.md
+++ b/ops/receipts/2026-07-11/PROJ-1761/validation.md
@@ -1,16 +1,21 @@
 # PROJ-1761 validation receipt
 
-Date: 2026-07-11 (America/Los_Angeles)
+Date: 2026-07-12 (America/Los_Angeles)
 Repository: `andrewnordstrom-eng/bluesky-community-feed`
 Pull request: https://github.com/andrewnordstrom-eng/bluesky-community-feed/pull/340
 Validated implementation head before this receipt: `9ff14a7722c3c1509510f1ddb35aadb2e668a97e`
 
 ## Delivered behavior
 
-The CodeRabbit freshness workflow can use a complete exact-head review when the
-Actions token cannot observe CodeRabbit's third-party status or check suite. The
-fallback requires the CodeRabbit `Bot` actor, a normalized canonical login, the
-exact pull-request head commit, and complete review pagination.
+The CodeRabbit freshness workflow recognizes the exact-head `CodeRabbit` check
+run only when GitHub attributes it to the `coderabbitai` GitHub App. This covers
+the production API shape where the Actions token can list the check run but the
+corresponding check-suite query returns no CodeRabbit suite.
+
+If neither a legacy status nor that authenticated check run nor a check suite is
+visible, the workflow can use a complete exact-head review. The fallback
+requires the CodeRabbit `Bot` actor, a normalized canonical login, the exact
+pull-request head commit, and complete review pagination.
 
 Only an exact-head `APPROVED` review passes. `CHANGES_REQUESTED`, `COMMENTED`,
 `PENDING`, `DISMISSED`, a stale review, incomplete pagination, or ambiguous
@@ -28,12 +33,14 @@ The workflow harness executes the production script and covers:
   including fail-closed comment-only behavior;
 - newest-decisive-review ordering;
 - commit-status and GraphQL review pagination;
+- authenticated check-run success plus failure, neutral, skipped, pending, and
+  lookalike-app rejection;
 - nullable review data, a missing pull-request node, incomplete pagination,
   the 100-page safety bound, and GraphQL failure.
 
 ## Verification
 
-- Focused workflow harness: 22 tests passed.
+- Focused workflow harness: 29 tests passed.
 - `actionlint .github/workflows/coderabbit-freshness.yml`: passed.
 - `npm run build`: passed.
 - `npm run docs:verify`: passed.
@@ -53,5 +60,6 @@ No CodeRabbit exemption, synthetic status, duplicate raw review request,
 ruleset weakening, or break-glass merge was used. The repair changes only the
 freshness workflow, its executable regression harness, and this receipt.
 
-Current-head CodeRabbit approval, freshness, closeout, merge, and deployment
-remain pending. Merge remains subject to Andrew's separate approval.
+Current-head CodeRabbit freshness, closeout, merge, and deployment remain
+pending. Andrew approved end-to-end landing on 2026-07-12; repository gates
+remain authoritative.

--- a/ops/receipts/2026-07-11/PROJ-1761/validation.md
+++ b/ops/receipts/2026-07-11/PROJ-1761/validation.md
@@ -8,9 +8,11 @@ Validated implementation head before this receipt: `9ff14a7722c3c1509510f1ddb35a
 ## Delivered behavior
 
 The CodeRabbit freshness workflow recognizes the exact-head `CodeRabbit` check
-run only when GitHub attributes it to the `coderabbitai` GitHub App. This covers
-the production API shape where the Actions token can list the check run but the
-corresponding check-suite query returns no CodeRabbit suite.
+run only when GitHub attributes it to the `coderabbitai` GitHub App. It checks
+both the REST check-run endpoint and the exact commit's GraphQL status rollup.
+This covers the production API shape where the Actions token's REST check and
+check-suite queries hide the CodeRabbit result while GitHub's branch-protection
+rollup still exposes it.
 
 If neither a legacy status nor that authenticated check run nor a check suite is
 visible, the workflow can use a complete exact-head review. The fallback
@@ -35,12 +37,13 @@ The workflow harness executes the production script and covers:
 - commit-status and GraphQL review pagination;
 - authenticated check-run success plus failure, neutral, skipped, pending, and
   lookalike-app rejection;
+- exact-head status-rollup fallback and lookalike-app rejection;
 - nullable review data, a missing pull-request node, incomplete pagination,
   the 100-page safety bound, and GraphQL failure.
 
 ## Verification
 
-- Focused workflow harness: 29 tests passed.
+- Focused workflow harness: 31 tests passed.
 - `actionlint .github/workflows/coderabbit-freshness.yml`: passed.
 - `npm run build`: passed.
 - `npm run docs:verify`: passed.

--- a/ops/receipts/2026-07-11/PROJ-1761/validation.md
+++ b/ops/receipts/2026-07-11/PROJ-1761/validation.md
@@ -1,0 +1,57 @@
+# PROJ-1761 validation receipt
+
+Date: 2026-07-11 (America/Los_Angeles)
+Repository: `andrewnordstrom-eng/bluesky-community-feed`
+Pull request: https://github.com/andrewnordstrom-eng/bluesky-community-feed/pull/340
+Validated implementation head before this receipt: `9ff14a7722c3c1509510f1ddb35aadb2e668a97e`
+
+## Delivered behavior
+
+The CodeRabbit freshness workflow can use a complete exact-head review when the
+Actions token cannot observe CodeRabbit's third-party status or check suite. The
+fallback requires the CodeRabbit `Bot` actor, a normalized canonical login, the
+exact pull-request head commit, and complete review pagination.
+
+Only an exact-head `APPROVED` review passes. `CHANGES_REQUESTED`, `COMMENTED`,
+`PENDING`, `DISMISSED`, a stale review, incomplete pagination, or ambiguous
+author identity fails closed. The separately required
+`coderabbit-thread-check` remains authoritative for unresolved findings.
+
+## Failure coverage
+
+The workflow harness executes the production script and covers:
+
+- bare and suffixed CodeRabbit Bot identities, case normalization, and User
+  spoof rejection;
+- exact-head and stale-head review commits;
+- comment-only, approval, changes-requested, pending, and dismissed states,
+  including fail-closed comment-only behavior;
+- newest-decisive-review ordering;
+- commit-status and GraphQL review pagination;
+- nullable review data, a missing pull-request node, incomplete pagination,
+  the 100-page safety bound, and GraphQL failure.
+
+## Verification
+
+- Focused workflow harness: 22 tests passed.
+- `actionlint .github/workflows/coderabbit-freshness.yml`: passed.
+- `npm run build`: passed.
+- `npm run docs:verify`: passed.
+- Deterministic full suite after integrating current `main`: 138 files and
+  1,418 tests passed. HTTP-load tests ran with local loopback enabled.
+- Hosted checks for `9ff14a`: backend/frontend/report/docs CI, CodeQL, security,
+  quality, secret scan, Linear policy, internal-tooling hygiene, CodeRabbit
+  thread check, and Aikido thread check passed. CodeRabbit review and freshness
+  remain pending at receipt authoring time; this receipt does not claim the PR
+  is merge-ready.
+- Unresolved CodeRabbit threads: zero.
+- Current-head changes-requested rounds: zero.
+
+## Safety
+
+No CodeRabbit exemption, synthetic status, duplicate raw review request,
+ruleset weakening, or break-glass merge was used. The repair changes only the
+freshness workflow, its executable regression harness, and this receipt.
+
+Current-head CodeRabbit approval, freshness, closeout, merge, and deployment
+remain pending. Merge remains subject to Andrew's separate approval.

--- a/tests/coderabbit-freshness-workflow.test.ts
+++ b/tests/coderabbit-freshness-workflow.test.ts
@@ -1,0 +1,309 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+interface Review {
+  author: {
+    __typename: string;
+    login: string;
+  };
+  commit: {
+    oid: string;
+  };
+  state: string;
+  submittedAt: string;
+}
+
+interface ScenarioResult {
+  failures: string[];
+  notices: string[];
+  pageCount: number;
+}
+
+interface ReviewPage {
+  nodes: Array<Review | null>;
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+}
+
+type WorkflowExecutor = (
+  github: unknown,
+  context: unknown,
+  core: unknown,
+) => Promise<void>;
+
+const workflowUrl = new URL(
+  '../.github/workflows/coderabbit-freshness.yml',
+  import.meta.url,
+);
+const workflowLines = readFileSync(workflowUrl, 'utf8').split('\n');
+const scriptMarker = workflowLines.findIndex((line) => line.trim() === 'script: |');
+
+if (scriptMarker === -1) {
+  throw new Error('coderabbit-freshness workflow script block was not found');
+}
+
+const workflowScript = workflowLines
+  .slice(scriptMarker + 1)
+  .map((line) => (line.startsWith('            ') ? line.slice(12) : line))
+  .join('\n');
+const AsyncFunction = Object.getPrototypeOf(
+  async function workflowStub() {},
+).constructor as FunctionConstructor;
+const executeWorkflow = AsyncFunction(
+  'github',
+  'context',
+  'core',
+  workflowScript,
+) as WorkflowExecutor;
+
+function approvedReview(
+  sha: string,
+  login: string,
+  actorType: string,
+  state = 'APPROVED',
+  submittedAt = '2026-07-11T23:31:42Z',
+): Review {
+  return {
+    author: {
+      __typename: actorType,
+      login,
+    },
+    commit: {
+      oid: sha,
+    },
+    state,
+    submittedAt,
+  };
+}
+
+async function runScenario(
+  reviews: Array<Review | null>,
+  options: {
+    pages?: ReviewPage[];
+    graphqlError?: Error;
+  } = {},
+): Promise<ScenarioResult> {
+  const failures: string[] = [];
+  const notices: string[] = [];
+  let pageIndex = 0;
+  const listCommitStatusesForRef = (): undefined => undefined;
+  const listSuitesForRef = (): undefined => undefined;
+  const github = {
+    rest: {
+      pulls: {
+        get: async () => ({
+          data: {
+            number: 340,
+            state: 'open',
+            draft: false,
+            user: {
+              login: 'human',
+              type: 'User',
+            },
+            labels: [],
+            head: {
+              sha: 'head',
+            },
+          },
+        }),
+      },
+      repos: {
+        listCommitStatusesForRef,
+      },
+      checks: {
+        listSuitesForRef,
+      },
+    },
+    paginate: async (
+      method: unknown,
+      _args: unknown,
+      map: ((response: { data: { check_suites: unknown[] } }) => unknown) | undefined,
+    ) => {
+      if (method === listCommitStatusesForRef) {
+        return [];
+      }
+      if (method === listSuitesForRef) {
+        const response = {
+          data: {
+            check_suites: [],
+          },
+        };
+        return map === undefined ? response : map(response);
+      }
+      throw new Error('Unexpected pagination method in freshness workflow test');
+    },
+    graphql: async () => {
+      if (options.graphqlError !== undefined) {
+        throw options.graphqlError;
+      }
+      const page = options.pages?.[pageIndex] ?? {
+        nodes: reviews,
+        pageInfo: {
+          hasNextPage: false,
+          endCursor: null,
+        },
+      };
+      pageIndex += 1;
+      return {
+        repository: {
+          pullRequest: {
+            reviews: page,
+          },
+        },
+      };
+    },
+  };
+  const context = {
+    repo: {
+      owner: 'andrewnordstrom-eng',
+      repo: 'bluesky-community-feed',
+    },
+    payload: {
+      pull_request: {
+        number: 340,
+      },
+    },
+  };
+  const core = {
+    info: (_message: string): undefined => undefined,
+    notice: (message: string): void => {
+      notices.push(message);
+    },
+    setFailed: (message: string): void => {
+      failures.push(message);
+    },
+  };
+
+  await executeWorkflow(github, context, core);
+  return {
+    failures,
+    notices,
+    pageCount: pageIndex,
+  };
+}
+
+describe('coderabbit freshness exact-head review identity', () => {
+  it('accepts a bare coderabbitai login only for a Bot actor on the exact head', async () => {
+    const result = await runScenario([
+      approvedReview('head', 'coderabbitai', 'Bot'),
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.notices[0]).toMatch(/\[coderabbit-freshness:ok_review\]/);
+  });
+
+  it('rejects a User actor with the bare coderabbitai login', async () => {
+    const result = await runScenario([
+      approvedReview('head', 'coderabbitai', 'User'),
+    ]);
+
+    expect(result.failures[0]).toMatch(/exact-head review/);
+  });
+
+  it('accepts a mixed-case canonical bot login on the exact head', async () => {
+    const result = await runScenario([
+      approvedReview('head', 'CodeRabbitAI[bot]', 'Bot'),
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.notices[0]).toMatch(/\[coderabbit-freshness:ok_review\]/);
+  });
+
+  it('rejects a CodeRabbit Bot review attached to a non-head commit', async () => {
+    const result = await runScenario([
+      approvedReview('stale-head', 'coderabbitai', 'Bot'),
+    ]);
+
+    expect(result.failures[0]).toMatch(/exact-head review/);
+  });
+
+  it('accepts an exact-head comment-only review while leaving findings to the thread gate', async () => {
+    const result = await runScenario([
+      approvedReview('head', 'coderabbitai', 'Bot', 'COMMENTED'),
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.notices[0]).toMatch(/ok_review_comment_only/);
+  });
+
+  it('rejects a genuinely missing exact-head CodeRabbit review', async () => {
+    const result = await runScenario([]);
+
+    expect(result.failures[0]).toMatch(/Missing CodeRabbit status\/check-suite and exact-head review/);
+  });
+
+  it('rejects an exact-head changes-requested review', async () => {
+    const result = await runScenario([
+      approvedReview('head', 'coderabbitai', 'Bot', 'CHANGES_REQUESTED'),
+    ]);
+
+    expect(result.failures[0]).toMatch(/CHANGES_REQUESTED/);
+  });
+
+  it('uses the newest decisive exact-head state while ignoring a later comment', async () => {
+    const result = await runScenario([
+      approvedReview('head', 'coderabbitai', 'Bot', 'APPROVED', '2026-07-11T23:31:42Z'),
+      approvedReview('head', 'coderabbitai', 'Bot', 'COMMENTED', '2026-07-11T23:31:43Z'),
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.notices[0]).toMatch(/\[coderabbit-freshness:ok_review\]/);
+  });
+
+  it('rejects when a newer exact-head changes request supersedes approval', async () => {
+    const result = await runScenario([
+      approvedReview('head', 'coderabbitai', 'Bot', 'APPROVED', '2026-07-11T23:31:42Z'),
+      approvedReview('head', 'coderabbitai', 'Bot', 'CHANGES_REQUESTED', '2026-07-11T23:31:43Z'),
+    ]);
+
+    expect(result.failures[0]).toMatch(/CHANGES_REQUESTED/);
+  });
+
+  it('accepts when a newer exact-head approval supersedes changes requested', async () => {
+    const result = await runScenario([
+      approvedReview('head', 'coderabbitai', 'Bot', 'CHANGES_REQUESTED', '2026-07-11T23:31:42Z'),
+      approvedReview('head', 'coderabbitai', 'Bot', 'APPROVED', '2026-07-11T23:31:43Z'),
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.notices[0]).toMatch(/\[coderabbit-freshness:ok_review\]/);
+  });
+
+  it('paginates all reviews before trusting an exact-head approval', async () => {
+    const result = await runScenario([], {
+      pages: [
+        {
+          nodes: [null, approvedReview('stale-head', 'coderabbitai', 'Bot')],
+          pageInfo: { hasNextPage: true, endCursor: 'next-page' },
+        },
+        {
+          nodes: [approvedReview('head', 'coderabbitai', 'Bot')],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      ],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.pageCount).toBe(2);
+  });
+
+  it('fails closed when review pagination is incomplete', async () => {
+    const result = await runScenario([], {
+      pages: [{
+        nodes: [approvedReview('head', 'coderabbitai', 'Bot')],
+        pageInfo: { hasNextPage: true, endCursor: null },
+      }],
+    });
+
+    expect(result.failures[0]).toMatch(/pagination is incomplete/);
+  });
+
+  it('fails closed when the GraphQL review query rejects', async () => {
+    const result = await runScenario([], { graphqlError: new Error('GraphQL unavailable') });
+
+    expect(result.failures[0]).toMatch(/Could not verify complete exact-head CodeRabbit review truth/);
+    expect(result.failures[0]).toMatch(/GraphQL unavailable/);
+  });
+});

--- a/tests/coderabbit-freshness-workflow.test.ts
+++ b/tests/coderabbit-freshness-workflow.test.ts
@@ -35,11 +35,24 @@ interface CommitStatus {
   updated_at: string;
 }
 
+interface CheckRun {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  app: {
+    slug: string;
+  } | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
 interface ScenarioOptions {
   pages?: ReviewPage[];
   graphqlError?: Error;
   missingPullRequest?: boolean;
   statusPages?: CommitStatus[][];
+  checkRunPages?: CheckRun[][];
 }
 
 type WorkflowExecutor = (
@@ -116,6 +129,7 @@ async function runScenario(
   let pageIndex = 0;
   let statusPageCount = 0;
   const listCommitStatusesForRef = (): undefined => undefined;
+  const listForRef = (): undefined => undefined;
   const listSuitesForRef = (): undefined => undefined;
   const github = {
     rest: {
@@ -147,13 +161,19 @@ async function runScenario(
         listCommitStatusesForRef,
       },
       checks: {
+        listForRef,
         listSuitesForRef,
       },
     },
     paginate: async (
       method: unknown,
       args: unknown,
-      map: ((response: { data: { check_suites: unknown[] } }) => unknown) | undefined,
+      map: ((response: {
+        data: {
+          check_runs?: unknown[];
+          check_suites?: unknown[];
+        };
+      }) => unknown) | undefined,
     ) => {
       if (method === listCommitStatusesForRef) {
         expect(args).toEqual({
@@ -165,6 +185,20 @@ async function runScenario(
         const statusPages = options?.statusPages ?? [[]];
         statusPageCount = statusPages.length;
         return statusPages.flat();
+      }
+      if (method === listForRef) {
+        expect(args).toEqual({
+          owner: 'andrewnordstrom-eng',
+          repo: 'bluesky-community-feed',
+          ref: 'head',
+          per_page: 100,
+        });
+        const response = {
+          data: {
+            check_runs: (options?.checkRunPages ?? [[]]).flat(),
+          },
+        };
+        return map === undefined ? response : map(response);
       }
       if (method === listSuitesForRef) {
         expect(args).toEqual({
@@ -245,6 +279,101 @@ async function runScenario(
 }
 
 describe('coderabbit freshness exact-head review identity', () => {
+  it('accepts an exact-head successful check run from the CodeRabbit GitHub App', async () => {
+    const now = new Date().toISOString();
+    const result = await runScenario([], {
+      checkRunPages: [[{
+        name: 'CodeRabbit',
+        status: 'completed',
+        conclusion: 'success',
+        app: { slug: 'coderabbitai' },
+        created_at: now,
+        started_at: now,
+        completed_at: now,
+      }]],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.notices[0]).toMatch(/\[coderabbit-freshness:ok_run\]/);
+    expect(result.pageCount).toBe(0);
+  });
+
+  it.each(['failure', 'neutral', 'skipped'])(
+    'rejects a completed CodeRabbit check run with conclusion %s',
+    async (conclusion) => {
+      const now = new Date().toISOString();
+      const result = await runScenario([], {
+        checkRunPages: [[{
+          name: 'CodeRabbit',
+          status: 'completed',
+          conclusion,
+          app: { slug: 'coderabbitai' },
+          created_at: now,
+          started_at: now,
+          completed_at: now,
+        }]],
+      });
+
+      expect(result.failures[0]).toMatch(new RegExp(`check-run conclusion is ${conclusion}`));
+      expect(result.pageCount).toBe(0);
+    },
+  );
+
+  it('rejects a pending CodeRabbit check run instead of falling back to a review', async () => {
+    const now = new Date().toISOString();
+    const result = await runScenario([
+      approvedReview('head', 'coderabbitai', 'Bot'),
+    ], {
+      checkRunPages: [[{
+        name: 'CodeRabbit',
+        status: 'in_progress',
+        conclusion: null,
+        app: { slug: 'coderabbitai' },
+        created_at: now,
+        started_at: now,
+        completed_at: null,
+      }]],
+    });
+
+    expect(result.failures[0]).toMatch(/check-run is still in_progress/);
+    expect(result.pageCount).toBe(0);
+  });
+
+  it('rejects a stale pending CodeRabbit check run', async () => {
+    const stale = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    const result = await runScenario([], {
+      checkRunPages: [[{
+        name: 'CodeRabbit',
+        status: 'queued',
+        conclusion: null,
+        app: { slug: 'coderabbitai' },
+        created_at: stale,
+        started_at: stale,
+        completed_at: null,
+      }]],
+    });
+
+    expect(result.failures[0]).toMatch(/pending stale/);
+    expect(result.pageCount).toBe(0);
+  });
+
+  it('ignores lookalike check runs that are not owned by the CodeRabbit GitHub App', async () => {
+    const now = new Date().toISOString();
+    const result = await runScenario([], {
+      checkRunPages: [[{
+        name: 'CodeRabbit',
+        status: 'completed',
+        conclusion: 'success',
+        app: { slug: 'untrusted-app' },
+        created_at: now,
+        started_at: now,
+        completed_at: now,
+      }]],
+    });
+
+    expect(result.failures[0]).toMatch(/exact-head review/);
+  });
+
   it('accepts a bare coderabbitai login only for a Bot actor on the exact head', async () => {
     const result = await runScenario([
       approvedReview('head', 'coderabbitai', 'Bot'),

--- a/tests/coderabbit-freshness-workflow.test.ts
+++ b/tests/coderabbit-freshness-workflow.test.ts
@@ -279,7 +279,7 @@ describe('coderabbit freshness exact-head review identity', () => {
     expect(result.failures[0]).toMatch(/exact-head review/);
   });
 
-  it('accepts an exact-head comment-only review while leaving findings to the thread gate', async () => {
+  it('fails closed on an exact-head comment-only review', async () => {
     const result = await runScenario([
       review(
         'head',
@@ -290,8 +290,7 @@ describe('coderabbit freshness exact-head review identity', () => {
       ),
     ]);
 
-    expect(result.failures).toEqual([]);
-    expect(result.notices[0]).toMatch(/ok_review_comment_only/);
+    expect(result.failures[0]).toMatch(/no decisive APPROVED\/CHANGES_REQUESTED state/);
   });
 
   it('rejects a genuinely missing exact-head CodeRabbit review', async () => {
@@ -409,7 +408,7 @@ describe('coderabbit freshness exact-head review identity', () => {
         ),
       ]);
 
-      expect(result.failures[0]).toMatch(/no acceptable APPROVED\/CHANGES_REQUESTED\/COMMENTED state/);
+      expect(result.failures[0]).toMatch(/no decisive APPROVED\/CHANGES_REQUESTED state/);
     },
   );
 

--- a/tests/coderabbit-freshness-workflow.test.ts
+++ b/tests/coderabbit-freshness-workflow.test.ts
@@ -5,26 +5,41 @@ interface Review {
   author: {
     __typename: string;
     login: string;
-  };
+  } | null;
   commit: {
     oid: string;
-  };
-  state: string;
-  submittedAt: string;
+  } | null;
+  state: string | null;
+  submittedAt: string | null;
 }
 
 interface ScenarioResult {
   failures: string[];
   notices: string[];
   pageCount: number;
+  statusPageCount: number;
 }
 
 interface ReviewPage {
-  nodes: Array<Review | null>;
+  nodes: Array<Review | null | undefined>;
   pageInfo: {
     hasNextPage: boolean;
     endCursor: string | null;
   };
+}
+
+interface CommitStatus {
+  context: string;
+  state: string;
+  description: string;
+  updated_at: string;
+}
+
+interface ScenarioOptions {
+  pages?: ReviewPage[];
+  graphqlError?: Error;
+  missingPullRequest?: boolean;
+  statusPages?: CommitStatus[][];
 }
 
 type WorkflowExecutor = (
@@ -62,8 +77,22 @@ function approvedReview(
   sha: string,
   login: string,
   actorType: string,
-  state = 'APPROVED',
-  submittedAt = '2026-07-11T23:31:42Z',
+): Review {
+  return review(
+    sha,
+    login,
+    actorType,
+    'APPROVED',
+    '2026-07-11T23:31:42Z',
+  );
+}
+
+function review(
+  sha: string,
+  login: string,
+  actorType: string,
+  state: string,
+  submittedAt: string,
 ): Review {
   return {
     author: {
@@ -79,35 +108,40 @@ function approvedReview(
 }
 
 async function runScenario(
-  reviews: Array<Review | null>,
-  options: {
-    pages?: ReviewPage[];
-    graphqlError?: Error;
-  } = {},
+  reviews: Array<Review | null | undefined>,
+  options?: ScenarioOptions,
 ): Promise<ScenarioResult> {
   const failures: string[] = [];
   const notices: string[] = [];
   let pageIndex = 0;
+  let statusPageCount = 0;
   const listCommitStatusesForRef = (): undefined => undefined;
   const listSuitesForRef = (): undefined => undefined;
   const github = {
     rest: {
       pulls: {
-        get: async () => ({
-          data: {
-            number: 340,
-            state: 'open',
-            draft: false,
-            user: {
-              login: 'human',
-              type: 'User',
+        get: async (args: unknown) => {
+          expect(args).toEqual({
+            owner: 'andrewnordstrom-eng',
+            repo: 'bluesky-community-feed',
+            pull_number: 340,
+          });
+          return {
+            data: {
+              number: 340,
+              state: 'open',
+              draft: false,
+              user: {
+                login: 'human',
+                type: 'User',
+              },
+              labels: [],
+              head: {
+                sha: 'head',
+              },
             },
-            labels: [],
-            head: {
-              sha: 'head',
-            },
-          },
-        }),
+          };
+        },
       },
       repos: {
         listCommitStatusesForRef,
@@ -118,13 +152,27 @@ async function runScenario(
     },
     paginate: async (
       method: unknown,
-      _args: unknown,
+      args: unknown,
       map: ((response: { data: { check_suites: unknown[] } }) => unknown) | undefined,
     ) => {
       if (method === listCommitStatusesForRef) {
-        return [];
+        expect(args).toEqual({
+          owner: 'andrewnordstrom-eng',
+          repo: 'bluesky-community-feed',
+          ref: 'head',
+          per_page: 100,
+        });
+        const statusPages = options?.statusPages ?? [[]];
+        statusPageCount = statusPages.length;
+        return statusPages.flat();
       }
       if (method === listSuitesForRef) {
+        expect(args).toEqual({
+          owner: 'andrewnordstrom-eng',
+          repo: 'bluesky-community-feed',
+          ref: 'head',
+          per_page: 100,
+        });
         const response = {
           data: {
             check_suites: [],
@@ -134,11 +182,22 @@ async function runScenario(
       }
       throw new Error('Unexpected pagination method in freshness workflow test');
     },
-    graphql: async () => {
-      if (options.graphqlError !== undefined) {
+    graphql: async (query: unknown, variables: unknown) => {
+      expect(query).toEqual(expect.stringContaining('author { __typename login }'));
+      expect(query).toEqual(expect.stringContaining('reviews(first: 100, after: $after)'));
+      const priorCursor = pageIndex === 0
+        ? null
+        : options?.pages?.[pageIndex - 1]?.pageInfo.endCursor ?? null;
+      expect(variables).toEqual({
+        owner: 'andrewnordstrom-eng',
+        repo: 'bluesky-community-feed',
+        prNumber: 340,
+        after: priorCursor,
+      });
+      if (options?.graphqlError !== undefined) {
         throw options.graphqlError;
       }
-      const page = options.pages?.[pageIndex] ?? {
+      const page = options?.pages?.[pageIndex] ?? {
         nodes: reviews,
         pageInfo: {
           hasNextPage: false,
@@ -148,7 +207,7 @@ async function runScenario(
       pageIndex += 1;
       return {
         repository: {
-          pullRequest: {
+          pullRequest: options?.missingPullRequest === true ? null : {
             reviews: page,
           },
         },
@@ -181,6 +240,7 @@ async function runScenario(
     failures,
     notices,
     pageCount: pageIndex,
+    statusPageCount,
   };
 }
 
@@ -221,7 +281,13 @@ describe('coderabbit freshness exact-head review identity', () => {
 
   it('accepts an exact-head comment-only review while leaving findings to the thread gate', async () => {
     const result = await runScenario([
-      approvedReview('head', 'coderabbitai', 'Bot', 'COMMENTED'),
+      review(
+        'head',
+        'coderabbitai',
+        'Bot',
+        'COMMENTED',
+        '2026-07-11T23:31:42Z',
+      ),
     ]);
 
     expect(result.failures).toEqual([]);
@@ -236,7 +302,13 @@ describe('coderabbit freshness exact-head review identity', () => {
 
   it('rejects an exact-head changes-requested review', async () => {
     const result = await runScenario([
-      approvedReview('head', 'coderabbitai', 'Bot', 'CHANGES_REQUESTED'),
+      review(
+        'head',
+        'coderabbitai',
+        'Bot',
+        'CHANGES_REQUESTED',
+        '2026-07-11T23:31:42Z',
+      ),
     ]);
 
     expect(result.failures[0]).toMatch(/CHANGES_REQUESTED/);
@@ -244,8 +316,8 @@ describe('coderabbit freshness exact-head review identity', () => {
 
   it('uses the newest decisive exact-head state while ignoring a later comment', async () => {
     const result = await runScenario([
-      approvedReview('head', 'coderabbitai', 'Bot', 'APPROVED', '2026-07-11T23:31:42Z'),
-      approvedReview('head', 'coderabbitai', 'Bot', 'COMMENTED', '2026-07-11T23:31:43Z'),
+      review('head', 'coderabbitai', 'Bot', 'APPROVED', '2026-07-11T23:31:42Z'),
+      review('head', 'coderabbitai', 'Bot', 'COMMENTED', '2026-07-11T23:31:43Z'),
     ]);
 
     expect(result.failures).toEqual([]);
@@ -254,8 +326,8 @@ describe('coderabbit freshness exact-head review identity', () => {
 
   it('rejects when a newer exact-head changes request supersedes approval', async () => {
     const result = await runScenario([
-      approvedReview('head', 'coderabbitai', 'Bot', 'APPROVED', '2026-07-11T23:31:42Z'),
-      approvedReview('head', 'coderabbitai', 'Bot', 'CHANGES_REQUESTED', '2026-07-11T23:31:43Z'),
+      review('head', 'coderabbitai', 'Bot', 'APPROVED', '2026-07-11T23:31:42Z'),
+      review('head', 'coderabbitai', 'Bot', 'CHANGES_REQUESTED', '2026-07-11T23:31:43Z'),
     ]);
 
     expect(result.failures[0]).toMatch(/CHANGES_REQUESTED/);
@@ -263,8 +335,8 @@ describe('coderabbit freshness exact-head review identity', () => {
 
   it('accepts when a newer exact-head approval supersedes changes requested', async () => {
     const result = await runScenario([
-      approvedReview('head', 'coderabbitai', 'Bot', 'CHANGES_REQUESTED', '2026-07-11T23:31:42Z'),
-      approvedReview('head', 'coderabbitai', 'Bot', 'APPROVED', '2026-07-11T23:31:43Z'),
+      review('head', 'coderabbitai', 'Bot', 'CHANGES_REQUESTED', '2026-07-11T23:31:42Z'),
+      review('head', 'coderabbitai', 'Bot', 'APPROVED', '2026-07-11T23:31:43Z'),
     ]);
 
     expect(result.failures).toEqual([]);
@@ -287,6 +359,78 @@ describe('coderabbit freshness exact-head review identity', () => {
 
     expect(result.failures).toEqual([]);
     expect(result.pageCount).toBe(2);
+  });
+
+  it('flattens paginated commit statuses before review fallback', async () => {
+    const result = await runScenario([], {
+      statusPages: [
+        [{
+          context: 'unrelated-check',
+          state: 'success',
+          description: '',
+          updated_at: '2026-07-11T23:31:41Z',
+        }],
+        [{
+          context: 'CodeRabbit',
+          state: 'success',
+          description: '',
+          updated_at: '2026-07-11T23:31:42Z',
+        }],
+      ],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.notices[0]).toMatch(/ok_status/);
+    expect(result.statusPageCount).toBe(2);
+    expect(result.pageCount).toBe(0);
+  });
+
+  it.each([
+    ['null node', null],
+    ['undefined node', undefined],
+    ['null author', { ...approvedReview('head', 'coderabbitai', 'Bot'), author: null }],
+    ['null commit', { ...approvedReview('head', 'coderabbitai', 'Bot'), commit: null }],
+  ])('rejects malformed nullable review data: %s', async (_name, malformedReview) => {
+    const result = await runScenario([malformedReview]);
+
+    expect(result.failures[0]).toMatch(/exact-head review/);
+  });
+
+  it.each(['PENDING', 'DISMISSED'])(
+    'fails closed on unsupported exact-head review state %s',
+    async (state) => {
+      const result = await runScenario([
+        review(
+          'head',
+          'coderabbitai',
+          'Bot',
+          state,
+          '2026-07-11T23:31:42Z',
+        ),
+      ]);
+
+      expect(result.failures[0]).toMatch(/no acceptable APPROVED\/CHANGES_REQUESTED\/COMMENTED state/);
+    },
+  );
+
+  it('fails closed when review pagination reaches the safety bound', async () => {
+    const pages = Array.from({ length: 100 }, (_value, index): ReviewPage => ({
+      nodes: [],
+      pageInfo: {
+        hasNextPage: true,
+        endCursor: `page-${index + 1}`,
+      },
+    }));
+    const result = await runScenario([], { pages });
+
+    expect(result.failures[0]).toMatch(/exceeded the 100-page safety bound/);
+    expect(result.pageCount).toBe(100);
+  });
+
+  it('fails closed when the review query does not return the pull request', async () => {
+    const result = await runScenario([], { missingPullRequest: true });
+
+    expect(result.failures[0]).toMatch(/PR #340 was not returned by the review query/);
   });
 
   it('fails closed when review pagination is incomplete', async () => {

--- a/tests/coderabbit-freshness-workflow.test.ts
+++ b/tests/coderabbit-freshness-workflow.test.ts
@@ -47,12 +47,36 @@ interface CheckRun {
   completed_at: string | null;
 }
 
+interface RollupCheckRun {
+  __typename: 'CheckRun';
+  name: string;
+  status: string;
+  conclusion: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  checkSuite: {
+    app: {
+      slug: string;
+    } | null;
+  } | null;
+}
+
+interface RollupPage {
+  nodes: Array<RollupCheckRun | null | undefined>;
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+}
+
 interface ScenarioOptions {
   pages?: ReviewPage[];
   graphqlError?: Error;
   missingPullRequest?: boolean;
   statusPages?: CommitStatus[][];
   checkRunPages?: CheckRun[][];
+  rollupPages?: RollupPage[];
+  rollupError?: Error;
 }
 
 type WorkflowExecutor = (
@@ -127,6 +151,7 @@ async function runScenario(
   const failures: string[] = [];
   const notices: string[] = [];
   let pageIndex = 0;
+  let rollupPageIndex = 0;
   let statusPageCount = 0;
   const listCommitStatusesForRef = (): undefined => undefined;
   const listForRef = (): undefined => undefined;
@@ -217,6 +242,38 @@ async function runScenario(
       throw new Error('Unexpected pagination method in freshness workflow test');
     },
     graphql: async (query: unknown, variables: unknown) => {
+      if (typeof query === 'string' && query.includes('statusCheckRollup')) {
+        const priorCursor = rollupPageIndex === 0
+          ? null
+          : options?.rollupPages?.[rollupPageIndex - 1]?.pageInfo.endCursor ?? null;
+        expect(variables).toEqual({
+          owner: 'andrewnordstrom-eng',
+          repo: 'bluesky-community-feed',
+          headSha: 'head',
+          after: priorCursor,
+        });
+        if (options?.rollupError !== undefined) {
+          throw options.rollupError;
+        }
+        const page = options?.rollupPages?.[rollupPageIndex] ?? {
+          nodes: [],
+          pageInfo: {
+            hasNextPage: false,
+            endCursor: null,
+          },
+        };
+        rollupPageIndex += 1;
+        return {
+          repository: {
+            object: {
+              oid: 'head',
+              statusCheckRollup: {
+                contexts: page,
+              },
+            },
+          },
+        };
+      }
       expect(query).toEqual(expect.stringContaining('author { __typename login }'));
       expect(query).toEqual(expect.stringContaining('reviews(first: 100, after: $after)'));
       const priorCursor = pageIndex === 0
@@ -279,6 +336,48 @@ async function runScenario(
 }
 
 describe('coderabbit freshness exact-head review identity', () => {
+  it('accepts the authenticated CodeRabbit check run from the exact-head status rollup', async () => {
+    const now = new Date().toISOString();
+    const result = await runScenario([], {
+      rollupPages: [{
+        nodes: [{
+          __typename: 'CheckRun',
+          name: 'CodeRabbit',
+          status: 'COMPLETED',
+          conclusion: 'SUCCESS',
+          startedAt: now,
+          completedAt: now,
+          checkSuite: { app: { slug: 'coderabbitai' } },
+        }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      }],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.notices[0]).toMatch(/\[coderabbit-freshness:ok_run\]/);
+    expect(result.pageCount).toBe(0);
+  });
+
+  it('ignores a status-rollup lookalike not owned by the CodeRabbit GitHub App', async () => {
+    const now = new Date().toISOString();
+    const result = await runScenario([], {
+      rollupPages: [{
+        nodes: [{
+          __typename: 'CheckRun',
+          name: 'CodeRabbit',
+          status: 'COMPLETED',
+          conclusion: 'SUCCESS',
+          startedAt: now,
+          completedAt: now,
+          checkSuite: { app: { slug: 'untrusted-app' } },
+        }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      }],
+    });
+
+    expect(result.failures[0]).toMatch(/exact-head review/);
+  });
+
   it('accepts an exact-head successful check run from the CodeRabbit GitHub App', async () => {
     const now = new Date().toISOString();
     const result = await runScenario([], {


### PR DESCRIPTION
## What changed

- keep the existing CodeRabbit commit-status and check-suite freshness paths
- when the workflow token cannot see either signal, paginate all PR reviews and accept only the latest CodeRabbit review whose commit OID exactly matches the PR head and whose state is `APPROVED`
- fail closed on stale-head reviews, changes requested, lookalike authors, missing reviews, incomplete pagination, or query failures
- replace the raw review-comment instruction with the sanctioned review-readiness/request wrappers

## Why

PR #338 has a successful CodeRabbit suite, an exact-head approved review, and zero unresolved threads, but the required freshness workflow's `GITHUB_TOKEN` cannot see the third-party suite. Two reruns failed identically. This aligns the public repository's local workflow with the authoritative exact-head truth already used by the org wrappers without weakening the separate thread gate.

## Validation

- `actionlint .github/workflows/coderabbit-freshness.yml`
- seven-scenario execution harness: visible suite, exact-head approval, paginated approval, stale-head rejection, changes-requested rejection, lookalike-author rejection, incomplete-pagination rejection
- `npm run build`
- `npm run docs:verify`
- `git diff --check`
- staged-path lease validation
- local CodeRabbit review completed with no HIGH/MEDIUM issues; one trivial backward-pagination suggestion was intentionally not applied because this packet requires complete pagination before trusting review truth

## Non-goals

No ruleset weakening, fake status/check creation, exemption label, duplicate review request, or product-code change.

Linear: [PROJ-1761](https://linear.app/andrewnord/issue/PROJ-1761/ci-make-corgi-coderabbit-freshness-trust-exact-head-approved-review)

Blocks: #338