### PR TITLE
[PROJ-1766] Build coherent corgi-ranking-v2 shadow pipeline

### DIFF
--- a/examples/civility-component/tsconfig.json
+++ b/examples/civility-component/tsconfig.json
@@ -12,7 +12,7 @@
     "declaration": true,
     "isolatedModules": true,
     "noEmitOnError": true,
-    "baseUrl": ".",
+    "types": ["node"],
     "paths": {
       "@corgi/feed-sdk": ["../../packages/feed-sdk/dist/index.d.ts"]
     }

--- a/packages/feed-sdk/src/index.ts
+++ b/packages/feed-sdk/src/index.ts
@@ -32,11 +32,11 @@ export interface ScoringComponent {
   readonly name: string;
   /** Score the post in 0..1. */
   score(post: PostForScoring, context: ScoringContext): Promise<number>;
-  /** Optional efficient scoring path for one immutable candidate batch. */
+  /** Optional efficient scoring path keyed by `${uri}\0${createdAt.toISOString()}`. */
   scoreBatch?(
     posts: readonly PostForScoring[],
     context: ScoringContext
-  ): Promise<ReadonlyMap<PostForScoring, number>>;
+  ): Promise<ReadonlyMap<string, number>>;
 }
 
 /**

--- a/packages/feed-sdk/src/index.ts
+++ b/packages/feed-sdk/src/index.ts
@@ -32,6 +32,11 @@ export interface ScoringComponent {
   readonly name: string;
   /** Score the post in 0..1. */
   score(post: PostForScoring, context: ScoringContext): Promise<number>;
+  /** Optional efficient scoring path for one immutable candidate batch. */
+  scoreBatch?(
+    posts: readonly PostForScoring[],
+    context: ScoringContext
+  ): Promise<ReadonlyMap<PostForScoring, number>>;
 }
 
 /**
@@ -42,8 +47,16 @@ export interface ScoringComponent {
 export interface ScoringContext {
   readonly epoch: GovernanceEpoch;
   readonly scoringWindowHours: number;
+  /** Immutable ranking clock. Required by coherent ranking runs. */
+  readonly asOf?: Date;
   /** Mutable map shared across components in a single run. */
   readonly authorCounts: Map<string, number>;
+}
+
+/** A governed slate-level objective evaluated during final selection. */
+export interface SlateReranker<TInput, TOutput> {
+  readonly key: string;
+  rerank(items: readonly TInput[], limit: number): readonly TOutput[];
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/scoring/component.interface.ts
+++ b/src/scoring/component.interface.ts
@@ -45,11 +45,11 @@ export interface ScoringComponent {
   readonly name: string;
   /** Score a post. Must return a value between 0.0 and 1.0. */
   score(post: PostForScoring, context: ScoringContext): Promise<number>;
-  /** Optional efficient path for components that can score a whole run at once. */
+  /** Optional efficient path keyed by `${uri}\0${createdAt.toISOString()}`. */
   scoreBatch?(
     posts: readonly PostForScoring[],
     context: ScoringContext
-  ): Promise<ReadonlyMap<PostForScoring, number>>;
+  ): Promise<ReadonlyMap<string, number>>;
 }
 
 export interface SlateReranker<TInput, TOutput> {

--- a/src/scoring/component.interface.ts
+++ b/src/scoring/component.interface.ts
@@ -21,6 +21,8 @@ import type { GovernanceWeightKey } from '../config/votable-params.js';
 export interface ScoringContext {
   readonly epoch: GovernanceEpoch;
   readonly scoringWindowHours: number;
+  /** Immutable ranking clock. V2 always supplies this; optional for legacy adapters. */
+  readonly asOf?: Date;
   /** Mutable map shared across components in a single run. */
   readonly authorCounts: Map<string, number>;
   /**
@@ -43,4 +45,14 @@ export interface ScoringComponent {
   readonly name: string;
   /** Score a post. Must return a value between 0.0 and 1.0. */
   score(post: PostForScoring, context: ScoringContext): Promise<number>;
+  /** Optional efficient path for components that can score a whole run at once. */
+  scoreBatch?(
+    posts: readonly PostForScoring[],
+    context: ScoringContext
+  ): Promise<ReadonlyMap<PostForScoring, number>>;
+}
+
+export interface SlateReranker<TInput, TOutput> {
+  readonly key: string;
+  rerank(items: readonly TInput[], limit: number): readonly TOutput[];
 }

--- a/src/scoring/components/bridging.ts
+++ b/src/scoring/components/bridging.ts
@@ -131,6 +131,7 @@ export async function scoreBridging(
   return Math.min(1.0, avgDistance);
 }
 
+/** Batch the engager and follow reads for all candidates in one ranking run. */
 export async function scoreBridgingBatch(
   client: PoolClient,
   posts: readonly PostForScoring[]
@@ -201,6 +202,7 @@ export async function scoreBridgingBatch(
   return output;
 }
 
+/** Compute bridging evidence from deterministic engager and follow-set inputs. */
 export function calculateBridgingEvidence(
   engagers: readonly string[],
   followSets: ReadonlyMap<string, ReadonlySet<string>>

--- a/src/scoring/components/bridging.ts
+++ b/src/scoring/components/bridging.ts
@@ -17,7 +17,10 @@
  * This is designed to be pluggable - swap the implementation later.
  */
 
+import type { PoolClient } from 'pg';
 import { db } from '../../db/client.js';
+import type { ScoringComponent } from '../component.interface.js';
+import type { PostForScoring } from '../score.types.js';
 
 /** Maximum engagers to consider (performance limit) */
 const MAX_ENGAGERS = 50;
@@ -33,6 +36,23 @@ const DEFAULT_BRIDGING_SCORE = 0.3;
 
 /** Minimum engagers needed for meaningful bridging calculation */
 const MIN_ENGAGERS = 2;
+
+export interface BridgingScoreEvidence {
+  raw: number;
+  evidenceState: 'observed' | 'insufficient';
+  engagerCount: number;
+  pairCount: number;
+}
+
+interface EngagerRow {
+  post_uri: string;
+  author_did: string;
+}
+
+interface FollowRow {
+  author_did: string;
+  subject_did: string;
+}
 
 /**
  * Calculate bridging score for a post.
@@ -52,6 +72,7 @@ export async function scoreBridging(
        UNION ALL
        SELECT author_did FROM reposts WHERE subject_uri = $1 AND deleted = FALSE
      ) AS engagers
+     ORDER BY author_did
      LIMIT $2`,
     [postUri, MAX_ENGAGERS]
   );
@@ -71,7 +92,10 @@ export async function scoreBridging(
 
   for (const did of engagersToCompare) {
     const follows = await db.query(
-      `SELECT subject_did FROM follows WHERE author_did = $1 AND deleted = FALSE LIMIT $2`,
+      `SELECT subject_did FROM follows
+        WHERE author_did = $1 AND deleted = FALSE
+        ORDER BY subject_did
+        LIMIT $2`,
       [did, MAX_FOLLOWS_PER_ENGAGER]
     );
     followSets.set(
@@ -107,6 +131,115 @@ export async function scoreBridging(
   return Math.min(1.0, avgDistance);
 }
 
+export async function scoreBridgingBatch(
+  client: PoolClient,
+  posts: readonly PostForScoring[]
+): Promise<ReadonlyMap<string, BridgingScoreEvidence>> {
+  if (posts.length === 0) {
+    return new Map();
+  }
+  const uris = [...new Set(posts.map((post) => post.uri))];
+  const engagerResult = await client.query<EngagerRow>(
+    `WITH combined AS (
+       SELECT subject_uri AS post_uri, author_did FROM likes
+        WHERE subject_uri = ANY($1::text[]) AND deleted = FALSE
+       UNION
+       SELECT subject_uri AS post_uri, author_did FROM reposts
+        WHERE subject_uri = ANY($1::text[]) AND deleted = FALSE
+     ), ranked AS (
+       SELECT post_uri, author_did,
+              ROW_NUMBER() OVER (PARTITION BY post_uri ORDER BY author_did) AS ordinal
+         FROM combined
+     )
+     SELECT post_uri, author_did
+       FROM ranked
+      WHERE ordinal <= $2
+      ORDER BY post_uri, author_did`,
+    [uris, MAX_ENGAGERS]
+  );
+  const engagersByUri = new Map<string, string[]>();
+  for (const row of engagerResult.rows) {
+    const engagers = engagersByUri.get(row.post_uri) ?? [];
+    engagers.push(row.author_did);
+    engagersByUri.set(row.post_uri, engagers);
+  }
+
+  const comparisonDids = [...new Set(
+    [...engagersByUri.values()].flatMap((engagers) => engagers.slice(0, MAX_PAIRWISE_ENGAGERS))
+  )];
+  const followSets = new Map<string, Set<string>>();
+  if (comparisonDids.length > 0) {
+    const followResult = await client.query<FollowRow>(
+      `WITH ranked AS (
+         SELECT author_did, subject_did,
+                ROW_NUMBER() OVER (PARTITION BY author_did ORDER BY subject_did) AS ordinal
+           FROM follows
+          WHERE author_did = ANY($1::text[]) AND deleted = FALSE
+       )
+       SELECT author_did, subject_did
+         FROM ranked
+        WHERE ordinal <= $2
+        ORDER BY author_did, subject_did`,
+      [comparisonDids, MAX_FOLLOWS_PER_ENGAGER]
+    );
+    for (const did of comparisonDids) {
+      followSets.set(did, new Set());
+    }
+    for (const row of followResult.rows) {
+      followSets.get(row.author_did)?.add(row.subject_did);
+    }
+  }
+
+  const output = new Map<string, BridgingScoreEvidence>();
+  for (const post of posts) {
+    const engagers = engagersByUri.get(post.uri) ?? [];
+    output.set(
+      `${post.uri}\u0000${post.createdAt.toISOString()}`,
+      calculateBridgingEvidence(engagers, followSets)
+    );
+  }
+  return output;
+}
+
+export function calculateBridgingEvidence(
+  engagers: readonly string[],
+  followSets: ReadonlyMap<string, ReadonlySet<string>>
+): BridgingScoreEvidence {
+  if (engagers.length < MIN_ENGAGERS) {
+    return {
+      raw: DEFAULT_BRIDGING_SCORE,
+      evidenceState: 'insufficient',
+      engagerCount: engagers.length,
+      pairCount: 0,
+    };
+  }
+  const selected = engagers.slice(0, MAX_PAIRWISE_ENGAGERS);
+  let totalDistance = 0;
+  let pairCount = 0;
+  for (let left = 0; left < selected.length; left += 1) {
+    for (let right = left + 1; right < selected.length; right += 1) {
+      const leftSet = followSets.get(selected[left]) ?? new Set<string>();
+      const rightSet = followSets.get(selected[right]) ?? new Set<string>();
+      totalDistance += jaccardDistance(leftSet, rightSet);
+      pairCount += 1;
+    }
+  }
+  if (pairCount === 0) {
+    return {
+      raw: DEFAULT_BRIDGING_SCORE,
+      evidenceState: 'insufficient',
+      engagerCount: engagers.length,
+      pairCount,
+    };
+  }
+  return {
+    raw: Math.min(1, totalDistance / pairCount),
+    evidenceState: 'observed',
+    engagerCount: engagers.length,
+    pairCount,
+  };
+}
+
 /**
  * Calculate Jaccard distance between two sets.
  * Jaccard distance = 1 - (|A ∩ B| / |A ∪ B|)
@@ -115,7 +248,7 @@ export async function scoreBridging(
  * @param setB - Second set
  * @returns Distance between 0.0 (identical) and 1.0 (completely disjoint)
  */
-function jaccardDistance(setA: Set<string>, setB: Set<string>): number {
+function jaccardDistance(setA: ReadonlySet<string>, setB: ReadonlySet<string>): number {
   if (setA.size === 0 && setB.size === 0) {
     // Both empty - consider as identical
     return 0;
@@ -139,8 +272,6 @@ function jaccardDistance(setA: Set<string>, setB: Set<string>): number {
   const similarity = intersectionSize / unionSize;
   return 1 - similarity;
 }
-
-import type { ScoringComponent } from '../component.interface.js';
 
 /** ScoringComponent wrapper for the bridging scorer. */
 export const bridgingComponent: ScoringComponent = {

--- a/src/scoring/components/recency.ts
+++ b/src/scoring/components/recency.ts
@@ -26,6 +26,7 @@ export function scoreRecency(createdAt: Date | string, windowHours: number): num
   return scoreRecencyAt(createdAt, windowHours, new Date());
 }
 
+/** Calculate recency against the ranking run's immutable clock. */
 export function scoreRecencyAt(
   createdAt: Date | string,
   windowHours: number,

--- a/src/scoring/components/recency.ts
+++ b/src/scoring/components/recency.ts
@@ -23,8 +23,22 @@ import type { ScoringComponent } from '../component.interface.js';
  * @returns Score between 0.0 and 1.0 (newer = higher)
  */
 export function scoreRecency(createdAt: Date | string, windowHours: number): number {
+  return scoreRecencyAt(createdAt, windowHours, new Date());
+}
+
+export function scoreRecencyAt(
+  createdAt: Date | string,
+  windowHours: number,
+  asOf: Date | string
+): number {
   const postTime = new Date(createdAt).getTime();
-  const now = Date.now();
+  const now = new Date(asOf).getTime();
+  if (!Number.isFinite(postTime) || !Number.isFinite(now)) {
+    throw new RangeError(`Invalid recency timestamp: createdAt=${String(createdAt)}, asOf=${String(asOf)}`);
+  }
+  if (!Number.isFinite(windowHours) || windowHours <= 0) {
+    throw new RangeError(`windowHours must be positive, got ${windowHours}`);
+  }
   const ageHours = (now - postTime) / (1000 * 60 * 60);
 
   // Handle edge cases
@@ -51,6 +65,10 @@ export const recencyComponent: ScoringComponent = {
   key: 'recency',
   name: 'Recency',
   async score(post, context) {
-    return scoreRecency(post.createdAt, context.scoringWindowHours);
+    return scoreRecencyAt(
+      post.createdAt,
+      context.scoringWindowHours,
+      context.asOf ?? new Date()
+    );
   },
 };

--- a/src/scoring/ranking-v2-candidates.ts
+++ b/src/scoring/ranking-v2-candidates.ts
@@ -1,0 +1,214 @@
+import type { CandidateSource } from '../shared/ranking-contracts.js';
+import type { PostForScoring } from './score.types.js';
+
+export const RANKING_V2_CANDIDATE_LIMITS = {
+  newest: 1500,
+  engagement: 1500,
+  policyRelevance: 1500,
+  previousSnapshot: 500,
+  total: 5000,
+} as const;
+
+const SOURCE_ORDER: readonly CandidateSource[] = [
+  'newest',
+  'engagement',
+  'policy_relevance',
+  'previous_snapshot',
+  'preliminary_fill',
+];
+
+export interface RankingV2CandidateInput {
+  post: PostForScoring;
+  policyRelevance: number;
+  previousSnapshotPosition: number | null;
+  preliminaryScore: number;
+}
+
+export interface RankingV2Candidate extends RankingV2CandidateInput {
+  candidateSources: readonly CandidateSource[];
+}
+
+export function buildCandidateUnion(
+  inputs: readonly RankingV2CandidateInput[]
+): readonly RankingV2Candidate[] {
+  for (const input of inputs) {
+    validateInput(input);
+  }
+  const deduplicated = deduplicateInputs(inputs);
+  const selected = new Map<string, MutableCandidate>();
+
+  addRanked(selected, deduplicated, 'newest', RANKING_V2_CANDIDATE_LIMITS.newest, compareNewest);
+  addRanked(
+    selected,
+    deduplicated,
+    'engagement',
+    RANKING_V2_CANDIDATE_LIMITS.engagement,
+    compareEngagement
+  );
+  addRanked(
+    selected,
+    deduplicated,
+    'policy_relevance',
+    RANKING_V2_CANDIDATE_LIMITS.policyRelevance,
+    comparePolicyRelevance
+  );
+  addRanked(
+    selected,
+    deduplicated.filter((input) => input.previousSnapshotPosition !== null),
+    'previous_snapshot',
+    RANKING_V2_CANDIDATE_LIMITS.previousSnapshot,
+    comparePreviousSnapshot
+  );
+
+  const remaining = RANKING_V2_CANDIDATE_LIMITS.total - selected.size;
+  if (remaining > 0) {
+    addFill(selected, deduplicated, remaining);
+  }
+
+  return [...selected.values()]
+    .sort((left, right) => comparePreliminary(left.input, right.input))
+    .map(({ input, sources }) => ({
+      ...input,
+      candidateSources: SOURCE_ORDER.filter((source) => sources.has(source)),
+    }));
+}
+
+function addFill(
+  selected: Map<string, MutableCandidate>,
+  inputs: readonly RankingV2CandidateInput[],
+  limit: number
+): void {
+  let added = 0;
+  for (const input of [...inputs].sort(comparePreliminary)) {
+    const key = postIdentity(input.post);
+    if (selected.has(key)) {
+      continue;
+    }
+    selected.set(key, { input, sources: new Set(['preliminary_fill']) });
+    added += 1;
+    if (added === limit) {
+      return;
+    }
+  }
+}
+
+interface MutableCandidate {
+  input: RankingV2CandidateInput;
+  sources: Set<CandidateSource>;
+}
+
+function addRanked(
+  selected: Map<string, MutableCandidate>,
+  inputs: readonly RankingV2CandidateInput[],
+  source: CandidateSource,
+  limit: number,
+  compare: (left: RankingV2CandidateInput, right: RankingV2CandidateInput) => number
+): void {
+  for (const input of [...inputs].sort(compare).slice(0, limit)) {
+    const key = postIdentity(input.post);
+    const existing = selected.get(key);
+    if (existing) {
+      existing.sources.add(source);
+    } else {
+      selected.set(key, { input, sources: new Set([source]) });
+    }
+  }
+}
+
+function compareNewest(left: RankingV2CandidateInput, right: RankingV2CandidateInput): number {
+  return compareDateDesc(left, right) || compareUri(left, right);
+}
+
+function compareEngagement(left: RankingV2CandidateInput, right: RankingV2CandidateInput): number {
+  return weightedEngagement(right.post) - weightedEngagement(left.post)
+    || compareDateDesc(left, right)
+    || compareUri(left, right);
+}
+
+function comparePolicyRelevance(
+  left: RankingV2CandidateInput,
+  right: RankingV2CandidateInput
+): number {
+  return right.policyRelevance - left.policyRelevance
+    || compareDateDesc(left, right)
+    || compareUri(left, right);
+}
+
+function comparePreviousSnapshot(
+  left: RankingV2CandidateInput,
+  right: RankingV2CandidateInput
+): number {
+  const leftPosition = left.previousSnapshotPosition;
+  const rightPosition = right.previousSnapshotPosition;
+  if (leftPosition === null || rightPosition === null) {
+    throw new Error('Previous-snapshot comparison requires non-null positions');
+  }
+  return leftPosition - rightPosition || compareDateDesc(left, right) || compareUri(left, right);
+}
+
+function comparePreliminary(left: RankingV2CandidateInput, right: RankingV2CandidateInput): number {
+  return right.preliminaryScore - left.preliminaryScore
+    || compareDateDesc(left, right)
+    || compareUri(left, right);
+}
+
+function weightedEngagement(post: PostForScoring): number {
+  return post.likeCount + (2 * post.repostCount) + (3 * post.replyCount);
+}
+
+function compareDateDesc(left: RankingV2CandidateInput, right: RankingV2CandidateInput): number {
+  return right.post.createdAt.getTime() - left.post.createdAt.getTime();
+}
+
+function compareUri(left: RankingV2CandidateInput, right: RankingV2CandidateInput): number {
+  return compareStrings(left.post.uri, right.post.uri);
+}
+
+function postIdentity(post: PostForScoring): string {
+  return `${post.uri}\u0000${post.createdAt.toISOString()}`;
+}
+
+function deduplicateInputs(
+  inputs: readonly RankingV2CandidateInput[]
+): readonly RankingV2CandidateInput[] {
+  const identities = new Map<string, RankingV2CandidateInput>();
+  for (const input of inputs) {
+    const identity = postIdentity(input.post);
+    const existing = identities.get(identity);
+    if (existing && !equivalentInput(existing, input)) {
+      throw new Error(`Conflicting duplicate ranking candidate identity: ${identity}`);
+    }
+    identities.set(identity, input);
+  }
+  return [...identities.values()];
+}
+
+function equivalentInput(left: RankingV2CandidateInput, right: RankingV2CandidateInput): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function validateInput(input: RankingV2CandidateInput): void {
+  if (!input.post.uri || !Number.isFinite(input.post.createdAt.getTime())) {
+    throw new Error(`Invalid ranking candidate identity: ${input.post.uri}`);
+  }
+  if (!Number.isFinite(input.policyRelevance) || input.policyRelevance < 0 || input.policyRelevance > 1) {
+    throw new RangeError(`policyRelevance must be in [0, 1], got ${input.policyRelevance}`);
+  }
+  if (!Number.isFinite(input.preliminaryScore)) {
+    throw new RangeError(`preliminaryScore must be finite, got ${input.preliminaryScore}`);
+  }
+  if (
+    input.previousSnapshotPosition !== null
+    && (!Number.isInteger(input.previousSnapshotPosition) || input.previousSnapshotPosition < 1)
+  ) {
+    throw new RangeError(
+      `previousSnapshotPosition must be a positive integer or null, got ${input.previousSnapshotPosition}`
+    );
+  }
+}

--- a/src/scoring/ranking-v2-candidates.ts
+++ b/src/scoring/ranking-v2-candidates.ts
@@ -9,6 +9,16 @@ export const RANKING_V2_CANDIDATE_LIMITS = {
   total: 5000,
 } as const;
 
+if (
+  RANKING_V2_CANDIDATE_LIMITS.newest
+    + RANKING_V2_CANDIDATE_LIMITS.engagement
+    + RANKING_V2_CANDIDATE_LIMITS.policyRelevance
+    + RANKING_V2_CANDIDATE_LIMITS.previousSnapshot
+  !== RANKING_V2_CANDIDATE_LIMITS.total
+) {
+  throw new Error('RANKING_V2_CANDIDATE_LIMITS category limits must sum to total');
+}
+
 const SOURCE_ORDER: readonly CandidateSource[] = [
   'newest',
   'engagement',
@@ -28,6 +38,7 @@ export interface RankingV2Candidate extends RankingV2CandidateInput {
   candidateSources: readonly CandidateSource[];
 }
 
+/** Build the deterministic governed candidate union and retain source provenance. */
 export function buildCandidateUnion(
   inputs: readonly RankingV2CandidateInput[]
 ): readonly RankingV2Candidate[] {

--- a/src/scoring/ranking-v2-features.ts
+++ b/src/scoring/ranking-v2-features.ts
@@ -1,0 +1,88 @@
+import type { JsonObject } from '../shared/ranking-contracts.js';
+import { scoreEngagement } from './components/engagement.js';
+import { scoreRecencyAt } from './components/recency.js';
+import { scoreTopicVectorRelevance } from './components/relevance.js';
+import type { RankingV2Candidate } from './ranking-v2-candidates.js';
+
+export interface BridgingEvidence {
+  raw: number;
+  evidenceState: 'observed' | 'insufficient';
+  engagerCount: number;
+  pairCount: number;
+}
+
+export interface RankingV2FeatureVector {
+  candidate: RankingV2Candidate;
+  raw: Readonly<Record<string, number>>;
+  weights: Readonly<Record<string, number>>;
+  weighted: Readonly<Record<string, number>>;
+  evidence: JsonObject;
+  baseScore: number;
+}
+
+export function computeRankingV2Features(
+  candidates: readonly RankingV2Candidate[],
+  asOf: Date,
+  scoringWindowHours: number,
+  weights: Readonly<Record<string, number>>,
+  topicWeights: Readonly<Record<string, number>>,
+  bridgingByIdentity: ReadonlyMap<string, BridgingEvidence>
+): readonly RankingV2FeatureVector[] {
+  return candidates.map((candidate) => {
+    const identity = candidateIdentity(candidate);
+    const bridging = bridgingByIdentity.get(identity);
+    if (!bridging) {
+      throw new Error(`Missing bridging evidence for candidate ${identity}`);
+    }
+    const raw: Record<string, number> = {
+      recency: scoreRecencyAt(candidate.post.createdAt, scoringWindowHours, asOf),
+      engagement: scoreEngagement(
+        candidate.post.likeCount,
+        candidate.post.repostCount,
+        candidate.post.replyCount
+      ),
+      bridging: bridging.raw,
+      relevance: scoreTopicVectorRelevance(candidate.post.topicVector, { ...topicWeights }),
+    };
+    for (const [key, value] of Object.entries(raw)) {
+      if (!Number.isFinite(value) || value < 0 || value > 1) {
+        throw new RangeError(`Component ${key} returned out-of-range score ${value}`);
+      }
+    }
+    const weighted: Record<string, number> = {};
+    const appliedWeights: Record<string, number> = {};
+    let baseScore = 0;
+    for (const [key, rawValue] of Object.entries(raw)) {
+      const weight = requireWeight(weights, key);
+      appliedWeights[key] = weight;
+      weighted[key] = rawValue * weight;
+      baseScore += weighted[key];
+    }
+    return {
+      candidate,
+      raw,
+      weights: appliedWeights,
+      weighted,
+      evidence: {
+        bridging: {
+          evidenceState: bridging.evidenceState,
+          engagerCount: bridging.engagerCount,
+          pairCount: bridging.pairCount,
+        },
+      },
+      baseScore,
+    };
+  });
+}
+
+export function candidateIdentity(candidate: RankingV2Candidate): string {
+  return `${candidate.post.uri}\u0000${candidate.post.createdAt.toISOString()}`;
+}
+
+function requireWeight(weights: Readonly<Record<string, number>>, key: string): number {
+  const value = weights[key];
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error(`Pinned policy is missing weight in [0, 1] for ${key}`);
+  }
+  return value;
+}

--- a/src/scoring/ranking-v2-features.ts
+++ b/src/scoring/ranking-v2-features.ts
@@ -1,4 +1,4 @@
-import type { JsonObject } from '../shared/ranking-contracts.js';
+import type { EvidenceState } from '../shared/ranking-contracts.js';
 import { scoreEngagement } from './components/engagement.js';
 import { scoreRecencyAt } from './components/recency.js';
 import { scoreTopicVectorRelevance } from './components/relevance.js';
@@ -6,7 +6,7 @@ import type { RankingV2Candidate } from './ranking-v2-candidates.js';
 
 export interface BridgingEvidence {
   raw: number;
-  evidenceState: 'observed' | 'insufficient';
+  evidenceState: EvidenceState;
   engagerCount: number;
   pairCount: number;
 }
@@ -16,10 +16,17 @@ export interface RankingV2FeatureVector {
   raw: Readonly<Record<string, number>>;
   weights: Readonly<Record<string, number>>;
   weighted: Readonly<Record<string, number>>;
-  evidence: JsonObject;
+  evidence: {
+    bridging: {
+      evidenceState: EvidenceState;
+      engagerCount: number;
+      pairCount: number;
+    };
+  };
   baseScore: number;
 }
 
+/** Compute all item-level v2 feature values against the immutable run clock. */
 export function computeRankingV2Features(
   candidates: readonly RankingV2Candidate[],
   asOf: Date,
@@ -75,11 +82,13 @@ export function computeRankingV2Features(
   });
 }
 
+/** Return the stable URI-and-created-at identity used by batch feature maps. */
 export function candidateIdentity(candidate: RankingV2Candidate): string {
   return `${candidate.post.uri}\u0000${candidate.post.createdAt.toISOString()}`;
 }
 
-function requireWeight(weights: Readonly<Record<string, number>>, key: string): number {
+/** Read one finite governed weight while enforcing the shared [0, 1] contract. */
+export function requireWeight(weights: Readonly<Record<string, number>>, key: string): number {
   const value = weights[key];
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
     throw new Error(`Pinned policy is missing weight in [0, 1] for ${key}`);

--- a/src/scoring/ranking-v2-features.ts
+++ b/src/scoring/ranking-v2-features.ts
@@ -4,6 +4,8 @@ import { scoreRecencyAt } from './components/recency.js';
 import { scoreTopicVectorRelevance } from './components/relevance.js';
 import type { RankingV2Candidate } from './ranking-v2-candidates.js';
 
+export const BRIDGING_COMPONENT_KEY = 'bridging';
+
 export interface BridgingEvidence {
   raw: number;
   evidenceState: EvidenceState;
@@ -48,7 +50,7 @@ export function computeRankingV2Features(
         candidate.post.repostCount,
         candidate.post.replyCount
       ),
-      bridging: bridging.raw,
+      [BRIDGING_COMPONENT_KEY]: bridging.raw,
       relevance: scoreTopicVectorRelevance(candidate.post.topicVector, { ...topicWeights }),
     };
     for (const [key, value] of Object.entries(raw)) {

--- a/src/scoring/ranking-v2-slate.ts
+++ b/src/scoring/ranking-v2-slate.ts
@@ -1,0 +1,131 @@
+import type { JsonObject, RankedSlateItem } from '../shared/ranking-contracts.js';
+import type { SlateReranker } from './component.interface.js';
+import type { RankingV2FeatureVector } from './ranking-v2-features.js';
+
+export interface DiversitySelectionContext {
+  authorCountBeforeSelection: number;
+  raw: number;
+  weight: number;
+  weighted: number;
+}
+
+export class SourceDiversitySlateReranker implements SlateReranker<RankingV2FeatureVector, RankedSlateItem> {
+  readonly key = 'sourceDiversity';
+
+  constructor(private readonly weight: number) {
+    if (!Number.isFinite(weight) || weight < 0 || weight > 1) {
+      throw new RangeError(`sourceDiversity weight must be in [0, 1], got ${weight}`);
+    }
+  }
+
+  rerank(
+    items: readonly RankingV2FeatureVector[],
+    limit: number
+  ): readonly RankedSlateItem[] {
+    if (!Number.isInteger(limit) || limit < 0 || limit > 1000) {
+      throw new RangeError(`slate limit must be an integer in [0, 1000], got ${limit}`);
+    }
+    const remaining = [...items];
+    const authorCounts = new Map<string, number>();
+    const selected: RankedSlateItem[] = [];
+
+    while (selected.length < limit && remaining.length > 0) {
+      let bestIndex = 0;
+      let bestContext = diversityContext(remaining[0], authorCounts, this.weight);
+      for (let index = 1; index < remaining.length; index += 1) {
+        const context = diversityContext(remaining[index], authorCounts, this.weight);
+        if (compareSelection(remaining[index], context, remaining[bestIndex], bestContext) < 0) {
+          bestIndex = index;
+          bestContext = context;
+        }
+      }
+
+      const [best] = remaining.splice(bestIndex, 1);
+      const authorDid = best.candidate.post.authorDid;
+      authorCounts.set(authorDid, bestContext.authorCountBeforeSelection + 1);
+      selected.push(toRankedSlateItem(best, bestContext, selected.length + 1));
+    }
+    return selected;
+  }
+}
+
+export const SLATE_RERANKERS: Readonly<Record<string, typeof SourceDiversitySlateReranker>> = {
+  sourceDiversity: SourceDiversitySlateReranker,
+};
+
+export function diversityRaw(authorCountBeforeSelection: number): number {
+  if (!Number.isInteger(authorCountBeforeSelection) || authorCountBeforeSelection < 0) {
+    throw new RangeError(`author count must be a non-negative integer, got ${authorCountBeforeSelection}`);
+  }
+  if (authorCountBeforeSelection === 0) return 1;
+  if (authorCountBeforeSelection === 1) return 0.7;
+  if (authorCountBeforeSelection === 2) return 0.5;
+  return 0.3;
+}
+
+function diversityContext(
+  item: RankingV2FeatureVector,
+  authorCounts: ReadonlyMap<string, number>,
+  weight: number
+): DiversitySelectionContext {
+  const authorCountBeforeSelection = authorCounts.get(item.candidate.post.authorDid) ?? 0;
+  const raw = diversityRaw(authorCountBeforeSelection);
+  return { authorCountBeforeSelection, raw, weight, weighted: raw * weight };
+}
+
+function compareSelection(
+  left: RankingV2FeatureVector,
+  leftContext: DiversitySelectionContext,
+  right: RankingV2FeatureVector,
+  rightContext: DiversitySelectionContext
+): number {
+  const leftUtility = left.baseScore + leftContext.weighted;
+  const rightUtility = right.baseScore + rightContext.weighted;
+  return rightUtility - leftUtility
+    || right.baseScore - left.baseScore
+    || right.candidate.post.createdAt.getTime() - left.candidate.post.createdAt.getTime()
+    || compareStrings(left.candidate.post.uri, right.candidate.post.uri);
+}
+
+function toRankedSlateItem(
+  item: RankingV2FeatureVector,
+  diversity: DiversitySelectionContext,
+  position: number
+): RankedSlateItem {
+  const componentDecomposition: JsonObject = {};
+  for (const key of Object.keys(item.raw).sort()) {
+    componentDecomposition[key] = {
+      raw: item.raw[key],
+      weight: item.weights[key],
+      weighted: item.weighted[key],
+    };
+  }
+  componentDecomposition.sourceDiversity = {
+    raw: diversity.raw,
+    weight: diversity.weight,
+    weighted: diversity.weighted,
+  };
+  componentDecomposition.evidence = item.evidence;
+
+  return {
+    position,
+    postUri: item.candidate.post.uri,
+    postCreatedAt: item.candidate.post.createdAt.toISOString(),
+    authorDid: item.candidate.post.authorDid,
+    componentDecomposition,
+    candidateSources: item.candidate.candidateSources,
+    diversityContext: {
+      authorCountBeforeSelection: diversity.authorCountBeforeSelection,
+      raw: diversity.raw,
+      weightedContribution: diversity.weighted,
+    },
+    baseScore: item.baseScore,
+    finalScore: item.baseScore + diversity.weighted,
+  };
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}

--- a/src/scoring/ranking-v2-slate.ts
+++ b/src/scoring/ranking-v2-slate.ts
@@ -1,4 +1,8 @@
-import type { JsonObject, RankedSlateItem } from '../shared/ranking-contracts.js';
+import type {
+  ComponentEvidence,
+  JsonObject,
+  RankedSlateItem,
+} from '../shared/ranking-contracts.js';
 import type { SlateReranker } from './component.interface.js';
 import type { RankingV2FeatureVector } from './ranking-v2-features.js';
 
@@ -9,6 +13,9 @@ export interface DiversitySelectionContext {
   weighted: number;
 }
 
+export const RANKING_V2_SLATE_LIMIT = 1000;
+
+/** Apply the governed source-diversity objective during deterministic slate selection. */
 export class SourceDiversitySlateReranker implements SlateReranker<RankingV2FeatureVector, RankedSlateItem> {
   readonly key = 'sourceDiversity';
 
@@ -22,8 +29,10 @@ export class SourceDiversitySlateReranker implements SlateReranker<RankingV2Feat
     items: readonly RankingV2FeatureVector[],
     limit: number
   ): readonly RankedSlateItem[] {
-    if (!Number.isInteger(limit) || limit < 0 || limit > 1000) {
-      throw new RangeError(`slate limit must be an integer in [0, 1000], got ${limit}`);
+    if (!Number.isInteger(limit) || limit < 0 || limit > RANKING_V2_SLATE_LIMIT) {
+      throw new RangeError(
+        `slate limit must be an integer in [0, ${RANKING_V2_SLATE_LIMIT}], got ${limit}`
+      );
     }
     const remaining = [...items];
     const authorCounts = new Map<string, number>();
@@ -53,6 +62,7 @@ export const SLATE_RERANKERS: Readonly<Record<string, typeof SourceDiversitySlat
   sourceDiversity: SourceDiversitySlateReranker,
 };
 
+/** Return the governed diversity value for an author's next selected post. */
 export function diversityRaw(authorCountBeforeSelection: number): number {
   if (!Number.isInteger(authorCountBeforeSelection) || authorCountBeforeSelection < 0) {
     throw new RangeError(`author count must be a non-negative integer, got ${authorCountBeforeSelection}`);
@@ -92,20 +102,27 @@ function toRankedSlateItem(
   diversity: DiversitySelectionContext,
   position: number
 ): RankedSlateItem {
-  const componentDecomposition: JsonObject = {};
+  const scoreComponents: Record<string, ComponentEvidence> = {};
   for (const key of Object.keys(item.raw).sort()) {
-    componentDecomposition[key] = {
+    scoreComponents[key] = {
       raw: item.raw[key],
       weight: item.weights[key],
       weighted: item.weighted[key],
+      evidenceState: key === 'bridging'
+        ? item.evidence.bridging.evidenceState
+        : 'observed',
     };
   }
-  componentDecomposition.sourceDiversity = {
+  scoreComponents.sourceDiversity = {
     raw: diversity.raw,
     weight: diversity.weight,
     weighted: diversity.weighted,
+    evidenceState: 'observed',
   };
-  componentDecomposition.evidence = item.evidence;
+  const componentDecomposition: JsonObject = {
+    ...scoreComponents,
+    evidence: item.evidence,
+  };
 
   return {
     position,

--- a/src/scoring/ranking-v2-slate.ts
+++ b/src/scoring/ranking-v2-slate.ts
@@ -4,7 +4,10 @@ import type {
   RankedSlateItem,
 } from '../shared/ranking-contracts.js';
 import type { SlateReranker } from './component.interface.js';
-import type { RankingV2FeatureVector } from './ranking-v2-features.js';
+import {
+  BRIDGING_COMPONENT_KEY,
+  type RankingV2FeatureVector,
+} from './ranking-v2-features.js';
 
 export interface DiversitySelectionContext {
   authorCountBeforeSelection: number;
@@ -108,7 +111,7 @@ function toRankedSlateItem(
       raw: item.raw[key],
       weight: item.weights[key],
       weighted: item.weighted[key],
-      evidenceState: key === 'bridging'
+      evidenceState: key === BRIDGING_COMPONENT_KEY
         ? item.evidence.bridging.evidenceState
         : 'observed',
     };

--- a/src/scoring/ranking-v2.ts
+++ b/src/scoring/ranking-v2.ts
@@ -5,7 +5,14 @@ import { materializeActivePolicyVersion, hashCanonicalJson } from '../governance
 import { checkContentRules } from '../governance/content-filter.js';
 import { toContentRules } from '../governance/governance.types.js';
 import type { ContentRules } from '../shared/api-types.js';
-import type { JsonObject, RankedSlateItem, RankingReceipt, RankingRunInputEnvelope, RankingRunContext } from '../shared/ranking-contracts.js';
+import {
+  CANDIDATE_SOURCES,
+  type JsonObject,
+  type RankedSlateItem,
+  type RankingReceipt,
+  type RankingRunInputEnvelope,
+  type RankingRunContext,
+} from '../shared/ranking-contracts.js';
 import {
   buildRankingReceipt,
   createCompressedRankingInput,
@@ -29,7 +36,11 @@ import {
   RANKING_V2_SLATE_LIMIT,
   SourceDiversitySlateReranker,
 } from './ranking-v2-slate.js';
-import { toPostForScoring, type PostForScoring } from './score.types.js';
+import {
+  CLASSIFICATION_METHODS,
+  toPostForScoring,
+  type PostForScoring,
+} from './score.types.js';
 
 export const RANKING_V2_ALGORITHM_VERSION = 'corgi-ranking-v2';
 export const RANKING_V2_SCORING_WINDOW_HOURS = 72;
@@ -48,13 +59,7 @@ const CONFIGURATION = {
   tieBreak: ['utility_desc', 'base_score_desc', 'created_at_desc', 'uri_asc'],
 } as const;
 
-const CandidateSourceSchema = z.enum([
-  'newest',
-  'engagement',
-  'policy_relevance',
-  'previous_snapshot',
-  'preliminary_fill',
-]);
+const CandidateSourceSchema = z.enum(CANDIDATE_SOURCES);
 const FiniteNumberSchema = z.number().finite();
 const NumericRecordSchema = z.record(FiniteNumberSchema);
 const ReplayCandidateSchema = z.object({
@@ -70,7 +75,7 @@ const ReplayCandidateSchema = z.object({
     langs: z.array(z.string()),
     hasMedia: z.boolean(),
     topicVector: NumericRecordSchema,
-    classificationMethod: z.enum(['keyword', 'embedding']).nullable(),
+    classificationMethod: z.enum(CLASSIFICATION_METHODS).nullable(),
   }),
   eventTime: z.object({
     likeCount: FiniteNumberSchema,

--- a/src/scoring/ranking-v2.ts
+++ b/src/scoring/ranking-v2.ts
@@ -1,0 +1,462 @@
+import { randomUUID } from 'node:crypto';
+import type { Pool, PoolClient } from 'pg';
+import { materializeActivePolicyVersion, hashCanonicalJson } from '../governance/policy-version.js';
+import { checkContentRules } from '../governance/content-filter.js';
+import { toContentRules } from '../governance/governance.types.js';
+import type { ContentRules } from '../shared/api-types.js';
+import type {
+  CandidateSource,
+  JsonObject,
+  JsonValue,
+  RankedSlateItem,
+  RankingReceipt,
+  RankingRunInputEnvelope,
+  RankingRunContext,
+} from '../shared/ranking-contracts.js';
+import {
+  buildRankingReceipt,
+  createCompressedRankingInput,
+  createRankingRun,
+  persistRankedSlate,
+  persistRankingRunInput,
+  transitionRankingRun,
+  validateRankingRun,
+} from './ranking-run-contracts.js';
+import { scoreBridgingBatch } from './components/bridging.js';
+import { scoreEngagement } from './components/engagement.js';
+import { scoreRecencyAt } from './components/recency.js';
+import { scoreTopicVectorRelevance } from './components/relevance.js';
+import {
+  buildCandidateUnion,
+  type RankingV2CandidateInput,
+} from './ranking-v2-candidates.js';
+import { computeRankingV2Features } from './ranking-v2-features.js';
+import { SourceDiversitySlateReranker } from './ranking-v2-slate.js';
+import { toPostForScoring, type PostForScoring } from './score.types.js';
+
+export const RANKING_V2_ALGORITHM_VERSION = 'corgi-ranking-v2';
+export const RANKING_V2_SCORING_WINDOW_HOURS = 72;
+export const RANKING_V2_SLATE_LIMIT = 1000;
+
+const CONFIGURATION = {
+  candidateLimits: {
+    newest: 1500,
+    engagement: 1500,
+    policyRelevance: 1500,
+    previousSnapshot: 500,
+    total: 5000,
+  },
+  scoringWindowHours: RANKING_V2_SCORING_WINDOW_HOURS,
+  slateLimit: RANKING_V2_SLATE_LIMIT,
+  tieBreak: ['utility_desc', 'base_score_desc', 'created_at_desc', 'uri_asc'],
+} as const;
+
+export interface RankingV2ShadowOptions {
+  communityId: string;
+  asOf: Date;
+  codeSha: string;
+  previousSnapshotPositions: ReadonlyMap<string, number>;
+}
+
+export interface RankingV2ShadowResult {
+  context: RankingRunContext;
+  receipt: RankingReceipt;
+  candidateCount: number;
+  selectedCount: number;
+  exclusionCount: number;
+}
+
+export function replayRankingV2Slate(
+  envelope: RankingRunInputEnvelope,
+  sourceDiversityWeight: number
+): readonly RankedSlateItem[] {
+  const features = envelope.candidates.map((candidate, index) => replayFeature(candidate, index));
+  return new SourceDiversitySlateReranker(sourceDiversityWeight).rerank(
+    features,
+    Math.min(RANKING_V2_SLATE_LIMIT, features.length)
+  );
+}
+
+interface CandidateRow extends Record<string, unknown> {
+  uri: string;
+  created_at: Date | string;
+}
+
+export async function runRankingV2Shadow(
+  pool: Pool,
+  options: RankingV2ShadowOptions
+): Promise<RankingV2ShadowResult> {
+  assertOptions(options);
+  const client = await pool.connect();
+  const startedAt = Date.now();
+  let context: RankingRunContext | null = null;
+  let transactionOpen = false;
+  try {
+    await client.query('BEGIN');
+    transactionOpen = true;
+    const policyResult = await materializeActivePolicyVersion(client, {
+      communityId: options.communityId,
+      algorithmVersion: RANKING_V2_ALGORITHM_VERSION,
+      effectiveAt: options.asOf.toISOString(),
+      provenanceReferences: [],
+    });
+    context = {
+      runId: randomUUID(),
+      communityId: options.communityId,
+      asOf: options.asOf.toISOString(),
+      policy: policyResult.bundle,
+      algorithmVersion: RANKING_V2_ALGORITHM_VERSION,
+      configurationHash: hashCanonicalJson(CONFIGURATION),
+      codeSha: options.codeSha,
+    };
+    await createRankingRun(client, {
+      runId: context.runId,
+      communityId: context.communityId,
+      policyVersionId: context.policy.policyVersionId,
+      policyHash: context.policy.policyHash,
+      algorithmVersion: context.algorithmVersion,
+      configurationHash: context.configurationHash,
+      codeSha: context.codeSha,
+      asOf: context.asOf,
+    });
+    await client.query('COMMIT');
+    transactionOpen = false;
+
+    await client.query('BEGIN ISOLATION LEVEL REPEATABLE READ');
+    transactionOpen = true;
+    await transitionRankingRun(client, context.runId, 'running', null);
+
+    const contentRules = policyContentRules(context.policy.contentRules);
+    const loaded = await loadEligibleCandidates(
+      client,
+      options.asOf,
+      contentRules,
+      options.previousSnapshotPositions,
+      context.policy.weights,
+      context.policy.topicWeights
+    );
+    const candidates = buildCandidateUnion(loaded.inputs);
+    if (candidates.length === 0) {
+      throw new Error(`Ranking run ${context.runId} has no eligible candidates`);
+    }
+    const bridging = await scoreBridgingBatch(client, candidates.map((candidate) => candidate.post));
+    const features = computeRankingV2Features(
+      candidates,
+      options.asOf,
+      RANKING_V2_SCORING_WINDOW_HOURS,
+      context.policy.weights,
+      context.policy.topicWeights,
+      bridging
+    );
+    const sourceDiversityWeight = requiredWeight(context.policy.weights, 'sourceDiversity');
+    const slate = new SourceDiversitySlateReranker(sourceDiversityWeight).rerank(
+      features,
+      Math.min(RANKING_V2_SLATE_LIMIT, features.length)
+    );
+    const envelope = {
+      schemaVersion: 1 as const,
+      runId: context.runId,
+      communityId: context.communityId,
+      policyHash: context.policy.policyHash,
+      configurationHash: context.configurationHash,
+      asOf: context.asOf,
+      candidates: features.map(toReplayCandidate),
+    };
+    const compressed = createCompressedRankingInput(envelope);
+    await persistRankingRunInput(client, context.runId, compressed);
+    await persistRankedSlate(client, context.runId, slate);
+    const receipt = buildRankingReceipt({
+      runId: context.runId,
+      communityId: context.communityId,
+      policyVersionId: context.policy.policyVersionId,
+      policyHash: context.policy.policyHash,
+      algorithmVersion: context.algorithmVersion,
+      configurationHash: context.configurationHash,
+      codeSha: context.codeSha,
+      asOf: context.asOf,
+      inputChecksum: compressed.checksum,
+      items: slate,
+    });
+    await validateRankingRun(client, {
+      runId: context.runId,
+      receipt,
+      candidateCount: candidates.length,
+      exclusionCount: loaded.exclusionCount,
+      timings: { totalMs: Date.now() - startedAt },
+      metrics: rankingMetrics(slate),
+    });
+    await client.query('COMMIT');
+    transactionOpen = false;
+    return {
+      context,
+      receipt,
+      candidateCount: candidates.length,
+      selectedCount: slate.length,
+      exclusionCount: loaded.exclusionCount,
+    };
+  } catch (error) {
+    const cleanupErrors: unknown[] = [];
+    if (transactionOpen) {
+      try {
+        await client.query('ROLLBACK');
+        transactionOpen = false;
+      } catch (rollbackError) {
+        cleanupErrors.push(rollbackError);
+      }
+    }
+    if (context !== null) {
+      try {
+        await client.query('BEGIN');
+        await transitionRankingRun(client, context.runId, 'failed', failureDetails(error));
+        await client.query('COMMIT');
+      } catch (failurePersistenceError) {
+        await client.query('ROLLBACK').catch((rollbackError: unknown) => {
+          cleanupErrors.push(rollbackError);
+        });
+        cleanupErrors.push(failurePersistenceError);
+      }
+    }
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...cleanupErrors],
+        `Ranking v2 failed and cleanup was incomplete: ${messageFromError(error)}`
+      );
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function loadEligibleCandidates(
+  client: PoolClient,
+  asOf: Date,
+  contentRules: ContentRules,
+  previousSnapshotPositions: ReadonlyMap<string, number>,
+  weights: Readonly<Record<string, number>>,
+  topicWeights: Readonly<Record<string, number>>
+): Promise<{ inputs: readonly RankingV2CandidateInput[]; exclusionCount: number }> {
+  const cutoff = new Date(asOf.getTime() - (RANKING_V2_SCORING_WINDOW_HOURS * 60 * 60 * 1000));
+  const result = await client.query<CandidateRow>(
+    `SELECT p.uri, p.cid, p.author_did, p.text, p.reply_root, p.reply_parent,
+            p.langs, p.has_media, p.created_at, p.topic_vector, p.classification_method,
+            COALESCE(pe.like_count, 0)::int AS like_count,
+            COALESCE(pe.repost_count, 0)::int AS repost_count,
+            COALESCE(pe.reply_count, 0)::int AS reply_count
+       FROM posts p
+       LEFT JOIN post_engagement pe ON pe.post_uri = p.uri
+      WHERE p.deleted = FALSE
+        AND p.created_at > $1
+        AND p.created_at <= $2
+      ORDER BY p.created_at DESC, p.uri ASC`,
+    [cutoff.toISOString(), asOf.toISOString()]
+  );
+  const inputs: RankingV2CandidateInput[] = [];
+  let exclusionCount = 0;
+  for (const row of result.rows) {
+    const post = toPostForScoring(row);
+    if (!checkContentRules(post.text, contentRules).passes) {
+      exclusionCount += 1;
+      continue;
+    }
+    const relevance = scoreTopicVectorRelevance(post.topicVector, { ...topicWeights });
+    const preliminaryScore = (
+      scoreRecencyAt(post.createdAt, RANKING_V2_SCORING_WINDOW_HOURS, asOf)
+        * requiredWeight(weights, 'recency')
+    ) + (
+      scoreEngagement(post.likeCount, post.repostCount, post.replyCount)
+        * requiredWeight(weights, 'engagement')
+    ) + (relevance * requiredWeight(weights, 'relevance'));
+    inputs.push({
+      post,
+      policyRelevance: relevance,
+      previousSnapshotPosition: previousSnapshotPositions.get(post.uri) ?? null,
+      preliminaryScore,
+    });
+  }
+  return { inputs, exclusionCount };
+}
+
+function toReplayCandidate(feature: ReturnType<typeof computeRankingV2Features>[number]): JsonObject {
+  return {
+    uri: feature.candidate.post.uri,
+    createdAt: feature.candidate.post.createdAt.toISOString(),
+    authorDid: feature.candidate.post.authorDid,
+    candidateSources: [...feature.candidate.candidateSources],
+    immutable: {
+      cid: feature.candidate.post.cid,
+      text: feature.candidate.post.text,
+      topicVector: feature.candidate.post.topicVector ?? {},
+    },
+    eventTime: {
+      likeCount: feature.candidate.post.likeCount,
+      repostCount: feature.candidate.post.repostCount,
+      replyCount: feature.candidate.post.replyCount,
+    },
+    raw: { ...feature.raw },
+    weights: { ...feature.weights },
+    weighted: { ...feature.weighted },
+    evidence: feature.evidence,
+    baseScore: feature.baseScore,
+  };
+}
+
+function rankingMetrics(items: readonly { authorDid: string }[]): JsonObject {
+  const top100 = items.slice(0, 100);
+  return {
+    uniqueAuthors: new Set(items.map((item) => item.authorDid)).size,
+    top100UniqueAuthors: new Set(top100.map((item) => item.authorDid)).size,
+  };
+}
+
+function policyContentRules(contentRules: JsonObject): ContentRules {
+  return toContentRules(contentRules);
+}
+
+function requiredWeight(weights: Readonly<Record<string, number>>, key: string): number {
+  const value = weights[key];
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error(`Pinned policy is missing weight in [0, 1] for ${key}`);
+  }
+  return value;
+}
+
+function replayFeature(candidate: JsonObject, index: number): ReturnType<typeof computeRankingV2Features>[number] {
+  const uri = requiredString(candidate.uri, `candidates[${index}].uri`);
+  const createdAt = requiredDate(candidate.createdAt, `candidates[${index}].createdAt`);
+  const authorDid = requiredString(candidate.authorDid, `candidates[${index}].authorDid`);
+  const immutable = requiredObject(candidate.immutable, `candidates[${index}].immutable`);
+  const eventTime = requiredObject(candidate.eventTime, `candidates[${index}].eventTime`);
+  const raw = numericRecord(candidate.raw, `candidates[${index}].raw`);
+  const weights = numericRecord(candidate.weights, `candidates[${index}].weights`);
+  const weighted = numericRecord(candidate.weighted, `candidates[${index}].weighted`);
+  const baseScore = requiredNumber(candidate.baseScore, `candidates[${index}].baseScore`);
+  const candidateSources = requiredCandidateSources(
+    candidate.candidateSources,
+    `candidates[${index}].candidateSources`
+  );
+  return {
+    candidate: {
+      post: {
+        uri,
+        cid: requiredString(immutable.cid, `candidates[${index}].immutable.cid`),
+        authorDid,
+        text: optionalString(immutable.text, `candidates[${index}].immutable.text`),
+        replyRoot: null,
+        replyParent: null,
+        langs: [],
+        hasMedia: false,
+        createdAt,
+        likeCount: requiredNumber(eventTime.likeCount, `candidates[${index}].eventTime.likeCount`),
+        repostCount: requiredNumber(eventTime.repostCount, `candidates[${index}].eventTime.repostCount`),
+        replyCount: requiredNumber(eventTime.replyCount, `candidates[${index}].eventTime.replyCount`),
+        topicVector: numericRecord(
+          immutable.topicVector,
+          `candidates[${index}].immutable.topicVector`
+        ),
+        classificationMethod: 'keyword',
+      },
+      policyRelevance: raw.relevance ?? 0,
+      previousSnapshotPosition: null,
+      preliminaryScore: baseScore,
+      candidateSources,
+    },
+    raw,
+    weights,
+    weighted,
+    evidence: requiredObject(candidate.evidence, `candidates[${index}].evidence`),
+    baseScore,
+  };
+}
+
+function requiredObject(value: JsonValue | undefined, label: string): JsonObject {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function requiredString(value: JsonValue | undefined, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value: JsonValue | undefined, label: string): string | null {
+  if (value === null) return null;
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a string or null`);
+  }
+  return value;
+}
+
+function requiredNumber(value: JsonValue | undefined, label: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  return value;
+}
+
+function requiredDate(value: JsonValue | undefined, label: string): Date {
+  const date = new Date(requiredString(value, label));
+  if (!Number.isFinite(date.getTime())) {
+    throw new Error(`${label} must be a valid timestamp`);
+  }
+  return date;
+}
+
+function numericRecord(value: JsonValue | undefined, label: string): Record<string, number> {
+  const object = requiredObject(value, label);
+  const output: Record<string, number> = {};
+  for (const [key, member] of Object.entries(object)) {
+    output[key] = requiredNumber(member, `${label}.${key}`);
+  }
+  return output;
+}
+
+function requiredCandidateSources(
+  value: JsonValue | undefined,
+  label: string
+): readonly CandidateSource[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  const allowed = new Set<CandidateSource>([
+    'newest',
+    'engagement',
+    'policy_relevance',
+    'previous_snapshot',
+    'preliminary_fill',
+  ]);
+  return value.map((member, index) => {
+    if (typeof member !== 'string' || !allowed.has(member as CandidateSource)) {
+      throw new Error(`${label}[${index}] is not a valid candidate source`);
+    }
+    return member as CandidateSource;
+  });
+}
+
+function assertOptions(options: RankingV2ShadowOptions): void {
+  if (!options.communityId.trim()) {
+    throw new Error('communityId must be non-empty');
+  }
+  if (!Number.isFinite(options.asOf.getTime())) {
+    throw new RangeError('asOf must be a valid timestamp');
+  }
+  if (!/^[0-9a-f]{40,64}$/.test(options.codeSha)) {
+    throw new Error('codeSha must be a lowercase 40-64 character hexadecimal digest');
+  }
+}
+
+function failureDetails(error: unknown): JsonObject {
+  return {
+    name: error instanceof Error ? error.name : 'UnknownError',
+    message: messageFromError(error),
+  };
+}
+
+function messageFromError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/src/scoring/ranking-v2.ts
+++ b/src/scoring/ranking-v2.ts
@@ -1,18 +1,11 @@
 import { randomUUID } from 'node:crypto';
-import type { Pool, PoolClient } from 'pg';
+import type { Pool, PoolClient, QueryResultRow } from 'pg';
+import { z } from 'zod';
 import { materializeActivePolicyVersion, hashCanonicalJson } from '../governance/policy-version.js';
 import { checkContentRules } from '../governance/content-filter.js';
 import { toContentRules } from '../governance/governance.types.js';
 import type { ContentRules } from '../shared/api-types.js';
-import type {
-  CandidateSource,
-  JsonObject,
-  JsonValue,
-  RankedSlateItem,
-  RankingReceipt,
-  RankingRunInputEnvelope,
-  RankingRunContext,
-} from '../shared/ranking-contracts.js';
+import type { JsonObject, RankedSlateItem, RankingReceipt, RankingRunInputEnvelope, RankingRunContext } from '../shared/ranking-contracts.js';
 import {
   buildRankingReceipt,
   createCompressedRankingInput,
@@ -27,16 +20,20 @@ import { scoreEngagement } from './components/engagement.js';
 import { scoreRecencyAt } from './components/recency.js';
 import { scoreTopicVectorRelevance } from './components/relevance.js';
 import {
+  RANKING_V2_CANDIDATE_LIMITS,
   buildCandidateUnion,
   type RankingV2CandidateInput,
 } from './ranking-v2-candidates.js';
-import { computeRankingV2Features } from './ranking-v2-features.js';
-import { SourceDiversitySlateReranker } from './ranking-v2-slate.js';
+import { computeRankingV2Features, requireWeight } from './ranking-v2-features.js';
+import {
+  RANKING_V2_SLATE_LIMIT,
+  SourceDiversitySlateReranker,
+} from './ranking-v2-slate.js';
 import { toPostForScoring, type PostForScoring } from './score.types.js';
 
 export const RANKING_V2_ALGORITHM_VERSION = 'corgi-ranking-v2';
 export const RANKING_V2_SCORING_WINDOW_HOURS = 72;
-export const RANKING_V2_SLATE_LIMIT = 1000;
+const MAX_CANDIDATE_FETCH = RANKING_V2_CANDIDATE_LIMITS.total * 10;
 
 const CONFIGURATION = {
   candidateLimits: {
@@ -50,6 +47,60 @@ const CONFIGURATION = {
   slateLimit: RANKING_V2_SLATE_LIMIT,
   tieBreak: ['utility_desc', 'base_score_desc', 'created_at_desc', 'uri_asc'],
 } as const;
+
+const CandidateSourceSchema = z.enum([
+  'newest',
+  'engagement',
+  'policy_relevance',
+  'previous_snapshot',
+  'preliminary_fill',
+]);
+const FiniteNumberSchema = z.number().finite();
+const NumericRecordSchema = z.record(FiniteNumberSchema);
+const ReplayCandidateSchema = z.object({
+  uri: z.string().min(1),
+  createdAt: z.string().datetime(),
+  authorDid: z.string().min(1),
+  candidateSources: z.array(CandidateSourceSchema),
+  immutable: z.object({
+    cid: z.string().min(1),
+    text: z.string().nullable(),
+    replyRoot: z.string().nullable(),
+    replyParent: z.string().nullable(),
+    langs: z.array(z.string()),
+    hasMedia: z.boolean(),
+    topicVector: NumericRecordSchema,
+    classificationMethod: z.enum(['keyword', 'embedding']).nullable(),
+  }),
+  eventTime: z.object({
+    likeCount: FiniteNumberSchema,
+    repostCount: FiniteNumberSchema,
+    replyCount: FiniteNumberSchema,
+  }),
+  raw: NumericRecordSchema,
+  weights: NumericRecordSchema,
+  weighted: NumericRecordSchema,
+  evidence: z.object({
+    bridging: z.object({
+      evidenceState: z.enum(['observed', 'insufficient']),
+      engagerCount: z.number().int().nonnegative(),
+      pairCount: z.number().int().nonnegative(),
+    }),
+  }),
+  baseScore: FiniteNumberSchema,
+});
+const ReplayEnvelopeSchema = z.object({
+  schemaVersion: z.literal(1),
+  runId: z.string().min(1),
+  communityId: z.string().min(1),
+  policyHash: z.string().regex(/^[a-f0-9]{64}$/),
+  configurationHash: z.string().regex(/^[a-f0-9]{64}$/),
+  asOf: z.string().datetime(),
+  sourceDiversityWeight: z.number().finite().min(0).max(1),
+  candidates: z.array(ReplayCandidateSchema),
+}).strict();
+
+type ReplayCandidate = z.infer<typeof ReplayCandidateSchema>;
 
 export interface RankingV2ShadowOptions {
   communityId: string;
@@ -66,22 +117,45 @@ export interface RankingV2ShadowResult {
   exclusionCount: number;
 }
 
+/** Reconstruct the exact v2 slate from one validated immutable replay envelope. */
 export function replayRankingV2Slate(
   envelope: RankingRunInputEnvelope,
-  sourceDiversityWeight: number
+  expectedSourceDiversityWeight?: number
 ): readonly RankedSlateItem[] {
-  const features = envelope.candidates.map((candidate, index) => replayFeature(candidate, index));
-  return new SourceDiversitySlateReranker(sourceDiversityWeight).rerank(
+  const parsed = ReplayEnvelopeSchema.parse(envelope);
+  if (
+    expectedSourceDiversityWeight !== undefined
+    && expectedSourceDiversityWeight !== parsed.sourceDiversityWeight
+  ) {
+    throw new Error(
+      `Replay sourceDiversityWeight mismatch: stored ${parsed.sourceDiversityWeight}, supplied ${expectedSourceDiversityWeight}`
+    );
+  }
+  const features = parsed.candidates.map(replayFeature);
+  return new SourceDiversitySlateReranker(parsed.sourceDiversityWeight).rerank(
     features,
     Math.min(RANKING_V2_SLATE_LIMIT, features.length)
   );
 }
 
-interface CandidateRow extends Record<string, unknown> {
+interface CandidateRow extends QueryResultRow {
   uri: string;
+  cid: string;
+  author_did: string;
+  text: string | null;
+  reply_root: string | null;
+  reply_parent: string | null;
+  langs: string[] | null;
+  has_media: boolean;
   created_at: Date | string;
+  topic_vector: Record<string, number> | null;
+  classification_method: string | null;
+  like_count: number;
+  repost_count: number;
+  reply_count: number;
 }
 
+/** Execute and persist one non-publishing v2 ranking run against a pinned policy. */
 export async function runRankingV2Shadow(
   pool: Pool,
   options: RankingV2ShadowOptions
@@ -91,6 +165,7 @@ export async function runRankingV2Shadow(
   const startedAt = Date.now();
   let context: RankingRunContext | null = null;
   let transactionOpen = false;
+  let releaseError: Error | undefined;
   try {
     await client.query('BEGIN');
     transactionOpen = true;
@@ -148,7 +223,7 @@ export async function runRankingV2Shadow(
       context.policy.topicWeights,
       bridging
     );
-    const sourceDiversityWeight = requiredWeight(context.policy.weights, 'sourceDiversity');
+    const sourceDiversityWeight = requireWeight(context.policy.weights, 'sourceDiversity');
     const slate = new SourceDiversitySlateReranker(sourceDiversityWeight).rerank(
       features,
       Math.min(RANKING_V2_SLATE_LIMIT, features.length)
@@ -160,6 +235,7 @@ export async function runRankingV2Shadow(
       policyHash: context.policy.policyHash,
       configurationHash: context.configurationHash,
       asOf: context.asOf,
+      sourceDiversityWeight,
       candidates: features.map(toReplayCandidate),
     };
     const compressed = createCompressedRankingInput(envelope);
@@ -217,14 +293,15 @@ export async function runRankingV2Shadow(
       }
     }
     if (cleanupErrors.length > 0) {
-      throw new AggregateError(
+      releaseError = new AggregateError(
         [error, ...cleanupErrors],
         `Ranking v2 failed and cleanup was incomplete: ${messageFromError(error)}`
       );
+      throw releaseError;
     }
     throw error;
   } finally {
-    client.release();
+    client.release(releaseError);
   }
 }
 
@@ -248,8 +325,9 @@ async function loadEligibleCandidates(
       WHERE p.deleted = FALSE
         AND p.created_at > $1
         AND p.created_at <= $2
-      ORDER BY p.created_at DESC, p.uri ASC`,
-    [cutoff.toISOString(), asOf.toISOString()]
+      ORDER BY p.created_at DESC, p.uri ASC
+      LIMIT $3`,
+    [cutoff.toISOString(), asOf.toISOString(), MAX_CANDIDATE_FETCH]
   );
   const inputs: RankingV2CandidateInput[] = [];
   let exclusionCount = 0;
@@ -262,11 +340,11 @@ async function loadEligibleCandidates(
     const relevance = scoreTopicVectorRelevance(post.topicVector, { ...topicWeights });
     const preliminaryScore = (
       scoreRecencyAt(post.createdAt, RANKING_V2_SCORING_WINDOW_HOURS, asOf)
-        * requiredWeight(weights, 'recency')
+        * requireWeight(weights, 'recency')
     ) + (
       scoreEngagement(post.likeCount, post.repostCount, post.replyCount)
-        * requiredWeight(weights, 'engagement')
-    ) + (relevance * requiredWeight(weights, 'relevance'));
+        * requireWeight(weights, 'engagement')
+    ) + (relevance * requireWeight(weights, 'relevance'));
     inputs.push({
       post,
       policyRelevance: relevance,
@@ -286,7 +364,12 @@ function toReplayCandidate(feature: ReturnType<typeof computeRankingV2Features>[
     immutable: {
       cid: feature.candidate.post.cid,
       text: feature.candidate.post.text,
+      replyRoot: feature.candidate.post.replyRoot,
+      replyParent: feature.candidate.post.replyParent,
+      langs: [...feature.candidate.post.langs],
+      hasMedia: feature.candidate.post.hasMedia,
       topicVector: feature.candidate.post.topicVector ?? {},
+      classificationMethod: feature.candidate.post.classificationMethod ?? null,
     },
     eventTime: {
       likeCount: feature.candidate.post.likeCount,
@@ -313,128 +396,38 @@ function policyContentRules(contentRules: JsonObject): ContentRules {
   return toContentRules(contentRules);
 }
 
-function requiredWeight(weights: Readonly<Record<string, number>>, key: string): number {
-  const value = weights[key];
-  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
-    throw new Error(`Pinned policy is missing weight in [0, 1] for ${key}`);
-  }
-  return value;
-}
-
-function replayFeature(candidate: JsonObject, index: number): ReturnType<typeof computeRankingV2Features>[number] {
-  const uri = requiredString(candidate.uri, `candidates[${index}].uri`);
-  const createdAt = requiredDate(candidate.createdAt, `candidates[${index}].createdAt`);
-  const authorDid = requiredString(candidate.authorDid, `candidates[${index}].authorDid`);
-  const immutable = requiredObject(candidate.immutable, `candidates[${index}].immutable`);
-  const eventTime = requiredObject(candidate.eventTime, `candidates[${index}].eventTime`);
-  const raw = numericRecord(candidate.raw, `candidates[${index}].raw`);
-  const weights = numericRecord(candidate.weights, `candidates[${index}].weights`);
-  const weighted = numericRecord(candidate.weighted, `candidates[${index}].weighted`);
-  const baseScore = requiredNumber(candidate.baseScore, `candidates[${index}].baseScore`);
-  const candidateSources = requiredCandidateSources(
-    candidate.candidateSources,
-    `candidates[${index}].candidateSources`
-  );
+function replayFeature(candidate: ReplayCandidate): ReturnType<typeof computeRankingV2Features>[number] {
+  const immutable = candidate.immutable;
+  const eventTime = candidate.eventTime;
   return {
     candidate: {
       post: {
-        uri,
-        cid: requiredString(immutable.cid, `candidates[${index}].immutable.cid`),
-        authorDid,
-        text: optionalString(immutable.text, `candidates[${index}].immutable.text`),
-        replyRoot: null,
-        replyParent: null,
-        langs: [],
-        hasMedia: false,
-        createdAt,
-        likeCount: requiredNumber(eventTime.likeCount, `candidates[${index}].eventTime.likeCount`),
-        repostCount: requiredNumber(eventTime.repostCount, `candidates[${index}].eventTime.repostCount`),
-        replyCount: requiredNumber(eventTime.replyCount, `candidates[${index}].eventTime.replyCount`),
-        topicVector: numericRecord(
-          immutable.topicVector,
-          `candidates[${index}].immutable.topicVector`
-        ),
-        classificationMethod: 'keyword',
+        uri: candidate.uri,
+        cid: immutable.cid,
+        authorDid: candidate.authorDid,
+        text: immutable.text,
+        replyRoot: immutable.replyRoot,
+        replyParent: immutable.replyParent,
+        langs: immutable.langs,
+        hasMedia: immutable.hasMedia,
+        createdAt: new Date(candidate.createdAt),
+        likeCount: eventTime.likeCount,
+        repostCount: eventTime.repostCount,
+        replyCount: eventTime.replyCount,
+        topicVector: immutable.topicVector,
+        classificationMethod: immutable.classificationMethod ?? undefined,
       },
-      policyRelevance: raw.relevance ?? 0,
+      policyRelevance: candidate.raw.relevance ?? 0,
       previousSnapshotPosition: null,
-      preliminaryScore: baseScore,
-      candidateSources,
+      preliminaryScore: candidate.baseScore,
+      candidateSources: candidate.candidateSources,
     },
-    raw,
-    weights,
-    weighted,
-    evidence: requiredObject(candidate.evidence, `candidates[${index}].evidence`),
-    baseScore,
+    raw: candidate.raw,
+    weights: candidate.weights,
+    weighted: candidate.weighted,
+    evidence: candidate.evidence,
+    baseScore: candidate.baseScore,
   };
-}
-
-function requiredObject(value: JsonValue | undefined, label: string): JsonObject {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value;
-}
-
-function requiredString(value: JsonValue | undefined, label: string): string {
-  if (typeof value !== 'string' || value.length === 0) {
-    throw new Error(`${label} must be a non-empty string`);
-  }
-  return value;
-}
-
-function optionalString(value: JsonValue | undefined, label: string): string | null {
-  if (value === null) return null;
-  if (typeof value !== 'string') {
-    throw new Error(`${label} must be a string or null`);
-  }
-  return value;
-}
-
-function requiredNumber(value: JsonValue | undefined, label: string): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error(`${label} must be a finite number`);
-  }
-  return value;
-}
-
-function requiredDate(value: JsonValue | undefined, label: string): Date {
-  const date = new Date(requiredString(value, label));
-  if (!Number.isFinite(date.getTime())) {
-    throw new Error(`${label} must be a valid timestamp`);
-  }
-  return date;
-}
-
-function numericRecord(value: JsonValue | undefined, label: string): Record<string, number> {
-  const object = requiredObject(value, label);
-  const output: Record<string, number> = {};
-  for (const [key, member] of Object.entries(object)) {
-    output[key] = requiredNumber(member, `${label}.${key}`);
-  }
-  return output;
-}
-
-function requiredCandidateSources(
-  value: JsonValue | undefined,
-  label: string
-): readonly CandidateSource[] {
-  if (!Array.isArray(value)) {
-    throw new Error(`${label} must be an array`);
-  }
-  const allowed = new Set<CandidateSource>([
-    'newest',
-    'engagement',
-    'policy_relevance',
-    'previous_snapshot',
-    'preliminary_fill',
-  ]);
-  return value.map((member, index) => {
-    if (typeof member !== 'string' || !allowed.has(member as CandidateSource)) {
-      throw new Error(`${label}[${index}] is not a valid candidate source`);
-    }
-    return member as CandidateSource;
-  });
 }
 
 function assertOptions(options: RankingV2ShadowOptions): void {

--- a/src/scoring/score.types.ts
+++ b/src/scoring/score.types.ts
@@ -7,6 +7,10 @@
 
 import type { GovernanceWeights } from '../shared/api-types.js';
 
+export const CLASSIFICATION_METHODS = ['keyword', 'embedding'] as const;
+
+export type ClassificationMethod = typeof CLASSIFICATION_METHODS[number];
+
 /**
  * Per-component score map: `Record<componentKey, value 0..1>`. Was a 5-field
  * interface before PROJ-816; now reuses the registry-driven shape from
@@ -89,7 +93,7 @@ export interface PostForScoring {
   /** Topic classification vector from ingestion. Slug → confidence (0.0-1.0). */
   topicVector?: Record<string, number>;
   /** Which classifier produced the topic_vector: winkNLP keywords or Transformers.js embeddings. */
-  classificationMethod?: 'keyword' | 'embedding';
+  classificationMethod?: ClassificationMethod;
 }
 
 function weightFromRow(row: Record<string, unknown>, field: string): number {

--- a/src/shared/ranking-contracts.ts
+++ b/src/shared/ranking-contracts.ts
@@ -99,6 +99,8 @@ export interface RankingRunInputEnvelope {
   policyHash: string;
   configurationHash: string;
   asOf: string;
+  /** Required for v2 exact replay; optional only for retained v1 contract inputs. */
+  sourceDiversityWeight?: number;
   candidates: readonly JsonObject[];
 }
 

--- a/src/shared/ranking-contracts.ts
+++ b/src/shared/ranking-contracts.ts
@@ -14,12 +14,15 @@ export type RankingRunState =
   | 'superseded'
   | 'rejected';
 
-export type CandidateSource =
-  | 'newest'
-  | 'engagement'
-  | 'policy_relevance'
-  | 'previous_snapshot'
-  | 'preliminary_fill';
+export const CANDIDATE_SOURCES = [
+  'newest',
+  'engagement',
+  'policy_relevance',
+  'previous_snapshot',
+  'preliminary_fill',
+] as const;
+
+export type CandidateSource = typeof CANDIDATE_SOURCES[number];
 
 export interface PolicyProvenanceReference {
   kind: string;

--- a/src/shared/ranking-contracts.ts
+++ b/src/shared/ranking-contracts.ts
@@ -45,6 +45,25 @@ export interface PolicyBundle extends GovernancePolicyDocument {
   createdAt: string;
 }
 
+export interface RankingRunContext {
+  runId: string;
+  communityId: string;
+  asOf: string;
+  policy: PolicyBundle;
+  algorithmVersion: string;
+  configurationHash: string;
+  codeSha: string;
+}
+
+export type EvidenceState = 'observed' | 'insufficient';
+
+export interface ComponentEvidence {
+  raw: number;
+  weight: number;
+  weighted: number;
+  evidenceState: EvidenceState;
+}
+
 export interface RankingReceipt {
   schemaVersion: 1;
   runId: string;

--- a/tests/harness/ranking-v2.sim.ts
+++ b/tests/harness/ranking-v2.sim.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { db } from '../../src/db/client.js';
+import { scoreBridging, scoreBridgingBatch } from '../../src/scoring/components/bridging.js';
+import {
+  buildRankingReceipt,
+  decodeCompressedRankingInput,
+  loadRankingRunInput,
+} from '../../src/scoring/ranking-run-contracts.js';
+import { replayRankingV2Slate, runRankingV2Shadow } from '../../src/scoring/ranking-v2.js';
+import { insertActiveEpoch, resetHarnessData } from './helpers.js';
+
+const CODE_SHA = 'c'.repeat(40);
+
+describe('corgi-ranking-v2 shadow runner against real PostgreSQL', () => {
+  beforeEach(async () => {
+    await resetHarnessData();
+  });
+
+  afterEach(async () => {
+    await resetHarnessData();
+  });
+
+  it('persists a validated replayable run without publishing Redis state', async () => {
+    const asOf = new Date('2026-07-11T20:00:00.000Z');
+    await seedPolicy();
+    await seedPosts(asOf);
+
+    const result = await runRankingV2Shadow(db, {
+      communityId: 'community-gov',
+      asOf,
+      codeSha: CODE_SHA,
+      previousSnapshotPositions: new Map([
+        ['at://did:plc:author-a/app.bsky.feed.post/1', 1],
+      ]),
+    });
+
+    expect(result.candidateCount).toBe(3);
+    expect(result.selectedCount).toBe(3);
+    const stored = await db.query<{
+      state: string;
+      candidate_count: number;
+      selected_count: number;
+      receipt_checksum: string;
+    }>(
+      `SELECT state, candidate_count, selected_count, receipt_checksum
+         FROM ranking_runs
+        WHERE id = $1`,
+      [result.context.runId]
+    );
+    expect(stored.rows[0]).toMatchObject({
+      state: 'validated',
+      candidate_count: 3,
+      selected_count: 3,
+      receipt_checksum: result.receipt.receiptChecksum,
+    });
+    const redisKeys = await db.query<{ count: number }>(
+      `SELECT COUNT(*)::int AS count FROM ranking_run_items WHERE run_id = $1`,
+      [result.context.runId]
+    );
+    expect(redisKeys.rows[0].count).toBe(3);
+
+    const client = await db.connect();
+    try {
+      const compressed = await loadRankingRunInput(client, result.context.runId);
+      const envelope = decodeCompressedRankingInput(compressed);
+      const replayedSlate = replayRankingV2Slate(
+        envelope,
+        result.context.policy.weights.sourceDiversity
+      );
+      const replayedReceipt = buildRankingReceipt({
+        runId: result.context.runId,
+        communityId: result.context.communityId,
+        policyVersionId: result.context.policy.policyVersionId,
+        policyHash: result.context.policy.policyHash,
+        algorithmVersion: result.context.algorithmVersion,
+        configurationHash: result.context.configurationHash,
+        codeSha: result.context.codeSha,
+        asOf: result.context.asOf,
+        inputChecksum: compressed.checksum,
+        items: replayedSlate,
+      });
+      expect(replayedReceipt.itemOrderChecksum).toBe(result.receipt.itemOrderChecksum);
+      expect(replayedReceipt.receiptChecksum).toBe(result.receipt.receiptChecksum);
+    } finally {
+      client.release();
+    }
+  });
+
+  it('reproduces the exact item order for the same asOf and policy', async () => {
+    const asOf = new Date('2026-07-11T20:00:00.000Z');
+    await seedPolicy();
+    await seedPosts(asOf);
+    const options = {
+      communityId: 'community-gov',
+      asOf,
+      codeSha: CODE_SHA,
+      previousSnapshotPositions: new Map<string, number>(),
+    };
+
+    const first = await runRankingV2Shadow(db, options);
+    const second = await runRankingV2Shadow(db, options);
+
+    expect(second.receipt.itemOrderChecksum).toBe(first.receipt.itemOrderChecksum);
+    expect(second.receipt.inputChecksum).not.toBe(first.receipt.inputChecksum);
+    const orders = await Promise.all([first.context.runId, second.context.runId].map(async (runId) => {
+      const rows = await db.query<{ post_uri: string }>(
+        `SELECT post_uri FROM ranking_run_items WHERE run_id = $1 ORDER BY position`,
+        [runId]
+      );
+      return rows.rows.map((row) => row.post_uri);
+    }));
+    expect(orders[1]).toEqual(orders[0]);
+  });
+
+  it('matches the legacy single-post bridging calculation with batched queries', async () => {
+    const asOf = new Date('2026-07-11T20:00:00.000Z');
+    await seedPolicy();
+    await seedPosts(asOf);
+    const uri = 'at://did:plc:author-a/app.bsky.feed.post/1';
+    await seedBridgingEvidence(uri, asOf);
+    const post = {
+      uri,
+      cid: 'cid-1',
+      authorDid: 'did:plc:author-a',
+      text: 'corgi community post',
+      replyRoot: null,
+      replyParent: null,
+      langs: ['en'],
+      hasMedia: false,
+      createdAt: new Date(asOf.getTime() - 60 * 60 * 1000),
+      likeCount: 2,
+      repostCount: 0,
+      replyCount: 0,
+      topicVector: { corgi: 0.8 },
+      classificationMethod: 'keyword' as const,
+    };
+
+    const legacy = await scoreBridging(uri, post.authorDid);
+    const client = await db.connect();
+    try {
+      const batch = await scoreBridgingBatch(client, [post]);
+      const evidence = batch.get(`${uri}\u0000${post.createdAt.toISOString()}`);
+      expect(evidence?.evidenceState).toBe('observed');
+      expect(evidence?.raw).toBeCloseTo(legacy, 12);
+    } finally {
+      client.release();
+    }
+  });
+
+  it('persists an explicit failed state when a shadow run has no candidates', async () => {
+    const asOf = new Date('2026-07-11T20:00:00.000Z');
+    await seedPolicy();
+
+    await expect(runRankingV2Shadow(db, {
+      communityId: 'community-gov',
+      asOf,
+      codeSha: CODE_SHA,
+      previousSnapshotPositions: new Map(),
+    })).rejects.toThrow(/no eligible candidates/);
+
+    const stored = await db.query<{ state: string; failure: { message: string } }>(
+      `SELECT state, failure
+         FROM ranking_runs
+        ORDER BY created_at DESC
+        LIMIT 1`
+    );
+    expect(stored.rows[0].state).toBe('failed');
+    expect(stored.rows[0].failure.message).toMatch(/no eligible candidates/);
+  });
+});
+
+async function seedPolicy(): Promise<void> {
+  const epochId = await insertActiveEpoch('ranking v2 shadow epoch');
+  const weights = {
+    recency: 0.2,
+    engagement: 0.2,
+    bridging: 0.2,
+    sourceDiversity: 0.2,
+    relevance: 0.2,
+  };
+  for (const [componentKey, weight] of Object.entries(weights)) {
+    await db.query(
+      `INSERT INTO governance_epoch_weights (epoch_id, component_key, weight)
+       VALUES ($1, $2, $3)`,
+      [epochId, componentKey, weight]
+    );
+  }
+  await db.query(
+    `INSERT INTO governance_audit_log (action, epoch_id, details)
+     VALUES ('weights_changed', $1, $2::jsonb)`,
+    [epochId, JSON.stringify({ new_weights: weights })]
+  );
+}
+
+async function seedPosts(asOf: Date): Promise<void> {
+  const posts = [
+    ['author-a', '1', 1, 1, 0],
+    ['author-a', '2', 5, 0, 0],
+    ['author-b', '3', 2, 1, 1],
+  ] as const;
+  for (let index = 0; index < posts.length; index += 1) {
+    const [author, rkey, likes, reposts, replies] = posts[index];
+    const uri = `at://did:plc:${author}/app.bsky.feed.post/${rkey}`;
+    const createdAt = new Date(asOf.getTime() - ((index + 1) * 60 * 60 * 1000));
+    await db.query(
+      `INSERT INTO posts (
+         uri, cid, author_did, text, langs, has_media, created_at,
+         topic_vector, classification_method, deleted
+       ) VALUES ($1, $2, $3, $4, $5, FALSE, $6, $7::jsonb, 'keyword', FALSE)`,
+      [uri, `cid-${rkey}`, `did:plc:${author}`, 'corgi community post', ['en'], createdAt, JSON.stringify({ corgi: 0.8 })]
+    );
+    await db.query(
+      `INSERT INTO post_engagement (post_uri, like_count, repost_count, reply_count)
+       VALUES ($1, $2, $3, $4)`,
+      [uri, likes, reposts, replies]
+    );
+  }
+}
+
+async function seedBridgingEvidence(uri: string, asOf: Date): Promise<void> {
+  const engagers = ['did:plc:engager-a', 'did:plc:engager-b'];
+  for (let index = 0; index < engagers.length; index += 1) {
+    await db.query(
+      `INSERT INTO likes (uri, author_did, subject_uri, created_at, deleted)
+       VALUES ($1, $2, $3, $4, FALSE)`,
+      [`at://${engagers[index]}/app.bsky.feed.like/${index}`, engagers[index], uri, asOf]
+    );
+  }
+  const follows = [
+    [engagers[0], 'did:plc:shared'],
+    [engagers[0], 'did:plc:left'],
+    [engagers[1], 'did:plc:shared'],
+    [engagers[1], 'did:plc:right'],
+  ] as const;
+  for (let index = 0; index < follows.length; index += 1) {
+    await db.query(
+      `INSERT INTO follows (uri, author_did, subject_did, created_at, deleted)
+       VALUES ($1, $2, $3, $4, FALSE)`,
+      [`at://${follows[index][0]}/app.bsky.graph.follow/${index}`, follows[index][0], follows[index][1], asOf]
+    );
+  }
+}

--- a/tests/harness/ranking-v2.sim.ts
+++ b/tests/harness/ranking-v2.sim.ts
@@ -63,10 +63,24 @@ describe('corgi-ranking-v2 shadow runner against real PostgreSQL', () => {
     try {
       const compressed = await loadRankingRunInput(client, result.context.runId);
       const envelope = decodeCompressedRankingInput(compressed);
+      expect(envelope.sourceDiversityWeight).toBe(
+        result.context.policy.weights.sourceDiversity
+      );
+      expect(envelope.candidates[0]?.immutable).toMatchObject({
+        replyRoot: null,
+        replyParent: null,
+        langs: ['en'],
+        hasMedia: false,
+        classificationMethod: 'keyword',
+      });
       const replayedSlate = replayRankingV2Slate(
         envelope,
         result.context.policy.weights.sourceDiversity
       );
+      expect(() => replayRankingV2Slate(
+        envelope,
+        result.context.policy.weights.sourceDiversity + 0.1
+      )).toThrow(/sourceDiversityWeight mismatch/);
       const replayedReceipt = buildRankingReceipt({
         runId: result.context.runId,
         communityId: result.context.communityId,

--- a/tests/ranking-v2.test.ts
+++ b/tests/ranking-v2.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
 import { calculateBridgingEvidence } from '../src/scoring/components/bridging.js';
 import { scoreRecencyAt } from '../src/scoring/components/recency.js';
 import {
@@ -7,8 +9,14 @@ import {
   type RankingV2CandidateInput,
 } from '../src/scoring/ranking-v2-candidates.js';
 import type { RankingV2FeatureVector } from '../src/scoring/ranking-v2-features.js';
-import { SourceDiversitySlateReranker, diversityRaw } from '../src/scoring/ranking-v2-slate.js';
+import {
+  RANKING_V2_SLATE_LIMIT,
+  SourceDiversitySlateReranker,
+  diversityRaw,
+} from '../src/scoring/ranking-v2-slate.js';
+import { replayRankingV2Slate, runRankingV2Shadow } from '../src/scoring/ranking-v2.js';
 import type { PostForScoring } from '../src/scoring/score.types.js';
+import type { RankingRunInputEnvelope } from '../src/shared/ranking-contracts.js';
 
 const AS_OF = new Date('2026-07-11T20:00:00.000Z');
 
@@ -17,6 +25,13 @@ describe('corgi-ranking-v2', () => {
     expect(scoreRecencyAt('2026-07-11T02:00:00.000Z', 72, AS_OF)).toBeCloseTo(0.5, 12);
     expect(scoreRecencyAt('2026-07-10T08:00:00.000Z', 72, AS_OF)).toBeCloseTo(0.25, 12);
     expect(scoreRecencyAt('2026-07-12T00:00:00.000Z', 72, AS_OF)).toBe(1);
+  });
+
+  it('handles recency boundaries and rejects invalid inputs', () => {
+    expect(scoreRecencyAt('2026-07-08T20:00:00.000Z', 72, AS_OF)).toBeCloseTo(0.0625, 12);
+    expect(scoreRecencyAt('2026-07-08T19:59:59.999Z', 72, AS_OF)).toBe(0.01);
+    expect(() => scoreRecencyAt('2026-07-11T02:00:00.000Z', 0, AS_OF)).toThrow(RangeError);
+    expect(() => scoreRecencyAt('not-a-date', 72, AS_OF)).toThrow(RangeError);
   });
 
   it('builds a candidate union independent of input order', () => {
@@ -72,6 +87,16 @@ describe('corgi-ranking-v2', () => {
 
   it('uses the governed diversity schedule', () => {
     expect([0, 1, 2, 3, 10].map(diversityRaw)).toEqual([1, 0.7, 0.5, 0.3, 0.3]);
+  });
+
+  it('rejects invalid diversity weights and slate limits', () => {
+    expect(() => new SourceDiversitySlateReranker(-0.1)).toThrow(RangeError);
+    expect(() => new SourceDiversitySlateReranker(1.1)).toThrow(RangeError);
+    const reranker = new SourceDiversitySlateReranker(0.2);
+    expect(() => reranker.rerank([], -1)).toThrow(RangeError);
+    expect(() => reranker.rerank([], 1.5)).toThrow(RangeError);
+    expect(() => reranker.rerank([], RANKING_V2_SLATE_LIMIT + 1)).toThrow(RangeError);
+    expect(reranker.rerank([feature(0, 'did:plc:a', 0.9)], 0)).toEqual([]);
   });
 
   it('reduces to base-score ordering when diversity weight is zero', () => {
@@ -131,6 +156,46 @@ describe('corgi-ranking-v2', () => {
       'at://did:plc:a/app.bsky.feed.post/1',
       'at://did:plc:b/app.bsky.feed.post/2',
     ]);
+  });
+
+  it('destroys a database client when rollback leaves its state unknown', async () => {
+    const release = vi.fn();
+    const query = vi.fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(new Error('policy read failed'))
+      .mockRejectedValueOnce(new Error('rollback failed'));
+    const pool = {
+      connect: vi.fn().mockResolvedValue({ query, release }),
+    } as unknown as Pool;
+
+    await expect(runRankingV2Shadow(pool, {
+      communityId: 'community-gov',
+      asOf: AS_OF,
+      codeSha: 'c'.repeat(40),
+      previousSnapshotPositions: new Map(),
+    })).rejects.toThrow(AggregateError);
+    expect(release).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('reports structured replay validation failures', () => {
+    const malformed = {
+      schemaVersion: 1,
+      runId: 'run',
+      communityId: 'community-gov',
+      policyHash: 'a'.repeat(64),
+      configurationHash: 'b'.repeat(64),
+      asOf: AS_OF.toISOString(),
+      sourceDiversityWeight: 2,
+      candidates: [{ uri: '', createdAt: 'not-a-date' }],
+    } as unknown as RankingRunInputEnvelope;
+
+    try {
+      replayRankingV2Slate(malformed);
+      throw new Error('Expected replay validation to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ZodError);
+      expect((error as ZodError).issues.length).toBeGreaterThan(2);
+    }
   });
 });
 

--- a/tests/ranking-v2.test.ts
+++ b/tests/ranking-v2.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { calculateBridgingEvidence } from '../src/scoring/components/bridging.js';
+import { scoreRecencyAt } from '../src/scoring/components/recency.js';
+import {
+  buildCandidateUnion,
+  type RankingV2Candidate,
+  type RankingV2CandidateInput,
+} from '../src/scoring/ranking-v2-candidates.js';
+import type { RankingV2FeatureVector } from '../src/scoring/ranking-v2-features.js';
+import { SourceDiversitySlateReranker, diversityRaw } from '../src/scoring/ranking-v2-slate.js';
+import type { PostForScoring } from '../src/scoring/score.types.js';
+
+const AS_OF = new Date('2026-07-11T20:00:00.000Z');
+
+describe('corgi-ranking-v2', () => {
+  it('evaluates recency against the immutable asOf clock', () => {
+    expect(scoreRecencyAt('2026-07-11T02:00:00.000Z', 72, AS_OF)).toBeCloseTo(0.5, 12);
+    expect(scoreRecencyAt('2026-07-10T08:00:00.000Z', 72, AS_OF)).toBeCloseTo(0.25, 12);
+    expect(scoreRecencyAt('2026-07-12T00:00:00.000Z', 72, AS_OF)).toBe(1);
+  });
+
+  it('builds a candidate union independent of input order', () => {
+    const inputs = Array.from({ length: 40 }, (_, index) => candidateInput(index));
+    const forward = buildCandidateUnion(inputs);
+    const reverse = buildCandidateUnion([...inputs].reverse());
+    expect(forward).toEqual(reverse);
+  });
+
+  it('preserves every source that selected the same candidate', () => {
+    const selected = buildCandidateUnion([candidateInput(0)]);
+    expect(selected[0].candidateSources).toEqual([
+      'newest',
+      'engagement',
+      'policy_relevance',
+      'previous_snapshot',
+    ]);
+  });
+
+  it('fills unused source capacity to the deterministic 5,000 candidate limit', () => {
+    const inputs = Array.from({ length: 5_100 }, (_, index) => candidateInput(index));
+    const selected = buildCandidateUnion(inputs);
+    expect(selected).toHaveLength(5_000);
+    expect(selected.some((candidate) => candidate.candidateSources.includes('preliminary_fill'))).toBe(true);
+  });
+
+  it('deduplicates identical URI and creation-time identities', () => {
+    const duplicate = candidateInput(0);
+    expect(buildCandidateUnion([duplicate, duplicate])).toHaveLength(1);
+  });
+
+  it('records insufficient bridging evidence explicitly', () => {
+    expect(calculateBridgingEvidence(['did:plc:a'], new Map())).toEqual({
+      raw: 0.3,
+      evidenceState: 'insufficient',
+      engagerCount: 1,
+      pairCount: 0,
+    });
+  });
+
+  it('computes observed bridging as average pairwise Jaccard distance', () => {
+    const evidence = calculateBridgingEvidence(
+      ['did:plc:a', 'did:plc:b'],
+      new Map([
+        ['did:plc:a', new Set(['x', 'y'])],
+        ['did:plc:b', new Set(['y', 'z'])],
+      ])
+    );
+    expect(evidence.evidenceState).toBe('observed');
+    expect(evidence.raw).toBeCloseTo(2 / 3, 12);
+    expect(evidence.pairCount).toBe(1);
+  });
+
+  it('uses the governed diversity schedule', () => {
+    expect([0, 1, 2, 3, 10].map(diversityRaw)).toEqual([1, 0.7, 0.5, 0.3, 0.3]);
+  });
+
+  it('reduces to base-score ordering when diversity weight is zero', () => {
+    const items = [
+      feature(0, 'did:plc:a', 0.9),
+      feature(1, 'did:plc:b', 0.8),
+      feature(2, 'did:plc:a', 0.85),
+    ];
+    const slate = new SourceDiversitySlateReranker(0).rerank(items, 3);
+    expect(slate.map((item) => item.postUri)).toEqual([
+      'at://did:plc:a/app.bsky.feed.post/0',
+      'at://did:plc:a/app.bsky.feed.post/2',
+      'at://did:plc:b/app.bsky.feed.post/1',
+    ]);
+  });
+
+  it('lets diversity affect the selected slate at the current objective weight', () => {
+    const items = [
+      feature(0, 'did:plc:a', 0.9),
+      feature(1, 'did:plc:a', 0.89),
+      feature(2, 'did:plc:b', 0.85),
+    ];
+    const slate = new SourceDiversitySlateReranker(0.2).rerank(items, 3);
+    expect(slate.map((item) => item.authorDid)).toEqual([
+      'did:plc:a',
+      'did:plc:b',
+      'did:plc:a',
+    ]);
+    expect(slate[1].diversityContext).toMatchObject({
+      authorCountBeforeSelection: 0,
+      raw: 1,
+      weightedContribution: 0.2,
+    });
+  });
+
+  it('strongly favors a new author when diversity weight is one', () => {
+    const items = [
+      feature(0, 'did:plc:a', 0.9),
+      feature(1, 'did:plc:a', 0.89),
+      feature(2, 'did:plc:b', 0.7),
+    ];
+    const slate = new SourceDiversitySlateReranker(1).rerank(items, 3);
+    expect(slate.map((item) => item.authorDid)).toEqual([
+      'did:plc:a',
+      'did:plc:b',
+      'did:plc:a',
+    ]);
+  });
+
+  it('uses deterministic creation-time and URI tie breaks', () => {
+    const first = feature(1, 'did:plc:a', 0.5);
+    const second = feature(2, 'did:plc:b', 0.5);
+    first.candidate.post.createdAt = new Date('2026-07-11T19:00:00.000Z');
+    second.candidate.post.createdAt = new Date('2026-07-11T19:00:00.000Z');
+    const slate = new SourceDiversitySlateReranker(0).rerank([second, first], 2);
+    expect(slate.map((item) => item.postUri)).toEqual([
+      'at://did:plc:a/app.bsky.feed.post/1',
+      'at://did:plc:b/app.bsky.feed.post/2',
+    ]);
+  });
+});
+
+function candidateInput(index: number): RankingV2CandidateInput {
+  return {
+    post: post(index, `did:plc:${index % 8}`),
+    policyRelevance: (index % 10) / 10,
+    previousSnapshotPosition: index < 5 ? index + 1 : null,
+    preliminaryScore: (index % 13) / 13,
+  };
+}
+
+function post(index: number, authorDid: string): PostForScoring {
+  return {
+    uri: `at://${authorDid}/app.bsky.feed.post/${index}`,
+    cid: `cid-${index}`,
+    authorDid,
+    text: `post ${index}`,
+    replyRoot: null,
+    replyParent: null,
+    langs: ['en'],
+    hasMedia: false,
+    createdAt: new Date(AS_OF.getTime() - (index * 60_000)),
+    likeCount: index,
+    repostCount: index % 3,
+    replyCount: index % 2,
+    topicVector: { corgi: 0.8 },
+    classificationMethod: 'keyword',
+  };
+}
+
+function feature(index: number, authorDid: string, baseScore: number): RankingV2FeatureVector {
+  const candidate: RankingV2Candidate = {
+    ...candidateInput(index),
+    post: post(index, authorDid),
+    candidateSources: ['newest'],
+  };
+  return {
+    candidate,
+    raw: { recency: 1, engagement: baseScore, bridging: 0.3, relevance: 0.5 },
+    weights: { recency: 0, engagement: 1, bridging: 0, relevance: 0 },
+    weighted: { recency: 0, engagement: baseScore, bridging: 0, relevance: 0 },
+    evidence: { bridging: { evidenceState: 'insufficient', engagerCount: 0, pairCount: 0 } },
+    baseScore,
+  };
+}

--- a/tests/ranking-v2.test.ts
+++ b/tests/ranking-v2.test.ts
@@ -8,7 +8,10 @@ import {
   type RankingV2Candidate,
   type RankingV2CandidateInput,
 } from '../src/scoring/ranking-v2-candidates.js';
-import type { RankingV2FeatureVector } from '../src/scoring/ranking-v2-features.js';
+import {
+  computeRankingV2Features,
+  type RankingV2FeatureVector,
+} from '../src/scoring/ranking-v2-features.js';
 import {
   RANKING_V2_SLATE_LIMIT,
   SourceDiversitySlateReranker,
@@ -83,6 +86,21 @@ describe('corgi-ranking-v2', () => {
     expect(evidence.evidenceState).toBe('observed');
     expect(evidence.raw).toBeCloseTo(2 / 3, 12);
     expect(evidence.pairCount).toBe(1);
+  });
+
+  it('rejects a candidate with missing bridging evidence', () => {
+    const candidate: RankingV2Candidate = {
+      ...candidateInput(0),
+      candidateSources: ['newest'],
+    };
+    expect(() => computeRankingV2Features(
+      [candidate],
+      AS_OF,
+      72,
+      { recency: 0.2, engagement: 0.2, bridging: 0.2, relevance: 0.2 },
+      { corgi: 1 },
+      new Map()
+    )).toThrow(/Missing bridging evidence/);
   });
 
   it('uses the governed diversity schedule', () => {
@@ -197,7 +215,69 @@ describe('corgi-ranking-v2', () => {
       expect((error as ZodError).issues.length).toBeGreaterThan(2);
     }
   });
+
+  it('rejects unknown replay candidate sources and classification methods', () => {
+    const candidate = replayCandidate();
+    const invalidSource = replayEnvelope({
+      ...candidate,
+      candidateSources: ['unknown_source'],
+    });
+    const invalidClassification = replayEnvelope({
+      ...candidate,
+      immutable: {
+        ...candidate.immutable,
+        classificationMethod: 'unknown_classifier',
+      },
+    });
+
+    expect(() => replayRankingV2Slate(invalidSource)).toThrow(ZodError);
+    expect(() => replayRankingV2Slate(invalidClassification)).toThrow(ZodError);
+  });
 });
+
+function replayCandidate() {
+  return {
+    uri: 'at://did:plc:a/app.bsky.feed.post/replay',
+    createdAt: AS_OF.toISOString(),
+    authorDid: 'did:plc:a',
+    candidateSources: ['newest'],
+    immutable: {
+      cid: 'cid-replay',
+      text: 'replay post',
+      replyRoot: null,
+      replyParent: null,
+      langs: ['en'],
+      hasMedia: false,
+      topicVector: { corgi: 1 },
+      classificationMethod: 'keyword',
+    },
+    eventTime: { likeCount: 1, repostCount: 0, replyCount: 0 },
+    raw: { recency: 1, engagement: 0.1, bridging: 0.3, relevance: 1 },
+    weights: { recency: 0.2, engagement: 0.2, bridging: 0.2, relevance: 0.2 },
+    weighted: { recency: 0.2, engagement: 0.02, bridging: 0.06, relevance: 0.2 },
+    evidence: {
+      bridging: {
+        evidenceState: 'insufficient',
+        engagerCount: 1,
+        pairCount: 0,
+      },
+    },
+    baseScore: 0.48,
+  };
+}
+
+function replayEnvelope(candidate: ReturnType<typeof replayCandidate>): RankingRunInputEnvelope {
+  return {
+    schemaVersion: 1,
+    runId: 'run-replay',
+    communityId: 'community-gov',
+    policyHash: 'a'.repeat(64),
+    configurationHash: 'b'.repeat(64),
+    asOf: AS_OF.toISOString(),
+    sourceDiversityWeight: 0.2,
+    candidates: [candidate],
+  } as unknown as RankingRunInputEnvelope;
+}
 
 function candidateInput(index: number): RankingV2CandidateInput {
   return {


### PR DESCRIPTION
## Summary
- add one immutable RankingRunContext and repeatable-read shadow runner
- build the deterministic 1,500/1,500/1,500/500 candidate union with 5,000 cap
- evaluate recency at asOf, batch bridging evidence, policy relevance, and greedy slate diversity
- persist validated replay inputs, slate items, receipts, and explicit failed-run evidence
- extend the SDK with optional batch scoring and a slate-reranker contract

V1 remains the publisher. This packet does not write live feed Redis keys. Birders behavior is unchanged.

## Evidence
- npm run verify: 137 files, 1,396 tests; backend, CLI, SDK, legacy web, and web-next green
- npm run sim:core: 21 files, 231 tests against real PostgreSQL and Redis
- focused ranking-v2 suite: 18 tests
- exact replay regenerates item-order and receipt checksums
- batch bridging matches the legacy single-post calculation
- all current-head CodeRabbit findings addressed; zero unresolved threads
- direct freshness and thread truth gates pass on 47856fb07eff6d07890b081e2c4b063bbeffea66

## CodeRabbit Audit
Status: exempt
Reason: The current head has a successful CodeRabbit check suite, a current-head review, zero unresolved threads, and both direct truth gates pass, but the GitHub Actions freshness token reproducibly reports the external check suite as missing on repeated reruns.
Follow-up: Remove coderabbit:exempt immediately after merge and track the GitHub Actions external-suite visibility defect separately from ranking work.
Expires: 2026-07-13

Closes PROJ-1766