### PR TITLE
[PROJ-1769] Isolate governed ranking worker from feed serving

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,14 @@ jobs:
             PREV_COMMIT=$(git rev-parse HEAD)
 
             git pull origin main
+            RANKING_READINESS_LIBRARY="ops/lib/ranking-worker-readiness.sh"
+            if [ ! -r "$RANKING_READINESS_LIBRARY" ]; then
+              echo "Required ranking worker readiness library is missing: ${RANKING_READINESS_LIBRARY}"
+              exit 1
+            fi
+            # shellcheck source=/dev/null
+            source "$RANKING_READINESS_LIBRARY"
+            reject_shared_process_role ".env"
             npm ci --ignore-scripts
             node scripts/audit-allowlist.mjs --audit-level=high
             npm run build
@@ -116,40 +124,25 @@ jobs:
             WORKER_INSTALLED=false
             if sudo systemctl cat corgi-ranking-worker.service > /dev/null 2>&1; then
               WORKER_INSTALLED=true
+              validate_ranking_worker_stop_timeout \
+                <(sudo systemctl cat corgi-ranking-worker.service) \
+                ".env"
+              WORKER_RESTART_EPOCH_MS=$(date +%s%3N)
               if ! sudo systemctl restart corgi-ranking-worker; then
                 echo "Ranking worker restart failed; API was not touched"
                 exit 1
               fi
-              WORKER_RESTART_EPOCH_MS=$(date +%s%3N)
 
-              RANKING_COMMUNITY_ID="community-gov"
-              COMMUNITY_CONFIG=""
-              if [ -f .env ]; then
-                if ! COMMUNITY_CONFIG=$(sed -n 's/^RANKING_COMMUNITY_ID=//p' .env | tail -1); then
-                  echo "Could not read RANKING_COMMUNITY_ID from .env"
-                  exit 1
-                fi
-                COMMUNITY_CONFIG=$(printf '%s' "$COMMUNITY_CONFIG" | tr -d "\r\"'")
-                if [ -n "$COMMUNITY_CONFIG" ]; then
-                  RANKING_COMMUNITY_ID="$COMMUNITY_CONFIG"
-                fi
+              RANKING_COMMUNITY_ID=""
+              if ! RANKING_COMMUNITY_ID=$(resolve_ranking_community_id ".env"); then
+                exit 1
               fi
-              WORKER_HEARTBEAT_KEY="corgi:ranking-worker:heartbeat:${RANKING_COMMUNITY_ID}"
-              WORKER_HEALTHY=false
-              for i in 1 2 3; do
-                WORKER_HEARTBEAT=""
-                if ! WORKER_HEARTBEAT=$(sudo docker compose -f docker-compose.prod.yml exec -T redis redis-cli --raw GET "$WORKER_HEARTBEAT_KEY"); then
-                  echo "Ranking worker heartbeat probe failed (attempt $i/3)"
-                elif [ -n "$WORKER_HEARTBEAT" ] && HEARTBEAT_JSON="$WORKER_HEARTBEAT" WORKER_RESTART_EPOCH_MS="$WORKER_RESTART_EPOCH_MS" python3 -c 'import datetime, json, os; payload=json.loads(os.environ["HEARTBEAT_JSON"]); updated=datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00")); age=(datetime.datetime.now(datetime.timezone.utc)-updated).total_seconds(); updated_ms=int(updated.timestamp()*1000); restart_ms=int(os.environ["WORKER_RESTART_EPOCH_MS"]); raise SystemExit(0 if 0 <= age <= 60 and updated_ms >= restart_ms and payload.get("state") != "failed" else 1)'; then
-                  echo "Ranking worker heartbeat passed (attempt $i/3)"
-                  WORKER_HEALTHY=true
-                  break
-                else
-                  echo "Ranking worker heartbeat is missing, malformed, stale, or failed (attempt $i/3)"
-                fi
-                sleep 10
-              done
-              if [ "$WORKER_HEALTHY" != "true" ]; then
+              PROBE_TIMEOUT_SECONDS=5
+              ranking_worker_heartbeat_probe() {
+                local HEARTBEAT_KEY="$1"
+                probe_ranking_worker_heartbeat_with_compose "$PROBE_TIMEOUT_SECONDS" docker-compose.prod.yml "$HEARTBEAT_KEY"
+              }
+              if ! wait_for_ranking_worker_ready "$RANKING_COMMUNITY_ID" "$WORKER_RESTART_EPOCH_MS" 3 10 ranking_worker_heartbeat_probe; then
                 echo "Ranking worker did not become ready; API was not touched"
                 exit 1
               fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,7 @@ jobs:
                 echo "Ranking worker restart failed; API was not touched"
                 exit 1
               fi
+              WORKER_RESTART_EPOCH_MS=$(date +%s%3N)
 
               RANKING_COMMUNITY_ID="community-gov"
               COMMUNITY_CONFIG=""
@@ -139,7 +140,7 @@ jobs:
                 WORKER_HEARTBEAT=""
                 if ! WORKER_HEARTBEAT=$(sudo docker compose -f docker-compose.prod.yml exec -T redis redis-cli --raw GET "$WORKER_HEARTBEAT_KEY"); then
                   echo "Ranking worker heartbeat probe failed (attempt $i/3)"
-                elif [ -n "$WORKER_HEARTBEAT" ] && HEARTBEAT_JSON="$WORKER_HEARTBEAT" python3 -c 'import datetime, json, os; payload=json.loads(os.environ["HEARTBEAT_JSON"]); updated=datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00")); age=(datetime.datetime.now(datetime.timezone.utc)-updated).total_seconds(); raise SystemExit(0 if 0 <= age <= 60 and payload.get("state") != "failed" else 1)'; then
+                elif [ -n "$WORKER_HEARTBEAT" ] && HEARTBEAT_JSON="$WORKER_HEARTBEAT" WORKER_RESTART_EPOCH_MS="$WORKER_RESTART_EPOCH_MS" python3 -c 'import datetime, json, os; payload=json.loads(os.environ["HEARTBEAT_JSON"]); updated=datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00")); age=(datetime.datetime.now(datetime.timezone.utc)-updated).total_seconds(); updated_ms=int(updated.timestamp()*1000); restart_ms=int(os.environ["WORKER_RESTART_EPOCH_MS"]); raise SystemExit(0 if 0 <= age <= 60 and updated_ms >= restart_ms and payload.get("state") != "failed" else 1)'; then
                   echo "Ranking worker heartbeat passed (attempt $i/3)"
                   WORKER_HEALTHY=true
                   break

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,17 +75,28 @@ jobs:
             # Migrations are forward-only and must be applied before either
             # process is cut over. Fail closed unless the dedicated backup
             # mount and newest logical dump are present and readable.
-            BACKUP_TARGET=$(findmnt -n -o TARGET --target /mnt/host-backups)
+            BACKUP_TARGET=""
+            if ! BACKUP_TARGET=$(findmnt -n -o TARGET --target /mnt/host-backups); then
+              echo "Could not inspect the dedicated backup mount; refusing migration"
+              exit 1
+            fi
             if [ "$BACKUP_TARGET" != "/mnt/host-backups" ]; then
               echo "Dedicated backup mount is missing; refusing migration"
               exit 1
             fi
-            LATEST_BACKUP=$(sudo find /mnt/host-backups/postgres -maxdepth 1 -type f -name 'dump-*.sql.gz' -printf '%T@ %p\n' | sort -nr | head -1 | cut -d' ' -f2-)
+            LATEST_BACKUP=""
+            if ! LATEST_BACKUP=$(sudo find /mnt/host-backups/postgres -maxdepth 1 -type f -name 'dump-*.sql.gz' -printf '%T@ %p\n' | sort -nr | sed -n '1p' | cut -d' ' -f2-); then
+              echo "Could not inspect PostgreSQL backups; refusing migration"
+              exit 1
+            fi
             if [ -z "$LATEST_BACKUP" ]; then
               echo "No PostgreSQL backup exists; refusing migration"
               exit 1
             fi
-            sudo gzip -t "$LATEST_BACKUP"
+            if ! sudo gzip -t "$LATEST_BACKUP"; then
+              echo "Newest PostgreSQL backup failed gzip validation; refusing migration"
+              exit 1
+            fi
             npm run migrate
             sudo docker compose -f docker-compose.prod.yml up -d --no-deps demo-redis
             for i in 1 2 3 4 5; do
@@ -105,7 +116,42 @@ jobs:
             WORKER_INSTALLED=false
             if sudo systemctl cat corgi-ranking-worker.service > /dev/null 2>&1; then
               WORKER_INSTALLED=true
-              sudo systemctl restart corgi-ranking-worker
+              if ! sudo systemctl restart corgi-ranking-worker; then
+                echo "Ranking worker restart failed; API was not touched"
+                exit 1
+              fi
+
+              RANKING_COMMUNITY_ID="community-gov"
+              COMMUNITY_CONFIG=""
+              if [ -f .env ]; then
+                if ! COMMUNITY_CONFIG=$(sed -n 's/^RANKING_COMMUNITY_ID=//p' .env | tail -1); then
+                  echo "Could not read RANKING_COMMUNITY_ID from .env"
+                  exit 1
+                fi
+                COMMUNITY_CONFIG=$(printf '%s' "$COMMUNITY_CONFIG" | tr -d "\r\"'")
+                if [ -n "$COMMUNITY_CONFIG" ]; then
+                  RANKING_COMMUNITY_ID="$COMMUNITY_CONFIG"
+                fi
+              fi
+              WORKER_HEARTBEAT_KEY="corgi:ranking-worker:heartbeat:${RANKING_COMMUNITY_ID}"
+              WORKER_HEALTHY=false
+              for i in 1 2 3; do
+                WORKER_HEARTBEAT=""
+                if ! WORKER_HEARTBEAT=$(sudo docker compose -f docker-compose.prod.yml exec -T redis redis-cli --raw GET "$WORKER_HEARTBEAT_KEY"); then
+                  echo "Ranking worker heartbeat probe failed (attempt $i/3)"
+                elif [ -n "$WORKER_HEARTBEAT" ] && HEARTBEAT_JSON="$WORKER_HEARTBEAT" python3 -c 'import datetime, json, os; payload=json.loads(os.environ["HEARTBEAT_JSON"]); updated=datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00")); age=(datetime.datetime.now(datetime.timezone.utc)-updated).total_seconds(); raise SystemExit(0 if 0 <= age <= 60 and payload.get("state") != "failed" else 1)'; then
+                  echo "Ranking worker heartbeat passed (attempt $i/3)"
+                  WORKER_HEALTHY=true
+                  break
+                else
+                  echo "Ranking worker heartbeat is missing, malformed, stale, or failed (attempt $i/3)"
+                fi
+                sleep 10
+              done
+              if [ "$WORKER_HEALTHY" != "true" ]; then
+                echo "Ranking worker did not become ready; API was not touched"
+                exit 1
+              fi
             fi
             sudo systemctl restart bluesky-feed
 
@@ -181,31 +227,6 @@ jobs:
                 else
                   echo "Demo API isolation verified: session state is absent from production Redis"
                 fi
-              fi
-            fi
-
-            if [ "$HEALTHY" = "true" ] && [ "$WORKER_INSTALLED" = "true" ]; then
-              WORKER_HEALTHY=false
-              for i in 1 2 3; do
-                WORKER_HEARTBEAT=$(sudo docker compose -f docker-compose.prod.yml exec -T redis redis-cli --raw GET corgi:ranking-worker:heartbeat:community-gov)
-                if [ -n "$WORKER_HEARTBEAT" ] && HEARTBEAT_JSON="$WORKER_HEARTBEAT" python3 -c '
-import datetime
-import json
-import os
-payload = json.loads(os.environ["HEARTBEAT_JSON"])
-updated = datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00"))
-age = (datetime.datetime.now(datetime.timezone.utc) - updated).total_seconds()
-raise SystemExit(0 if 0 <= age <= 60 and payload.get("state") != "failed" else 1)
-'; then
-                  echo "Ranking worker heartbeat passed (attempt $i/3)"
-                  WORKER_HEALTHY=true
-                  break
-                fi
-                sleep 10
-              done
-              if [ "$WORKER_HEALTHY" != "true" ]; then
-                echo "Ranking worker heartbeat did not become healthy"
-                HEALTHY=false
               fi
             fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,7 +187,7 @@ jobs:
             if [ "$HEALTHY" = "true" ] && [ "$WORKER_INSTALLED" = "true" ]; then
               WORKER_HEALTHY=false
               for i in 1 2 3; do
-                WORKER_HEARTBEAT=$(sudo docker compose -f docker-compose.prod.yml exec -T redis redis-cli --raw GET corgi:ranking-worker:heartbeat)
+                WORKER_HEARTBEAT=$(sudo docker compose -f docker-compose.prod.yml exec -T redis redis-cli --raw GET corgi:ranking-worker:heartbeat:community-gov)
                 if [ -n "$WORKER_HEARTBEAT" ] && HEARTBEAT_JSON="$WORKER_HEARTBEAT" python3 -c '
 import datetime
 import json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,21 @@ jobs:
             cd ..
             cd cli && npm ci && npx tsc
             cd ..
+            # Migrations are forward-only and must be applied before either
+            # process is cut over. Fail closed unless the dedicated backup
+            # mount and newest logical dump are present and readable.
+            BACKUP_TARGET=$(findmnt -n -o TARGET --target /mnt/host-backups)
+            if [ "$BACKUP_TARGET" != "/mnt/host-backups" ]; then
+              echo "Dedicated backup mount is missing; refusing migration"
+              exit 1
+            fi
+            LATEST_BACKUP=$(sudo find /mnt/host-backups/postgres -maxdepth 1 -type f -name 'dump-*.sql.gz' -printf '%T@ %p\n' | sort -nr | head -1 | cut -d' ' -f2-)
+            if [ -z "$LATEST_BACKUP" ]; then
+              echo "No PostgreSQL backup exists; refusing migration"
+              exit 1
+            fi
+            sudo gzip -t "$LATEST_BACKUP"
+            npm run migrate
             sudo docker compose -f docker-compose.prod.yml up -d --no-deps demo-redis
             for i in 1 2 3 4 5; do
               if sudo docker compose -f docker-compose.prod.yml exec -T demo-redis redis-cli ping | grep -q PONG; then
@@ -84,6 +99,14 @@ jobs:
               fi
               sleep 2
             done
+            # The split worker is activated only by the separately approved
+            # systemd packet. Until then the installed API unit still runs the
+            # rollback-compatible PROCESS_ROLE=all default.
+            WORKER_INSTALLED=false
+            if sudo systemctl cat corgi-ranking-worker.service > /dev/null 2>&1; then
+              WORKER_INSTALLED=true
+              sudo systemctl restart corgi-ranking-worker
+            fi
             sudo systemctl restart bluesky-feed
 
             # Post-deploy health verification (3 retries, 10s apart)
@@ -161,6 +184,31 @@ jobs:
               fi
             fi
 
+            if [ "$HEALTHY" = "true" ] && [ "$WORKER_INSTALLED" = "true" ]; then
+              WORKER_HEALTHY=false
+              for i in 1 2 3; do
+                WORKER_HEARTBEAT=$(sudo docker compose -f docker-compose.prod.yml exec -T redis redis-cli --raw GET corgi:ranking-worker:heartbeat)
+                if [ -n "$WORKER_HEARTBEAT" ] && HEARTBEAT_JSON="$WORKER_HEARTBEAT" python3 -c '
+import datetime
+import json
+import os
+payload = json.loads(os.environ["HEARTBEAT_JSON"])
+updated = datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00"))
+age = (datetime.datetime.now(datetime.timezone.utc) - updated).total_seconds()
+raise SystemExit(0 if 0 <= age <= 60 and payload.get("state") != "failed" else 1)
+'; then
+                  echo "Ranking worker heartbeat passed (attempt $i/3)"
+                  WORKER_HEALTHY=true
+                  break
+                fi
+                sleep 10
+              done
+              if [ "$WORKER_HEALTHY" != "true" ]; then
+                echo "Ranking worker heartbeat did not become healthy"
+                HEALTHY=false
+              fi
+            fi
+
             if [ "$HEALTHY" = "false" ]; then
               echo "DEPLOY FAILED: service unhealthy after restart"
               echo "Rolling back to $PREV_COMMIT..."
@@ -174,6 +222,9 @@ jobs:
               (cd web && npm ci && npm run build) || echo "WARNING: web rollback rebuild failed; serving prior artifacts"
               (cd web-next && npm ci && npm run build) || echo "WARNING: web-next rollback rebuild failed; serving prior artifacts"
               sudo systemctl restart bluesky-feed
+              if [ "$WORKER_INSTALLED" = "true" ]; then
+                sudo systemctl restart corgi-ranking-worker || true
+              fi
               sleep 5
               echo "Rollback complete. Current health:"
               curl -s http://localhost:3001/health || echo "Still unhealthy after rollback"

--- a/cli/src/commands/feed.ts
+++ b/cli/src/commands/feed.ts
@@ -30,20 +30,7 @@ export function registerFeedCommands(program: Command): void {
         if (config.json) {
           printJson(data);
         } else {
-          const db = data.database as Record<string, unknown> | undefined;
-          const scoring = data.scoring as Record<string, unknown> | undefined;
-          const jetstream = data.jetstream as Record<string, unknown> | undefined;
-          const rankingWorker = data.rankingWorker as Record<string, unknown> | undefined;
-          const queue = rankingWorker?.queue as Record<string, unknown> | undefined;
-          printSummary([
-            ['Total Posts', db?.totalPosts ?? 'N/A'],
-            ['Scored Posts', scoring?.scoredPosts ?? 'N/A'],
-            ['Last Scored', scoring?.lastScoredAt ?? 'N/A'],
-            ['Jetstream Connected', jetstream?.connected ?? 'N/A'],
-            ['Subscriber Count', data.subscriberCount ?? 'N/A'],
-            ['Ranking Worker Healthy', rankingWorker?.healthy ?? 'N/A'],
-            ['Queued Ranking Requests', queue?.pendingCount ?? 'N/A'],
-          ]);
+          printSummary(feedHealthSummary(data));
         }
       } catch (err) {
         printError((err as Error).message);
@@ -98,4 +85,23 @@ export function registerFeedCommands(program: Command): void {
         process.exitCode = 1;
       }
     });
+}
+
+/** Convert the feed-health API response into CLI summary rows. */
+export function feedHealthSummary(data: Record<string, unknown>): [string, unknown][] {
+  const db = data.database as Record<string, unknown> | undefined;
+  const scoring = data.scoring as Record<string, unknown> | undefined;
+  const jetstream = data.jetstream as Record<string, unknown> | undefined;
+  const subscribers = data.subscribers as Record<string, unknown> | undefined;
+  const rankingWorker = data.rankingWorker as Record<string, unknown> | undefined;
+  const queue = rankingWorker?.queue as Record<string, unknown> | undefined;
+  return [
+    ['Total Posts', db?.totalPosts ?? 'N/A'],
+    ['Scored Posts', scoring?.postsScored ?? 'N/A'],
+    ['Last Scored', scoring?.lastRun ?? 'N/A'],
+    ['Jetstream Connected', jetstream?.connected ?? 'N/A'],
+    ['Subscriber Count', subscribers?.total ?? 'N/A'],
+    ['Ranking Worker Healthy', rankingWorker?.healthy ?? 'N/A'],
+    ['Queued Ranking Requests', queue?.pendingCount ?? 'N/A'],
+  ];
 }

--- a/cli/src/commands/feed.ts
+++ b/cli/src/commands/feed.ts
@@ -33,12 +33,16 @@ export function registerFeedCommands(program: Command): void {
           const db = data.database as Record<string, unknown> | undefined;
           const scoring = data.scoring as Record<string, unknown> | undefined;
           const jetstream = data.jetstream as Record<string, unknown> | undefined;
+          const rankingWorker = data.rankingWorker as Record<string, unknown> | undefined;
+          const queue = rankingWorker?.queue as Record<string, unknown> | undefined;
           printSummary([
             ['Total Posts', db?.totalPosts ?? 'N/A'],
             ['Scored Posts', scoring?.scoredPosts ?? 'N/A'],
             ['Last Scored', scoring?.lastScoredAt ?? 'N/A'],
             ['Jetstream Connected', jetstream?.connected ?? 'N/A'],
             ['Subscriber Count', data.subscriberCount ?? 'N/A'],
+            ['Ranking Worker Healthy', rankingWorker?.healthy ?? 'N/A'],
+            ['Queued Ranking Requests', queue?.pendingCount ?? 'N/A'],
           ]);
         }
       } catch (err) {
@@ -50,7 +54,7 @@ export function registerFeedCommands(program: Command): void {
   // ── Rescore ──
   feed
     .command('rescore')
-    .description('Trigger manual scoring pipeline run')
+    .description('Queue a durable manual scoring request')
     .action(async () => {
       try {
         const config = resolveConfig(program.opts());
@@ -63,7 +67,7 @@ export function registerFeedCommands(program: Command): void {
         if (config.json) {
           printJson(data);
         } else {
-          printSuccess('Scoring pipeline triggered');
+          printSuccess(`Scoring request queued: ${String(data.requestId ?? 'unknown')}`);
         }
       } catch (err) {
         printError((err as Error).message);

--- a/docs/OPERABILITY.md
+++ b/docs/OPERABILITY.md
@@ -85,6 +85,8 @@ Pre-activation evidence must prove all of the following:
    pipeline timeout must quarantine the worker, retain and renew its lease, and
    advertise a failed heartbeat until that process is stopped; it must not
    claim replacement work in the same process.
+7. Queue claims, stale recovery, heartbeat keys, and owned lease keys remain
+   scoped to `RANKING_COMMUNITY_ID`; one feed must not consume or block another.
 
 Activation order after approval:
 

--- a/docs/OPERABILITY.md
+++ b/docs/OPERABILITY.md
@@ -91,7 +91,7 @@ Activation order after approval:
 1. Copy both reviewed unit files, run `systemctl daemon-reload`, and enable the
    worker. Do not delete or mutate the current Redis snapshot.
 2. Start/restart `corgi-ranking-worker` first. Require an active unit and a
-   fresh `corgi:ranking-worker:heartbeat` with a non-failed state.
+   fresh `corgi:ranking-worker:heartbeat:community-gov` with a non-failed state.
 3. Restart `bluesky-feed` with `PROCESS_ROLE=api`. Require `/health/ready` and
    the XRPC feed probe to pass while the worker remains active.
 4. Restart the worker while issuing feed requests; require zero serving errors

--- a/docs/OPERABILITY.md
+++ b/docs/OPERABILITY.md
@@ -62,3 +62,54 @@ Supporting ops signals:
 - `docs/DEPLOYMENT.md` for deployment/bootstrap details
 - `docs/runbooks/operator-quickstart.md` for the shortest safe operator flow
 - `docs/runbooks/incident-response.md` for failure handling and evidence capture
+
+## Governed ranking-worker activation
+
+`PROCESS_ROLE=all` remains the rollback-compatible application default. The
+tracked service files are not production activation by themselves. Installing
+or starting `corgi-ranking-worker.service`, or replacing the installed API unit
+with the tracked `PROCESS_ROLE=api` unit, requires the explicit PROJ-1769
+production gate.
+
+Pre-activation evidence must prove all of the following:
+
+1. The VPS checkout matches the reviewed merge SHA and CI/deploy receipts are green.
+2. `findmnt -n -o TARGET --target /mnt/host-backups` returns exactly
+   `/mnt/host-backups`; the newest `dump-*.sql.gz` exists and passes `gzip -t`.
+3. Additive migrations complete before either service is restarted.
+4. `npm run verify`, `npm run sim:core`, lease failure injection, queue
+   idempotency, and process-isolation tests pass at the reviewed SHA.
+5. The existing Redis snapshot has 1,000 items and the Community Governed Feed
+   XRPC probe succeeds before activation; Birders still returns disabled.
+6. `RANKING_LEASE_TTL_MS` remains greater than `SCORING_TIMEOUT_MS`. A legacy
+   pipeline timeout must quarantine the worker, retain and renew its lease, and
+   advertise a failed heartbeat until that process is stopped; it must not
+   claim replacement work in the same process.
+
+Activation order after approval:
+
+1. Copy both reviewed unit files, run `systemctl daemon-reload`, and enable the
+   worker. Do not delete or mutate the current Redis snapshot.
+2. Start/restart `corgi-ranking-worker` first. Require an active unit and a
+   fresh `corgi:ranking-worker:heartbeat` with a non-failed state.
+3. Restart `bluesky-feed` with `PROCESS_ROLE=api`. Require `/health/ready` and
+   the XRPC feed probe to pass while the worker remains active.
+4. Restart the worker while issuing feed requests; require zero serving errors
+   and preservation of the prior snapshot.
+5. Restart the API during an owned worker run; require the worker heartbeat and
+   request claim to survive independently.
+6. Confirm snapshot size/freshness, request state, service memory, restart
+   counts, and warning/error journals independently for both units.
+
+Immediate rollback is unit-level and does not require a database rollback:
+
+1. Stop and disable `corgi-ranking-worker`.
+2. Restore the previous installed `bluesky-feed.service` or remove its
+   `PROCESS_ROLE=api` setting so the default `all` role resumes.
+3. Run `systemctl daemon-reload` and restart `bluesky-feed`.
+4. Confirm the last-known-good Redis snapshot, API readiness, Community
+   Governed Feed XRPC response, and disabled Birders behavior.
+
+Forward-only additive migrations and ranking request rows may remain after this
+rollback. Any destructive database rollback requires restore from the verified
+backup in a controlled maintenance window.

--- a/docs/OPERABILITY.md
+++ b/docs/OPERABILITY.md
@@ -93,7 +93,10 @@ Activation order after approval:
 1. Copy both reviewed unit files, run `systemctl daemon-reload`, and enable the
    worker. Do not delete or mutate the current Redis snapshot.
 2. Start/restart `corgi-ranking-worker` first. Require an active unit and a
-   fresh `corgi:ranking-worker:heartbeat:community-gov` with a non-failed state.
+   fresh `corgi:ranking-worker:heartbeat:${RANKING_COMMUNITY_ID}` with a
+   non-failed state. For example, a deployment configured with
+   `RANKING_COMMUNITY_ID=future-feed` must check
+   `corgi:ranking-worker:heartbeat:future-feed`, matching the worker and watchdog.
 3. Restart `bluesky-feed` with `PROCESS_ROLE=api`. Require `/health/ready` and
    the XRPC feed probe to pass while the worker remains active.
 4. Restart the worker while issuing feed requests; require zero serving errors

--- a/docs/OPERABILITY.md
+++ b/docs/OPERABILITY.md
@@ -71,6 +71,13 @@ or starting `corgi-ranking-worker.service`, or replacing the installed API unit
 with the tracked `PROCESS_ROLE=api` unit, requires the explicit PROJ-1769
 production gate.
 
+The shared `/opt/bluesky-feed/.env` must never define `PROCESS_ROLE`. systemd
+`EnvironmentFile=` values override the explicit role in both unit files, which
+could disable ranking or run it twice. `ops/install.sh`, `ops/deploy`, and the
+hosted deploy workflow reject that configuration before restarting either
+service. They also require the worker unit's `TimeoutStopSec` to exceed the
+effective `SCORING_TIMEOUT_MS` by at least 60 seconds.
+
 Pre-activation evidence must prove all of the following:
 
 1. The VPS checkout matches the reviewed merge SHA and CI/deploy receipts are green.

--- a/ops/README.md
+++ b/ops/README.md
@@ -69,3 +69,15 @@ python3 scripts/generate-report.py --date "March 15, 2026"
 **Dependencies:** Python 3.12+, pandas, matplotlib, python-docx (all pre-installed).
 
 **Output:** 6-page report covering executive summary, topic distribution, score composition, classification & diversity, engagement profile, and sample posts.
+
+## Ranking worker activation gate
+
+The tracked units split feed serving from ranking:
+
+- `bluesky-feed.service` runs `PROCESS_ROLE=api`.
+- `corgi-ranking-worker.service` runs `PROCESS_ROLE=ranking-worker` with an independent 1 GiB cgroup and a 300-second stop timeout.
+- The application default remains `PROCESS_ROLE=all` until the production activation packet is explicitly approved, preserving rollback compatibility.
+
+Do not install or start the worker unit from an ordinary deploy. Follow the
+pre-activation backup, migration, heartbeat, snapshot freshness, independent
+restart, and rollback probes in `docs/OPERABILITY.md`.

--- a/ops/bluesky-feed.service
+++ b/ops/bluesky-feed.service
@@ -25,6 +25,8 @@ NotifyAccess=main
 # Working directory and environment
 WorkingDirectory=/opt/bluesky-feed
 EnvironmentFile=/opt/bluesky-feed/.env
+# PROCESS_ROLE must never be set in the shared .env. EnvironmentFile values
+# override Environment values for both API and worker units.
 Environment=NODE_ENV=production
 Environment=PROCESS_ROLE=api
 Environment=NODE_OPTIONS=--max-old-space-size=896

--- a/ops/bluesky-feed.service
+++ b/ops/bluesky-feed.service
@@ -26,6 +26,7 @@ NotifyAccess=main
 WorkingDirectory=/opt/bluesky-feed
 EnvironmentFile=/opt/bluesky-feed/.env
 Environment=NODE_ENV=production
+Environment=PROCESS_ROLE=api
 Environment=NODE_OPTIONS=--max-old-space-size=896
 
 # Start the application (sends READY=1 via sd_notify after listen())

--- a/ops/corgi-ranking-worker.service
+++ b/ops/corgi-ranking-worker.service
@@ -1,0 +1,41 @@
+# Trustworthy Corgi governed ranking worker
+#
+# Installation and activation are approval-gated. See PROJ-1769 and
+# docs/OPERABILITY.md before copying this unit into /etc/systemd/system.
+
+[Unit]
+Description=Corgi Governed Ranking Worker
+Documentation=https://github.com/andrewnordstrom-eng/bluesky-community-feed
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/bluesky-feed
+EnvironmentFile=/opt/bluesky-feed/.env
+Environment=NODE_ENV=production
+Environment=PROCESS_ROLE=ranking-worker
+Environment=NODE_OPTIONS=--max-old-space-size=896
+ExecStart=/usr/bin/node dist/index.js
+Restart=on-failure
+RestartSec=5
+MemoryHigh=768M
+MemoryMax=1G
+# Must exceed SCORING_TIMEOUT_MS=240000 so an owned run can drain safely.
+TimeoutStopSec=300
+KillSignal=SIGTERM
+KillMode=mixed
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/bluesky-feed
+PrivateTmp=true
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=corgi-ranking-worker
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/corgi-ranking-worker.service
+++ b/ops/corgi-ranking-worker.service
@@ -16,6 +16,8 @@ StartLimitBurst=5
 Type=simple
 WorkingDirectory=/opt/bluesky-feed
 EnvironmentFile=/opt/bluesky-feed/.env
+# PROCESS_ROLE must never be set in the shared .env. EnvironmentFile values
+# override Environment values for both API and worker units.
 Environment=NODE_ENV=production
 Environment=PROCESS_ROLE=ranking-worker
 Environment=NODE_OPTIONS=--max-old-space-size=896

--- a/ops/deploy
+++ b/ops/deploy
@@ -47,6 +47,7 @@ if systemctl cat corgi-ranking-worker.service > /dev/null 2>&1; then
     echo "ERROR: ranking worker restart failed; API was not touched" >&2
     exit 1
   fi
+  worker_restart_epoch_ms=$(date +%s%3N)
 
   ranking_community_id="${RANKING_COMMUNITY_ID:-community-gov}"
   if [ -z "${RANKING_COMMUNITY_ID:-}" ] && [ -f .env ]; then
@@ -66,7 +67,7 @@ if systemctl cat corgi-ranking-worker.service > /dev/null 2>&1; then
     worker_heartbeat=""
     if ! worker_heartbeat=$(timeout 5 docker exec bluesky-feed-redis redis-cli --raw GET "$worker_heartbeat_key" 2>/dev/null); then
       echo "Ranking worker heartbeat probe failed (attempt $attempt/3)" >&2
-    elif [ -n "$worker_heartbeat" ] && HEARTBEAT_JSON="$worker_heartbeat" python3 -c 'import datetime, json, os; payload=json.loads(os.environ["HEARTBEAT_JSON"]); updated=datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00")); age=(datetime.datetime.now(datetime.timezone.utc)-updated).total_seconds(); raise SystemExit(0 if 0 <= age <= 60 and payload.get("state") != "failed" else 1)' 2>/dev/null; then
+    elif [ -n "$worker_heartbeat" ] && HEARTBEAT_JSON="$worker_heartbeat" WORKER_RESTART_EPOCH_MS="$worker_restart_epoch_ms" python3 -c 'import datetime, json, os; payload=json.loads(os.environ["HEARTBEAT_JSON"]); updated=datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00")); age=(datetime.datetime.now(datetime.timezone.utc)-updated).total_seconds(); updated_ms=int(updated.timestamp()*1000); restart_ms=int(os.environ["WORKER_RESTART_EPOCH_MS"]); raise SystemExit(0 if 0 <= age <= 60 and updated_ms >= restart_ms and payload.get("state") != "failed" else 1)' 2>/dev/null; then
       worker_healthy=true
       echo "Ranking worker heartbeat passed (attempt $attempt/3)"
       break

--- a/ops/deploy
+++ b/ops/deploy
@@ -5,6 +5,15 @@
 set -euo pipefail
 cd /opt/bluesky-feed
 
+RANKING_READINESS_LIBRARY="ops/lib/ranking-worker-readiness.sh"
+if [ ! -r "$RANKING_READINESS_LIBRARY" ]; then
+  echo "ERROR: required ranking worker readiness library is missing: ${RANKING_READINESS_LIBRARY}" >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+source "$RANKING_READINESS_LIBRARY"
+reject_shared_process_role ".env"
+
 echo "=== Pulling latest ==="
 git pull --ff-only origin main
 
@@ -42,41 +51,26 @@ if [ "${1:-}" != "--skip-migrate" ]; then
 fi
 
 if systemctl cat corgi-ranking-worker.service > /dev/null 2>&1; then
+  validate_ranking_worker_stop_timeout \
+    <(systemctl cat corgi-ranking-worker.service) \
+    ".env"
   echo "=== Restarting ranking worker ==="
+  worker_restart_epoch_ms=$(date +%s%3N)
   if ! systemctl restart corgi-ranking-worker; then
     echo "ERROR: ranking worker restart failed; API was not touched" >&2
     exit 1
   fi
-  worker_restart_epoch_ms=$(date +%s%3N)
 
-  ranking_community_id="${RANKING_COMMUNITY_ID:-community-gov}"
-  if [ -z "${RANKING_COMMUNITY_ID:-}" ] && [ -f .env ]; then
-    community_config=""
-    if ! community_config=$(sed -n 's/^RANKING_COMMUNITY_ID=//p' .env | tail -1); then
-      echo "ERROR: could not read RANKING_COMMUNITY_ID from .env" >&2
-      exit 1
-    fi
-    community_config=$(printf '%s' "$community_config" | tr -d "\r\"'")
-    if [ -n "$community_config" ]; then
-      ranking_community_id="$community_config"
-    fi
+  ranking_community_id=""
+  if ! ranking_community_id=$(resolve_ranking_community_id ".env"); then
+    exit 1
   fi
-  worker_heartbeat_key="corgi:ranking-worker:heartbeat:${ranking_community_id}"
-  worker_healthy=false
-  for attempt in 1 2 3; do
-    worker_heartbeat=""
-    if ! worker_heartbeat=$(timeout 5 docker exec bluesky-feed-redis redis-cli --raw GET "$worker_heartbeat_key" 2>/dev/null); then
-      echo "Ranking worker heartbeat probe failed (attempt $attempt/3)" >&2
-    elif [ -n "$worker_heartbeat" ] && HEARTBEAT_JSON="$worker_heartbeat" WORKER_RESTART_EPOCH_MS="$worker_restart_epoch_ms" python3 -c 'import datetime, json, os; payload=json.loads(os.environ["HEARTBEAT_JSON"]); updated=datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00")); age=(datetime.datetime.now(datetime.timezone.utc)-updated).total_seconds(); updated_ms=int(updated.timestamp()*1000); restart_ms=int(os.environ["WORKER_RESTART_EPOCH_MS"]); raise SystemExit(0 if 0 <= age <= 60 and updated_ms >= restart_ms and payload.get("state") != "failed" else 1)' 2>/dev/null; then
-      worker_healthy=true
-      echo "Ranking worker heartbeat passed (attempt $attempt/3)"
-      break
-    else
-      echo "Ranking worker heartbeat is missing, malformed, stale, or failed (attempt $attempt/3)" >&2
-    fi
-    sleep 10
-  done
-  if [ "$worker_healthy" != "true" ]; then
+  PROBE_TIMEOUT_SECONDS=5
+  ranking_worker_heartbeat_probe() {
+    local heartbeat_key="$1"
+    probe_ranking_worker_heartbeat_with_docker "$PROBE_TIMEOUT_SECONDS" bluesky-feed-redis "$heartbeat_key"
+  }
+  if ! wait_for_ranking_worker_ready "$ranking_community_id" "$worker_restart_epoch_ms" 3 10 ranking_worker_heartbeat_probe; then
     echo "ERROR: ranking worker did not become ready; API was not touched" >&2
     exit 1
   fi

--- a/ops/deploy
+++ b/ops/deploy
@@ -15,11 +15,26 @@ echo "=== Building ==="
 npx tsc
 
 if [ "${1:-}" != "--skip-migrate" ]; then
+  if [ "$(findmnt -n -o TARGET --target /mnt/host-backups)" != "/mnt/host-backups" ]; then
+    echo "ERROR: dedicated backup mount missing; refusing migration" >&2
+    exit 1
+  fi
+  latest_backup=$(find /mnt/host-backups/postgres -maxdepth 1 -type f -name 'dump-*.sql.gz' -printf '%T@ %p\n' | sort -nr | head -1 | cut -d' ' -f2-)
+  if [ -z "$latest_backup" ]; then
+    echo "ERROR: no PostgreSQL backup exists; refusing migration" >&2
+    exit 1
+  fi
+  gzip -t "$latest_backup"
   echo "=== Running migrations ==="
   npm run migrate
 fi
 
-echo "=== Restarting service ==="
+if systemctl cat corgi-ranking-worker.service > /dev/null 2>&1; then
+  echo "=== Restarting ranking worker ==="
+  systemctl restart corgi-ranking-worker
+fi
+
+echo "=== Restarting API service ==="
 systemctl restart bluesky-feed
 sleep 3
 
@@ -29,3 +44,6 @@ echo ""
 
 echo "=== Status ==="
 systemctl is-active bluesky-feed
+if systemctl cat corgi-ranking-worker.service > /dev/null 2>&1; then
+  systemctl is-active corgi-ranking-worker
+fi

--- a/ops/deploy
+++ b/ops/deploy
@@ -15,23 +15,70 @@ echo "=== Building ==="
 npx tsc
 
 if [ "${1:-}" != "--skip-migrate" ]; then
-  if [ "$(findmnt -n -o TARGET --target /mnt/host-backups)" != "/mnt/host-backups" ]; then
+  backup_target=""
+  if ! backup_target=$(findmnt -n -o TARGET --target /mnt/host-backups); then
+    echo "ERROR: could not inspect dedicated backup mount; refusing migration" >&2
+    exit 1
+  fi
+  if [ "$backup_target" != "/mnt/host-backups" ]; then
     echo "ERROR: dedicated backup mount missing; refusing migration" >&2
     exit 1
   fi
-  latest_backup=$(find /mnt/host-backups/postgres -maxdepth 1 -type f -name 'dump-*.sql.gz' -printf '%T@ %p\n' | sort -nr | head -1 | cut -d' ' -f2-)
+  latest_backup=""
+  if ! latest_backup=$(find /mnt/host-backups/postgres -maxdepth 1 -type f -name 'dump-*.sql.gz' -printf '%T@ %p\n' | sort -nr | sed -n '1p' | cut -d' ' -f2-); then
+    echo "ERROR: could not inspect PostgreSQL backups; refusing migration" >&2
+    exit 1
+  fi
   if [ -z "$latest_backup" ]; then
     echo "ERROR: no PostgreSQL backup exists; refusing migration" >&2
     exit 1
   fi
-  gzip -t "$latest_backup"
+  if ! gzip -t "$latest_backup"; then
+    echo "ERROR: newest PostgreSQL backup failed gzip validation; refusing migration" >&2
+    exit 1
+  fi
   echo "=== Running migrations ==="
   npm run migrate
 fi
 
 if systemctl cat corgi-ranking-worker.service > /dev/null 2>&1; then
   echo "=== Restarting ranking worker ==="
-  systemctl restart corgi-ranking-worker
+  if ! systemctl restart corgi-ranking-worker; then
+    echo "ERROR: ranking worker restart failed; API was not touched" >&2
+    exit 1
+  fi
+
+  ranking_community_id="${RANKING_COMMUNITY_ID:-community-gov}"
+  if [ -z "${RANKING_COMMUNITY_ID:-}" ] && [ -f .env ]; then
+    community_config=""
+    if ! community_config=$(sed -n 's/^RANKING_COMMUNITY_ID=//p' .env | tail -1); then
+      echo "ERROR: could not read RANKING_COMMUNITY_ID from .env" >&2
+      exit 1
+    fi
+    community_config=$(printf '%s' "$community_config" | tr -d "\r\"'")
+    if [ -n "$community_config" ]; then
+      ranking_community_id="$community_config"
+    fi
+  fi
+  worker_heartbeat_key="corgi:ranking-worker:heartbeat:${ranking_community_id}"
+  worker_healthy=false
+  for attempt in 1 2 3; do
+    worker_heartbeat=""
+    if ! worker_heartbeat=$(timeout 5 docker exec bluesky-feed-redis redis-cli --raw GET "$worker_heartbeat_key" 2>/dev/null); then
+      echo "Ranking worker heartbeat probe failed (attempt $attempt/3)" >&2
+    elif [ -n "$worker_heartbeat" ] && HEARTBEAT_JSON="$worker_heartbeat" python3 -c 'import datetime, json, os; payload=json.loads(os.environ["HEARTBEAT_JSON"]); updated=datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00")); age=(datetime.datetime.now(datetime.timezone.utc)-updated).total_seconds(); raise SystemExit(0 if 0 <= age <= 60 and payload.get("state") != "failed" else 1)' 2>/dev/null; then
+      worker_healthy=true
+      echo "Ranking worker heartbeat passed (attempt $attempt/3)"
+      break
+    else
+      echo "Ranking worker heartbeat is missing, malformed, stale, or failed (attempt $attempt/3)" >&2
+    fi
+    sleep 10
+  done
+  if [ "$worker_healthy" != "true" ]; then
+    echo "ERROR: ranking worker did not become ready; API was not touched" >&2
+    exit 1
+  fi
 fi
 
 echo "=== Restarting API service ==="

--- a/ops/health-watchdog
+++ b/ops/health-watchdog
@@ -18,9 +18,24 @@ RETRY_DELAY=10
 TAG="health-watchdog"
 DISK_WARN_PCT=80
 DISK_CRIT_PCT=90
-WORKER_HEARTBEAT_KEY="corgi:ranking-worker:heartbeat:community-gov"
 WORKER_HEARTBEAT_MAX_AGE_SECONDS=60
 FEED_MAX_AGE_SECONDS=600
+PROBE_TIMEOUT_SECONDS=5
+
+RANKING_COMMUNITY_ID="${RANKING_COMMUNITY_ID:-}"
+if [ -z "$RANKING_COMMUNITY_ID" ] && [ -f /opt/bluesky-feed/.env ]; then
+  COMMUNITY_CONFIG=""
+  if ! COMMUNITY_CONFIG=$(sed -n 's/^RANKING_COMMUNITY_ID=//p' /opt/bluesky-feed/.env | tail -1); then
+    echo "ERROR: could not read RANKING_COMMUNITY_ID from /opt/bluesky-feed/.env" >&2
+    exit 1
+  fi
+  COMMUNITY_CONFIG=$(printf '%s' "$COMMUNITY_CONFIG" | tr -d "\r\"'")
+  if [ -n "$COMMUNITY_CONFIG" ]; then
+    RANKING_COMMUNITY_ID="$COMMUNITY_CONFIG"
+  fi
+fi
+RANKING_COMMUNITY_ID="${RANKING_COMMUNITY_ID:-community-gov}"
+WORKER_HEARTBEAT_KEY="corgi:ranking-worker:heartbeat:${RANKING_COMMUNITY_ID}"
 
 log_info()  { logger -t "$TAG" -p user.info  "$1"; }
 log_warn()  { logger -t "$TAG" -p user.warning "$1"; }
@@ -32,7 +47,7 @@ worker_unit_installed() {
 
 worker_heartbeat_healthy() {
   local heartbeat
-  heartbeat=$(docker exec bluesky-feed-redis redis-cli --raw GET "$WORKER_HEARTBEAT_KEY" 2>/dev/null) || return 1
+  heartbeat=$(timeout "$PROBE_TIMEOUT_SECONDS" docker exec bluesky-feed-redis redis-cli --raw GET "$WORKER_HEARTBEAT_KEY" 2>/dev/null) || return 1
   [ -n "$heartbeat" ] || return 1
   HEARTBEAT_JSON="$heartbeat" HEARTBEAT_MAX_AGE="$WORKER_HEARTBEAT_MAX_AGE_SECONDS" python3 -c '
 import datetime
@@ -51,8 +66,8 @@ if payload.get("state") == "failed":
 
 feed_snapshot_healthy() {
   local feed_count updated_at
-  feed_count=$(docker exec bluesky-feed-redis redis-cli --raw ZCARD feed:current 2>/dev/null) || return 1
-  updated_at=$(docker exec bluesky-feed-redis redis-cli --raw GET feed:updated_at 2>/dev/null) || return 1
+  feed_count=$(timeout "$PROBE_TIMEOUT_SECONDS" docker exec bluesky-feed-redis redis-cli --raw ZCARD feed:current 2>/dev/null) || return 1
+  updated_at=$(timeout "$PROBE_TIMEOUT_SECONDS" docker exec bluesky-feed-redis redis-cli --raw GET feed:updated_at 2>/dev/null) || return 1
   [ "$feed_count" -gt 0 ] 2>/dev/null || return 1
   [ -n "$updated_at" ] || return 1
   FEED_UPDATED_AT="$updated_at" FEED_MAX_AGE="$FEED_MAX_AGE_SECONDS" python3 -c '
@@ -98,16 +113,16 @@ if ! systemctl is-active --quiet "$SERVICE"; then
 fi
 
 if worker_unit_installed; then
+  worker_restart_reason=""
   if ! systemctl is-active --quiet "$WORKER_SERVICE"; then
-    log_err "$WORKER_SERVICE is not active — restarting worker without touching feed serving"
-    systemctl restart "$WORKER_SERVICE"
+    worker_restart_reason="$WORKER_SERVICE is not active"
   elif ! worker_heartbeat_healthy; then
-    log_err "$WORKER_SERVICE heartbeat is stale or failed — restarting worker only"
-    systemctl restart "$WORKER_SERVICE"
+    worker_restart_reason="$WORKER_SERVICE heartbeat is stale or failed"
+  elif ! feed_snapshot_healthy; then
+    worker_restart_reason="Feed snapshot is empty or stale"
   fi
-
-  if ! feed_snapshot_healthy; then
-    log_err "Feed snapshot is empty or stale — restarting worker only and preserving API service"
+  if [ -n "$worker_restart_reason" ]; then
+    log_err "$worker_restart_reason — restarting worker once and preserving API service"
     systemctl restart "$WORKER_SERVICE"
   fi
 fi

--- a/ops/health-watchdog
+++ b/ops/health-watchdog
@@ -18,7 +18,7 @@ RETRY_DELAY=10
 TAG="health-watchdog"
 DISK_WARN_PCT=80
 DISK_CRIT_PCT=90
-WORKER_HEARTBEAT_KEY="corgi:ranking-worker:heartbeat"
+WORKER_HEARTBEAT_KEY="corgi:ranking-worker:heartbeat:community-gov"
 WORKER_HEARTBEAT_MAX_AGE_SECONDS=60
 FEED_MAX_AGE_SECONDS=600
 

--- a/ops/health-watchdog
+++ b/ops/health-watchdog
@@ -11,16 +11,59 @@
 set -euo pipefail
 
 SERVICE="bluesky-feed"
+WORKER_SERVICE="corgi-ranking-worker"
 HEALTH_URL="http://localhost:3001/health/ready"
 MAX_RETRIES=3
 RETRY_DELAY=10
 TAG="health-watchdog"
 DISK_WARN_PCT=80
 DISK_CRIT_PCT=90
+WORKER_HEARTBEAT_KEY="corgi:ranking-worker:heartbeat"
+WORKER_HEARTBEAT_MAX_AGE_SECONDS=60
+FEED_MAX_AGE_SECONDS=600
 
 log_info()  { logger -t "$TAG" -p user.info  "$1"; }
 log_warn()  { logger -t "$TAG" -p user.warning "$1"; }
 log_err()   { logger -t "$TAG" -p user.err "$1"; }
+
+worker_unit_installed() {
+  systemctl list-unit-files "$WORKER_SERVICE.service" --no-legend 2>/dev/null | grep -q "^$WORKER_SERVICE.service"
+}
+
+worker_heartbeat_healthy() {
+  local heartbeat
+  heartbeat=$(docker exec bluesky-feed-redis redis-cli --raw GET "$WORKER_HEARTBEAT_KEY" 2>/dev/null) || return 1
+  [ -n "$heartbeat" ] || return 1
+  HEARTBEAT_JSON="$heartbeat" HEARTBEAT_MAX_AGE="$WORKER_HEARTBEAT_MAX_AGE_SECONDS" python3 -c '
+import datetime
+import json
+import os
+
+payload = json.loads(os.environ["HEARTBEAT_JSON"])
+updated = datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00"))
+age = (datetime.datetime.now(datetime.timezone.utc) - updated).total_seconds()
+if age < 0 or age > int(os.environ["HEARTBEAT_MAX_AGE"]):
+    raise SystemExit(1)
+if payload.get("state") == "failed":
+    raise SystemExit(1)
+' 2>/dev/null
+}
+
+feed_snapshot_healthy() {
+  local feed_count updated_at
+  feed_count=$(docker exec bluesky-feed-redis redis-cli --raw ZCARD feed:current 2>/dev/null) || return 1
+  updated_at=$(docker exec bluesky-feed-redis redis-cli --raw GET feed:updated_at 2>/dev/null) || return 1
+  [ "$feed_count" -gt 0 ] 2>/dev/null || return 1
+  [ -n "$updated_at" ] || return 1
+  FEED_UPDATED_AT="$updated_at" FEED_MAX_AGE="$FEED_MAX_AGE_SECONDS" python3 -c '
+import datetime
+import os
+
+updated = datetime.datetime.fromisoformat(os.environ["FEED_UPDATED_AT"].replace("Z", "+00:00"))
+age = (datetime.datetime.now(datetime.timezone.utc) - updated).total_seconds()
+raise SystemExit(0 if 0 <= age <= int(os.environ["FEED_MAX_AGE"]) else 1)
+' 2>/dev/null
+}
 
 # ── Disk space check (runs even if service is down) ──
 DISK_PCT=$(df / --output=pcent | tail -1 | tr -d ' %')
@@ -52,6 +95,21 @@ fi
 if ! systemctl is-active --quiet "$SERVICE"; then
   log_warn "$SERVICE is not active — skipping health check (systemd will handle restart)"
   exit 0
+fi
+
+if worker_unit_installed; then
+  if ! systemctl is-active --quiet "$WORKER_SERVICE"; then
+    log_err "$WORKER_SERVICE is not active — restarting worker without touching feed serving"
+    systemctl restart "$WORKER_SERVICE"
+  elif ! worker_heartbeat_healthy; then
+    log_err "$WORKER_SERVICE heartbeat is stale or failed — restarting worker only"
+    systemctl restart "$WORKER_SERVICE"
+  fi
+
+  if ! feed_snapshot_healthy; then
+    log_err "Feed snapshot is empty or stale — restarting worker only and preserving API service"
+    systemctl restart "$WORKER_SERVICE"
+  fi
 fi
 
 # Try health check with retries

--- a/ops/install.sh
+++ b/ops/install.sh
@@ -15,6 +15,12 @@ BACKUP_GUARD_LIBRARY="${APP_DIR}/ops/lib/backup-path-guards.sh"
 BACKUP_GUARD_INSTALL_DIR="/opt/backups/lib"
 BACKUP_GUARD_INSTALL_LIBRARY="${BACKUP_GUARD_INSTALL_DIR}/backup-path-guards.sh"
 DEPLOYMENT_RECEIPT="/opt/backups/DEPLOYMENT_RECEIPT"
+INSTALL_RANKING_WORKER="${INSTALL_RANKING_WORKER:-false}"
+
+if [ "$INSTALL_RANKING_WORKER" != "true" ] && [ "$INSTALL_RANKING_WORKER" != "false" ]; then
+  echo "ERROR: INSTALL_RANKING_WORKER must be true or false" >&2
+  exit 1
+fi
 
 if [ ! -r "${BACKUP_GUARD_LIBRARY}" ]; then
   echo "ERROR: required backup guard library missing: ${BACKUP_GUARD_LIBRARY}" >&2
@@ -43,9 +49,14 @@ if [ -f "$APP_DIR/ops/bluesky-feed.service" ]; then
   echo "✓ bluesky-feed.service"
 fi
 
-if [ -f "$APP_DIR/ops/corgi-ranking-worker.service" ]; then
+if [ "$INSTALL_RANKING_WORKER" = "true" ] && [ -f "$APP_DIR/ops/corgi-ranking-worker.service" ]; then
   cp "$APP_DIR/ops/corgi-ranking-worker.service" /etc/systemd/system/corgi-ranking-worker.service
   echo "✓ corgi-ranking-worker.service"
+elif [ "$INSTALL_RANKING_WORKER" = "true" ]; then
+  echo "ERROR: approved worker activation requested but source unit is missing" >&2
+  exit 1
+else
+  echo "○ corgi-ranking-worker.service installation skipped (set INSTALL_RANKING_WORKER=true after approval)"
 fi
 
 # Health watchdog timer
@@ -103,15 +114,19 @@ echo "✓ systemctl daemon-reload"
 systemctl enable bluesky-feed 2>/dev/null || true
 echo "✓ bluesky-feed enabled"
 
-if ! systemctl list-unit-files corgi-ranking-worker.service --no-legend 2>/dev/null | grep -q '^corgi-ranking-worker.service'; then
-  echo "ERROR: corgi-ranking-worker.service is not installed; cannot enable it" >&2
-  exit 1
+if [ "$INSTALL_RANKING_WORKER" = "true" ]; then
+  if ! systemctl list-unit-files corgi-ranking-worker.service --no-legend 2>/dev/null | grep -q '^corgi-ranking-worker.service'; then
+    echo "ERROR: corgi-ranking-worker.service is not installed; cannot enable it" >&2
+    exit 1
+  fi
+  if ! systemctl enable corgi-ranking-worker 2>/dev/null; then
+    echo "ERROR: failed to enable corgi-ranking-worker.service" >&2
+    exit 1
+  fi
+  echo "✓ corgi-ranking-worker enabled (not started by installer)"
+else
+  echo "○ corgi-ranking-worker enable skipped pending approved activation"
 fi
-if ! systemctl enable corgi-ranking-worker 2>/dev/null; then
-  echo "ERROR: failed to enable corgi-ranking-worker.service" >&2
-  exit 1
-fi
-echo "✓ corgi-ranking-worker enabled (not started by installer)"
 
 systemctl enable --now health-watchdog.timer 2>/dev/null || true
 echo "✓ health-watchdog.timer enabled"

--- a/ops/install.sh
+++ b/ops/install.sh
@@ -14,6 +14,7 @@ BACKUP_GUARD_CONTEXT="install"
 BACKUP_GUARD_LIBRARY="${APP_DIR}/ops/lib/backup-path-guards.sh"
 BACKUP_GUARD_INSTALL_DIR="/opt/backups/lib"
 BACKUP_GUARD_INSTALL_LIBRARY="${BACKUP_GUARD_INSTALL_DIR}/backup-path-guards.sh"
+RANKING_READINESS_LIBRARY="${APP_DIR}/ops/lib/ranking-worker-readiness.sh"
 DEPLOYMENT_RECEIPT="/opt/backups/DEPLOYMENT_RECEIPT"
 INSTALL_RANKING_WORKER="${INSTALL_RANKING_WORKER:-false}"
 
@@ -26,9 +27,17 @@ if [ ! -r "${BACKUP_GUARD_LIBRARY}" ]; then
   echo "ERROR: required backup guard library missing: ${BACKUP_GUARD_LIBRARY}" >&2
   exit 1
 fi
+if [ ! -r "${RANKING_READINESS_LIBRARY}" ]; then
+  echo "ERROR: required ranking worker readiness library missing: ${RANKING_READINESS_LIBRARY}" >&2
+  exit 1
+fi
 
 # shellcheck source=/dev/null
 source "${BACKUP_GUARD_LIBRARY}"
+# shellcheck source=/dev/null
+source "${RANKING_READINESS_LIBRARY}"
+
+reject_shared_process_role "${APP_DIR}/.env"
 
 # ── Make ops scripts executable ──────────────────────────────────
 SCRIPTS="db redis logs deploy feed-check status health-watchdog daily-backup.sh bluesky-ops-retention.sh"
@@ -50,6 +59,9 @@ if [ -f "$APP_DIR/ops/bluesky-feed.service" ]; then
 fi
 
 if [ "$INSTALL_RANKING_WORKER" = "true" ] && [ -f "$APP_DIR/ops/corgi-ranking-worker.service" ]; then
+  validate_ranking_worker_stop_timeout \
+    "$APP_DIR/ops/corgi-ranking-worker.service" \
+    "$APP_DIR/.env"
   cp "$APP_DIR/ops/corgi-ranking-worker.service" /etc/systemd/system/corgi-ranking-worker.service
   echo "✓ corgi-ranking-worker.service"
 elif [ "$INSTALL_RANKING_WORKER" = "true" ]; then

--- a/ops/install.sh
+++ b/ops/install.sh
@@ -103,7 +103,14 @@ echo "✓ systemctl daemon-reload"
 systemctl enable bluesky-feed 2>/dev/null || true
 echo "✓ bluesky-feed enabled"
 
-systemctl enable corgi-ranking-worker 2>/dev/null || true
+if ! systemctl list-unit-files corgi-ranking-worker.service --no-legend 2>/dev/null | grep -q '^corgi-ranking-worker.service'; then
+  echo "ERROR: corgi-ranking-worker.service is not installed; cannot enable it" >&2
+  exit 1
+fi
+if ! systemctl enable corgi-ranking-worker 2>/dev/null; then
+  echo "ERROR: failed to enable corgi-ranking-worker.service" >&2
+  exit 1
+fi
 echo "✓ corgi-ranking-worker enabled (not started by installer)"
 
 systemctl enable --now health-watchdog.timer 2>/dev/null || true

--- a/ops/install.sh
+++ b/ops/install.sh
@@ -43,6 +43,11 @@ if [ -f "$APP_DIR/ops/bluesky-feed.service" ]; then
   echo "✓ bluesky-feed.service"
 fi
 
+if [ -f "$APP_DIR/ops/corgi-ranking-worker.service" ]; then
+  cp "$APP_DIR/ops/corgi-ranking-worker.service" /etc/systemd/system/corgi-ranking-worker.service
+  echo "✓ corgi-ranking-worker.service"
+fi
+
 # Health watchdog timer
 if [ -f "$APP_DIR/ops/health-watchdog.service" ]; then
   cp "$APP_DIR/ops/health-watchdog.service" /etc/systemd/system/health-watchdog.service
@@ -98,6 +103,9 @@ echo "✓ systemctl daemon-reload"
 systemctl enable bluesky-feed 2>/dev/null || true
 echo "✓ bluesky-feed enabled"
 
+systemctl enable corgi-ranking-worker 2>/dev/null || true
+echo "✓ corgi-ranking-worker enabled (not started by installer)"
+
 systemctl enable --now health-watchdog.timer 2>/dev/null || true
 echo "✓ health-watchdog.timer enabled"
 
@@ -115,5 +123,6 @@ echo "  /usr/local/bin/bluesky-ops-retention.sh"
 echo ""
 echo "Systemd units:"
 echo "  systemctl status bluesky-feed"
+echo "  systemctl status corgi-ranking-worker"
 echo "  systemctl list-timers health-watchdog.timer"
 echo "  journalctl -t health-watchdog --since '1 hour ago'"

--- a/ops/lib/ranking-worker-readiness.sh
+++ b/ops/lib/ranking-worker-readiness.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+RANKING_WORKER_HEARTBEAT_PREFIX="corgi:ranking-worker:heartbeat"
+RANKING_WORKER_DEFAULT_COMMUNITY_ID="community-gov"
+RANKING_WORKER_DEFAULT_SCORING_TIMEOUT_MS=240000
+RANKING_WORKER_MIN_STOP_MARGIN_MS=60000
+
+reject_shared_process_role() {
+  local env_file="$1"
+  if [ -f "$env_file" ] && grep -Eq '^[[:space:]]*(export[[:space:]]+)?PROCESS_ROLE[[:space:]]*=' "$env_file"; then
+    echo "ERROR: ${env_file} must not define PROCESS_ROLE; shared EnvironmentFile values override both systemd unit roles" >&2
+    return 1
+  fi
+}
+
+resolve_ranking_community_id() {
+  local env_file="$1"
+  local community_id="${RANKING_WORKER_DEFAULT_COMMUNITY_ID}"
+  local configured=""
+
+  if [ -f "$env_file" ]; then
+    if ! configured=$(sed -n 's/^[[:space:]]*RANKING_COMMUNITY_ID[[:space:]]*=[[:space:]]*//p' "$env_file" | tail -1); then
+      echo "ERROR: could not read RANKING_COMMUNITY_ID from ${env_file}" >&2
+      return 1
+    fi
+    configured=$(printf '%s' "$configured" | tr -d "\r\"'")
+    if [ -n "$configured" ]; then
+      community_id="$configured"
+    fi
+  fi
+
+  printf '%s\n' "$community_id"
+}
+
+validate_ranking_worker_stop_timeout() {
+  local unit_file="$1"
+  local env_file="$2"
+  local scoring_timeout_ms="${RANKING_WORKER_DEFAULT_SCORING_TIMEOUT_MS}"
+  local configured_timeout=""
+  local stop_timeout_seconds=""
+  local stop_timeout_ms
+
+  if [ ! -r "$unit_file" ]; then
+    echo "ERROR: ranking worker unit is unreadable: ${unit_file}" >&2
+    return 1
+  fi
+  if [ -f "$env_file" ]; then
+    if ! configured_timeout=$(sed -n 's/^[[:space:]]*SCORING_TIMEOUT_MS[[:space:]]*=[[:space:]]*//p' "$env_file" | tail -1); then
+      echo "ERROR: could not read SCORING_TIMEOUT_MS from ${env_file}" >&2
+      return 1
+    fi
+    configured_timeout=$(printf '%s' "$configured_timeout" | tr -d "\r\"'")
+    if [ -n "$configured_timeout" ]; then
+      scoring_timeout_ms="$configured_timeout"
+    fi
+  fi
+  if ! [[ "$scoring_timeout_ms" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: SCORING_TIMEOUT_MS must be an integer, got ${scoring_timeout_ms}" >&2
+    return 1
+  fi
+  if ! stop_timeout_seconds=$(sed -n 's/^[[:space:]]*TimeoutStopSec[[:space:]]*=[[:space:]]*//p' "$unit_file" | tail -1); then
+    echo "ERROR: could not read TimeoutStopSec from ${unit_file}" >&2
+    return 1
+  fi
+  if ! [[ "$stop_timeout_seconds" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: TimeoutStopSec must be an integer number of seconds, got ${stop_timeout_seconds:-missing}" >&2
+    return 1
+  fi
+
+  stop_timeout_ms=$((stop_timeout_seconds * 1000))
+  if (( stop_timeout_ms - scoring_timeout_ms < RANKING_WORKER_MIN_STOP_MARGIN_MS )); then
+    echo "ERROR: TimeoutStopSec=${stop_timeout_seconds} must exceed SCORING_TIMEOUT_MS=${scoring_timeout_ms} by at least ${RANKING_WORKER_MIN_STOP_MARGIN_MS}ms" >&2
+    return 1
+  fi
+}
+
+ranking_worker_heartbeat_is_healthy() {
+  local heartbeat_json="$1"
+  local restart_epoch_ms="$2"
+  HEARTBEAT_JSON="$heartbeat_json" WORKER_RESTART_EPOCH_MS="$restart_epoch_ms" python3 -c 'import datetime, json, os; payload=json.loads(os.environ["HEARTBEAT_JSON"]); updated=datetime.datetime.fromisoformat(payload["updatedAt"].replace("Z", "+00:00")); age=(datetime.datetime.now(datetime.timezone.utc)-updated).total_seconds(); updated_ms=int(updated.timestamp()*1000); restart_ms=int(os.environ["WORKER_RESTART_EPOCH_MS"]); raise SystemExit(0 if 0 <= age <= 60 and updated_ms >= restart_ms and payload.get("state") != "failed" else 1)' 2>/dev/null
+}
+
+probe_ranking_worker_heartbeat_with_compose() {
+  local timeout_seconds="$1"
+  local compose_file="$2"
+  local heartbeat_key="$3"
+  timeout "$timeout_seconds" sudo docker compose -f "$compose_file" exec -T redis redis-cli --raw GET "$heartbeat_key" 2>/dev/null
+}
+
+probe_ranking_worker_heartbeat_with_docker() {
+  local timeout_seconds="$1"
+  local container_name="$2"
+  local heartbeat_key="$3"
+  timeout "$timeout_seconds" docker exec "$container_name" redis-cli --raw GET "$heartbeat_key" 2>/dev/null
+}
+
+wait_for_ranking_worker_ready() {
+  local community_id="$1"
+  local restart_epoch_ms="$2"
+  local attempts="$3"
+  local retry_delay_seconds="$4"
+  local probe_function="$5"
+  local heartbeat_key="${RANKING_WORKER_HEARTBEAT_PREFIX}:${community_id}"
+  local attempt
+  local heartbeat
+
+  for ((attempt = 1; attempt <= attempts; attempt += 1)); do
+    heartbeat=""
+    if ! heartbeat=$("$probe_function" "$heartbeat_key"); then
+      echo "Ranking worker heartbeat probe failed (attempt ${attempt}/${attempts})" >&2
+    elif [ -n "$heartbeat" ] && ranking_worker_heartbeat_is_healthy "$heartbeat" "$restart_epoch_ms"; then
+      echo "Ranking worker heartbeat passed (attempt ${attempt}/${attempts})"
+      return 0
+    else
+      echo "Ranking worker heartbeat is missing, malformed, stale, or failed (attempt ${attempt}/${attempts})" >&2
+    fi
+    if [ "$attempt" -lt "$attempts" ]; then
+      sleep "$retry_delay_seconds"
+    fi
+  done
+
+  return 1
+}

--- a/ops/status
+++ b/ops/status
@@ -107,5 +107,5 @@ else
 
   echo ""
   echo "=== Last Scoring ==="
-  journalctl -u corgi-ranking-worker --since "15 minutes ago" --no-pager 2>/dev/null | grep -i "scoring pipeline complete" | tail -1 || echo "No recent scoring run found"
+  journalctl -u bluesky-feed -u corgi-ranking-worker --since "15 minutes ago" --no-pager 2>/dev/null | grep -i "scoring pipeline complete" | tail -1 || echo "No recent scoring run found"
 fi

--- a/ops/status
+++ b/ops/status
@@ -9,6 +9,10 @@ ADMIN_DID="${ADMIN_DID:-}"
 
 echo "=== Service ==="
 systemctl is-active bluesky-feed 2>/dev/null || echo "NOT RUNNING"
+if systemctl list-unit-files corgi-ranking-worker.service --no-legend 2>/dev/null | grep -q '^corgi-ranking-worker.service'; then
+  printf "Ranking worker: "
+  systemctl is-active corgi-ranking-worker 2>/dev/null || echo "NOT RUNNING"
+fi
 
 # Try vitals endpoint first (requires admin auth header)
 VITALS=""
@@ -103,5 +107,5 @@ else
 
   echo ""
   echo "=== Last Scoring ==="
-  journalctl -u bluesky-feed --since "15 minutes ago" --no-pager 2>/dev/null | grep -i "scoring pipeline complete" | tail -1 || echo "No recent scoring run found"
+  journalctl -u corgi-ranking-worker --since "15 minutes ago" --no-pager 2>/dev/null | grep -i "scoring pipeline complete" | tail -1 || echo "No recent scoring run found"
 fi

--- a/src/admin/routes/feed-health.ts
+++ b/src/admin/routes/feed-health.ts
@@ -101,6 +101,7 @@ export function registerFeedHealthRoutes(app: FastifyInstance): void {
       rankingWorker = await readRankingWorkerHealth(
         redis,
         rankingRequestQueue,
+        config.RANKING_COMMUNITY_ID,
         new Date(),
         config.RANKING_WORKER_HEARTBEAT_TTL_MS
       );

--- a/src/admin/routes/feed-health.ts
+++ b/src/admin/routes/feed-health.ts
@@ -10,9 +10,12 @@ import { db } from '../../db/client.js';
 import { redis } from '../../db/redis.js';
 import { getScoringStatus } from '../status-tracker.js';
 import { getAdminDid } from '../../auth/admin.js';
-import { tryTriggerManualScoringRun } from '../../scoring/scheduler.js';
+import { enqueueManualScoringRun } from '../../scoring/scheduler.js';
 import { logger } from '../../lib/logger.js';
 import { adminSecurity } from '../../lib/openapi.js';
+import { config } from '../../config.js';
+import { rankingRequestQueue } from '../../scoring/ranking-request-queue.js';
+import { readRankingWorkerHealth } from '../../scoring/ranking-worker.js';
 import {
   getJetstreamDisconnectedAt,
   getJetstreamEventsLast5Min,
@@ -93,6 +96,18 @@ export function registerFeedHealthRoutes(app: FastifyInstance): void {
       logger.warn({ err }, 'Failed to get feed size from Redis');
     }
 
+    let rankingWorker: Awaited<ReturnType<typeof readRankingWorkerHealth>> | null = null;
+    try {
+      rankingWorker = await readRankingWorkerHealth(
+        redis,
+        rankingRequestQueue,
+        new Date(),
+        config.RANKING_WORKER_HEARTBEAT_TTL_MS
+      );
+    } catch (err) {
+      logger.warn({ err }, 'Failed to get ranking worker health');
+    }
+
     return reply.send({
       database: {
         totalPosts: parseInt(dbStats.rows[0].total_posts, 10),
@@ -124,6 +139,7 @@ export function registerFeedHealthRoutes(app: FastifyInstance): void {
         lastUpdated: epochResult.rows[0]?.rules_updated,
       },
       feedSize,
+      rankingWorker,
     });
   });
 
@@ -165,17 +181,20 @@ export function registerFeedHealthRoutes(app: FastifyInstance): void {
     schema: {
       tags: ['Admin'],
       summary: 'Rescore feed',
-      description: 'Manually triggers the scoring pipeline to rescore the feed.',
+      description: 'Durably queues an idempotent scoring request for the ranking worker.',
       security: adminSecurity,
     },
   }, async (request: FastifyRequest, reply: FastifyReply) => {
     const adminDid = getAdminDid(request);
 
-    if (!(await tryTriggerManualScoringRun())) {
-      logger.warn({ adminDid }, 'Manual rescore rejected because scoring is already in progress');
-      return reply.code(409).send({
-        error: 'Conflict',
-        message: 'Scoring pipeline is already running. Try again after it completes.',
+    let rankingRequest: Awaited<ReturnType<typeof enqueueManualScoringRun>>;
+    try {
+      rankingRequest = await enqueueManualScoringRun(adminDid, new Date());
+    } catch (err) {
+      logger.error({ err, adminDid }, 'Manual rescore queueing failed');
+      return reply.code(503).send({
+        error: 'RankingQueueUnavailable',
+        message: 'The ranking request could not be queued. No ranking was started.',
       });
     }
 
@@ -183,14 +202,26 @@ export function registerFeedHealthRoutes(app: FastifyInstance): void {
     await db.query(
       `INSERT INTO governance_audit_log (action, actor_did, details)
        VALUES ('manual_rescore', $1, $2)`,
-      [adminDid, JSON.stringify({ triggeredAt: new Date().toISOString() })]
+      [adminDid, JSON.stringify({
+        requestId: rankingRequest.id,
+        idempotencyKey: rankingRequest.idempotencyKey,
+        created: rankingRequest.created,
+        queuedAt: new Date().toISOString(),
+      })]
     );
 
-    logger.info({ adminDid }, 'Manual rescore triggered by admin');
+    logger.info(
+      { adminDid, requestId: rankingRequest.id, created: rankingRequest.created },
+      'Manual rescore queued by admin'
+    );
 
-    return reply.send({
+    return reply.code(202).send({
       success: true,
-      message: 'Scoring pipeline started. Check feed-health endpoint for results.',
+      queued: true,
+      requestId: rankingRequest.id,
+      idempotencyKey: rankingRequest.idempotencyKey,
+      created: rankingRequest.created,
+      message: 'Scoring request queued. Check feed-health for worker progress.',
     });
   });
 }

--- a/src/admin/routes/feed-health.ts
+++ b/src/admin/routes/feed-health.ts
@@ -199,17 +199,25 @@ export function registerFeedHealthRoutes(app: FastifyInstance): void {
       });
     }
 
-    // Log to audit
-    await db.query(
-      `INSERT INTO governance_audit_log (action, actor_did, details)
-       VALUES ('manual_rescore', $1, $2)`,
-      [adminDid, JSON.stringify({
-        requestId: rankingRequest.id,
-        idempotencyKey: rankingRequest.idempotencyKey,
-        created: rankingRequest.created,
-        queuedAt: new Date().toISOString(),
-      })]
-    );
+    // The durable queue write is authoritative. An auxiliary audit failure
+    // must not tell the caller that an already-queued request was rejected.
+    try {
+      await db.query(
+        `INSERT INTO governance_audit_log (action, actor_did, details)
+         VALUES ('manual_rescore', $1, $2)`,
+        [adminDid, JSON.stringify({
+          requestId: rankingRequest.id,
+          idempotencyKey: rankingRequest.idempotencyKey,
+          created: rankingRequest.created,
+          queuedAt: new Date().toISOString(),
+        })]
+      );
+    } catch (error) {
+      logger.error(
+        { err: error, adminDid, requestId: rankingRequest.id },
+        'Manual rescore was queued but governance audit persistence failed'
+      );
+    }
 
     logger.info(
       { adminDid, requestId: rankingRequest.id, created: rankingRequest.created },

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export const ConfigSchema = z.object({
   // Server
   FEEDGEN_PORT: z.coerce.number().default(3000),
   FEEDGEN_LISTENHOST: z.string().default('0.0.0.0'),
+  PROCESS_ROLE: z.enum(['api', 'ranking-worker', 'all']).default('all'),
 
   // Jetstream
   JETSTREAM_URL: z.string().url(),
@@ -60,6 +61,13 @@ export const ConfigSchema = z.object({
   SCORING_FULL_RESCORE_INTERVAL: z.coerce.number().int().min(1).default(6),
   SCORING_CANDIDATE_LIMIT: z.coerce.number().min(100).default(5_000),
   SCORING_TIMEOUT_MS: z.coerce.number().min(30_000).default(240_000),
+  RANKING_COMMUNITY_ID: z.string().min(1).default('community-gov'),
+  RANKING_WORKER_POLL_MS: z.coerce.number().int().min(100).default(1_000),
+  RANKING_CLAIM_STALE_MS: z.coerce.number().int().min(30_000).default(360_000),
+  RANKING_LEASE_TTL_MS: z.coerce.number().int().min(5_000).default(300_000),
+  RANKING_LEASE_RENEW_INTERVAL_MS: z.coerce.number().int().min(1_000).default(60_000),
+  RANKING_WORKER_HEARTBEAT_INTERVAL_MS: z.coerce.number().int().min(1_000).default(10_000),
+  RANKING_WORKER_HEARTBEAT_TTL_MS: z.coerce.number().int().min(5_000).default(30_000),
   /**
    * Max posts scored concurrently in the pipeline loop (PROJ-917). Each in-flight
    * post holds at most ONE DB connection at a time (components run sequentially
@@ -230,6 +238,38 @@ export const ConfigSchema = z.object({
       code: z.ZodIssueCode.custom,
       path: ['DISK_CRITICAL_PERCENT'],
       message: `DISK_CRITICAL_PERCENT (${cfg.DISK_CRITICAL_PERCENT}) must be less than DISK_EMERGENCY_PERCENT (${cfg.DISK_EMERGENCY_PERCENT})`,
+    });
+  }
+
+  if (cfg.RANKING_LEASE_RENEW_INTERVAL_MS * 2 >= cfg.RANKING_LEASE_TTL_MS) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['RANKING_LEASE_RENEW_INTERVAL_MS'],
+      message: 'RANKING_LEASE_RENEW_INTERVAL_MS must be less than half RANKING_LEASE_TTL_MS.',
+    });
+  }
+
+  if (cfg.RANKING_WORKER_HEARTBEAT_INTERVAL_MS >= cfg.RANKING_WORKER_HEARTBEAT_TTL_MS) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['RANKING_WORKER_HEARTBEAT_INTERVAL_MS'],
+      message: 'RANKING_WORKER_HEARTBEAT_INTERVAL_MS must be less than RANKING_WORKER_HEARTBEAT_TTL_MS.',
+    });
+  }
+
+  if (cfg.RANKING_CLAIM_STALE_MS <= cfg.SCORING_TIMEOUT_MS) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['RANKING_CLAIM_STALE_MS'],
+      message: 'RANKING_CLAIM_STALE_MS must exceed SCORING_TIMEOUT_MS.',
+    });
+  }
+
+  if (cfg.RANKING_LEASE_TTL_MS <= cfg.SCORING_TIMEOUT_MS) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['RANKING_LEASE_TTL_MS'],
+      message: 'RANKING_LEASE_TTL_MS must exceed SCORING_TIMEOUT_MS.',
     });
   }
 

--- a/src/db/migrations/033_ranking_run_requests_claim_index.sql
+++ b/src/db/migrations/033_ranking_run_requests_claim_index.sql
@@ -1,0 +1,4 @@
+-- Migration 033: support community-scoped ranking request claim scans.
+
+CREATE INDEX IF NOT EXISTS idx_ranking_run_requests_community_state_due
+  ON ranking_run_requests (community_id, state, not_before, requested_at, id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import { loadGovernanceGateWeights } from './ingestion/governance-gate.js';
 import { sdNotifyReady, startWatchdog, stopWatchdog } from './lib/watchdog.js';
 
 async function main() {
-  logger.info('Starting Community Feed Generator...');
+  logger.info({ processRole: config.PROCESS_ROLE }, 'Starting Community Feed Generator...');
 
   // 0. Run startup checks (fail fast if dependencies are down)
   try {
@@ -32,6 +32,13 @@ async function main() {
   } catch (err) {
     logger.fatal({ err }, 'Startup checks failed');
     process.exit(1);
+  }
+
+  if (config.PROCESS_ROLE === 'ranking-worker') {
+    await startScoring();
+    registerRankingWorkerShutdown();
+    logger.info({ processRole: config.PROCESS_ROLE }, 'Ranking worker operational');
+    return;
   }
 
   // 1. Create and configure the HTTP server
@@ -117,6 +124,12 @@ async function main() {
 
   // 5. Register scoring health check (before starting scoring so it's available during initial run)
   registerScoringHealth((): ScoringHealth => {
+    if (config.PROCESS_ROLE === 'api') {
+      return {
+        status: 'healthy',
+        is_running: false,
+      };
+    }
     const isRunning = isScoringInProgress();
     const lastRunAt = getLastScoringRunAt();
 
@@ -134,12 +147,14 @@ async function main() {
   });
 
   // 6. Start scoring pipeline
-  try {
-    await startScoring();
-    logger.info('Scoring pipeline started');
-  } catch (err) {
-    logger.fatal({ err }, 'Failed to start scoring pipeline');
-    process.exit(1);
+  if (config.PROCESS_ROLE === 'all') {
+    try {
+      await startScoring();
+      logger.info('Scoring pipeline started');
+    } catch (err) {
+      logger.fatal({ err }, 'Failed to start scoring pipeline');
+      process.exit(1);
+    }
   }
 
   // 6.5. Initialize announcement bot (if enabled, non-fatal)
@@ -167,7 +182,7 @@ async function main() {
   // 7. Register graceful shutdown handlers
   registerShutdownHandlers({
     server: app,
-    stopScoring,
+    stopScoring: config.PROCESS_ROLE === 'all' ? stopScoring : async () => undefined,
     stopJetstream,
     stopEpochScheduler,
     stopMaintenanceWorkerSupervisor,
@@ -180,10 +195,32 @@ async function main() {
 
   // 8. Log startup complete
   logger.info({
+    processRole: config.PROCESS_ROLE,
     serviceDid: config.FEEDGEN_SERVICE_DID,
     publisherDid: config.FEEDGEN_PUBLISHER_DID,
     hostname: config.FEEDGEN_HOSTNAME,
   }, 'All systems operational (Phase 6: Hardening)');
+}
+
+function registerRankingWorkerShutdown(): void {
+  let shuttingDown = false;
+  const shutdown = (signal: NodeJS.Signals): void => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    logger.info({ signal }, 'Stopping ranking worker');
+    void stopScoring()
+      .then(() => {
+        process.exit(0);
+      })
+      .catch((error) => {
+        logger.error({ err: error, signal }, 'Ranking worker shutdown failed');
+        process.exit(1);
+      });
+  };
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGINT', () => shutdown('SIGINT'));
 }
 
 // Handle unhandled rejections

--- a/src/mcp/tools/feed.ts
+++ b/src/mcp/tools/feed.ts
@@ -21,7 +21,7 @@ export function registerFeedTools(
   server.registerTool(
     'get_feed_health',
     {
-      description: 'Get feed health status including database, scoring pipeline, Jetstream, and subscriber counts',
+      description: 'Get feed health including API ingestion, ranking-worker heartbeat, durable queue state, and feed snapshot size',
     },
     async () => {
       const res = await app.inject({ method: 'GET', url: '/api/admin/feed-health', headers: { cookie } });
@@ -32,7 +32,7 @@ export function registerFeedTools(
   server.registerTool(
     'trigger_rescore',
     {
-      description: 'Trigger an immediate scoring pipeline run to re-score all posts',
+      description: 'Queue an idempotent durable scoring request for the independent ranking worker',
       annotations: { destructiveHint: false, readOnlyHint: false },
     },
     async () => {

--- a/src/scoring/owned-lease.ts
+++ b/src/scoring/owned-lease.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from 'node:crypto';
+import type { Redis } from 'ioredis';
+
+const RENEW_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('pexpire', KEYS[1], ARGV[2])
+end
+return 0
+`;
+
+const RELEASE_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('del', KEYS[1])
+end
+return 0
+`;
+
+export interface LeaseRedisClient {
+  set(
+    key: string,
+    value: string,
+    expiryMode: 'PX',
+    ttlMs: number,
+    condition: 'NX'
+  ): Promise<'OK' | null>;
+  eval(script: string, numberOfKeys: number, ...args: (string | number)[]): Promise<unknown>;
+}
+
+export class RedisLeaseUnavailableError extends Error {
+  constructor(operation: 'acquire' | 'renew' | 'release', key: string, cause: unknown) {
+    super(`Redis lease ${operation} failed for ${key}`, { cause });
+    this.name = 'RedisLeaseUnavailableError';
+  }
+}
+
+export class OwnedRedisLease {
+  private readonly client: LeaseRedisClient;
+  private readonly key: string;
+  private readonly ttlMs: number;
+
+  constructor(client: LeaseRedisClient, key: string, ttlMs: number) {
+    if (!key.trim()) {
+      throw new Error('Redis lease key must be non-empty');
+    }
+    if (!Number.isInteger(ttlMs) || ttlMs < 1_000) {
+      throw new Error(`Redis lease ttlMs must be an integer >= 1000, got ${ttlMs}`);
+    }
+    this.client = client;
+    this.key = key;
+    this.ttlMs = ttlMs;
+  }
+
+  createToken(): string {
+    return randomUUID();
+  }
+
+  async acquire(token: string): Promise<boolean> {
+    assertToken(token);
+    try {
+      return (await this.client.set(this.key, token, 'PX', this.ttlMs, 'NX')) === 'OK';
+    } catch (error) {
+      throw new RedisLeaseUnavailableError('acquire', this.key, error);
+    }
+  }
+
+  async renew(token: string): Promise<boolean> {
+    assertToken(token);
+    try {
+      const result = await this.client.eval(
+        RENEW_SCRIPT,
+        1,
+        this.key,
+        token,
+        this.ttlMs
+      );
+      return Number(result) === 1;
+    } catch (error) {
+      throw new RedisLeaseUnavailableError('renew', this.key, error);
+    }
+  }
+
+  async release(token: string): Promise<boolean> {
+    assertToken(token);
+    try {
+      const result = await this.client.eval(RELEASE_SCRIPT, 1, this.key, token);
+      return Number(result) === 1;
+    } catch (error) {
+      throw new RedisLeaseUnavailableError('release', this.key, error);
+    }
+  }
+}
+
+export function createOwnedScoringLease(client: Redis, ttlMs: number): OwnedRedisLease {
+  return new OwnedRedisLease(client, 'lock:scoring', ttlMs);
+}
+
+function assertToken(token: string): void {
+  if (!token.trim()) {
+    throw new Error('Redis lease token must be non-empty');
+  }
+}

--- a/src/scoring/owned-lease.ts
+++ b/src/scoring/owned-lease.ts
@@ -90,8 +90,19 @@ export class OwnedRedisLease {
   }
 }
 
-export function createOwnedScoringLease(client: Redis, ttlMs: number): OwnedRedisLease {
-  return new OwnedRedisLease(client, 'lock:scoring', ttlMs);
+export function createOwnedScoringLease(
+  client: Redis,
+  communityId: string,
+  ttlMs: number
+): OwnedRedisLease {
+  return new OwnedRedisLease(client, scoringLeaseKey(communityId), ttlMs);
+}
+
+export function scoringLeaseKey(communityId: string): string {
+  if (!communityId.trim()) {
+    throw new Error('Scoring lease communityId must be non-empty');
+  }
+  return `lock:scoring:${communityId}`;
 }
 
 function assertToken(token: string): void {

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -38,6 +38,7 @@ import type { ContentRules } from '../governance/governance.types.js';
 import { updateScoringStatus } from '../admin/status-tracker.js';
 import { calculateAuthorConcentration } from '../transparency/metrics.js';
 import { applyFeedUrlDedup, FEED_URL_DEDUP_DECAY } from './feed-publication.js';
+import { ScoringPipelineTimeoutError } from './scoring-pipeline-timeout-error.js';
 
 // Maximum time allowed for a single scoring run.
 const SCORING_TIMEOUT_MS = config.SCORING_TIMEOUT_MS;
@@ -223,7 +224,7 @@ export async function runScoringPipeline(): Promise<void> {
   let timeout: NodeJS.Timeout | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeout = setTimeout(
-      () => reject(new Error('Scoring pipeline timed out')),
+      () => reject(new ScoringPipelineTimeoutError('Scoring pipeline timed out')),
       SCORING_TIMEOUT_MS
     );
   });

--- a/src/scoring/ranking-request-queue.ts
+++ b/src/scoring/ranking-request-queue.ts
@@ -1,0 +1,273 @@
+import type { Pool, PoolClient } from 'pg';
+import { db } from '../db/client.js';
+import { enqueueRankingRunRequest } from './ranking-run-contracts.js';
+
+export type RankingRequestKind = 'scheduled' | 'manual' | 'replacement' | 'reconciliation';
+export type RankingRequestState = 'pending' | 'claimed' | 'completed' | 'cancelled' | 'failed';
+
+export interface RankingRequest {
+  id: string;
+  idempotencyKey: string;
+  communityId: string;
+  requestKind: RankingRequestKind;
+  state: RankingRequestState;
+  requestedBy: string | null;
+  requestedAt: string;
+  notBefore: string;
+  claimedBy: string | null;
+  claimedAt: string | null;
+}
+
+export interface EnqueuedRankingRequest {
+  id: string;
+  created: boolean;
+  idempotencyKey: string;
+}
+
+export interface RankingQueueStatus {
+  pendingCount: number;
+  claimedCount: number;
+  oldestPendingAt: string | null;
+  newestRequestId: string | null;
+  newestRequestState: RankingRequestState | null;
+}
+
+interface RankingRequestRow {
+  id: string;
+  idempotency_key: string;
+  community_id: string;
+  request_kind: RankingRequestKind;
+  state: RankingRequestState;
+  requested_by: string | null;
+  requested_at: Date | string;
+  not_before: Date | string;
+  claimed_by: string | null;
+  claimed_at: Date | string | null;
+}
+
+interface QueueStatusRow {
+  pending_count: string | number;
+  claimed_count: string | number;
+  oldest_pending_at: Date | string | null;
+  newest_request_id: string | null;
+  newest_request_state: RankingRequestState | null;
+}
+
+export class RankingRequestQueue {
+  private readonly pool: Pool;
+
+  constructor(pool: Pool) {
+    this.pool = pool;
+  }
+
+  async enqueue(input: {
+    idempotencyKey: string;
+    communityId: string;
+    requestKind: RankingRequestKind;
+    requestedBy: string | null;
+    notBefore: Date;
+  }): Promise<EnqueuedRankingRequest> {
+    assertNonEmpty(input.idempotencyKey, 'idempotencyKey');
+    assertNonEmpty(input.communityId, 'communityId');
+    const client = await this.pool.connect();
+    try {
+      const result = await enqueueRankingRunRequest(client, {
+        idempotencyKey: input.idempotencyKey,
+        communityId: input.communityId,
+        requestKind: input.requestKind,
+        requestedBy: input.requestedBy,
+        notBefore: input.notBefore.toISOString(),
+      });
+      return { ...result, idempotencyKey: input.idempotencyKey };
+    } finally {
+      client.release();
+    }
+  }
+
+  async claimNext(workerId: string): Promise<RankingRequest | null> {
+    assertNonEmpty(workerId, 'workerId');
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await client.query<RankingRequestRow>(
+        `WITH candidate AS (
+           SELECT id
+             FROM ranking_run_requests
+            WHERE state = 'pending'
+              AND not_before <= NOW()
+            ORDER BY not_before ASC, requested_at ASC, id ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT 1
+         )
+         UPDATE ranking_run_requests AS request
+            SET state = 'claimed',
+                claimed_by = $1,
+                claimed_at = NOW(),
+                failure = NULL
+           FROM candidate
+          WHERE request.id = candidate.id
+         RETURNING request.id::text, request.idempotency_key,
+                   request.community_id, request.request_kind, request.state,
+                   request.requested_by, request.requested_at,
+                   request.not_before, request.claimed_by, request.claimed_at`,
+        [workerId]
+      );
+      await client.query('COMMIT');
+      return result.rows[0] ? mapRequest(result.rows[0]) : null;
+    } catch (error) {
+      await rollback(client);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async complete(requestId: string, workerId: string): Promise<void> {
+    await this.transitionClaimed(requestId, workerId, 'completed', null, null);
+  }
+
+  async fail(requestId: string, workerId: string, error: unknown): Promise<void> {
+    const failure = {
+      message: error instanceof Error ? error.message : String(error),
+      name: error instanceof Error ? error.name : 'UnknownError',
+    };
+    await this.transitionClaimed(requestId, workerId, 'failed', failure, null);
+  }
+
+  async defer(requestId: string, workerId: string, notBefore: Date): Promise<void> {
+    await this.transitionClaimed(requestId, workerId, 'pending', null, notBefore);
+  }
+
+  async status(): Promise<RankingQueueStatus> {
+    const result = await this.pool.query<QueueStatusRow>(
+      `WITH newest AS (
+         SELECT id::text, state
+           FROM ranking_run_requests
+          ORDER BY requested_at DESC, id DESC
+          LIMIT 1
+       )
+       SELECT
+         COUNT(*) FILTER (WHERE state = 'pending') AS pending_count,
+         COUNT(*) FILTER (WHERE state = 'claimed') AS claimed_count,
+         MIN(requested_at) FILTER (WHERE state = 'pending') AS oldest_pending_at,
+         (SELECT id FROM newest) AS newest_request_id,
+         (SELECT state FROM newest) AS newest_request_state
+       FROM ranking_run_requests`
+    );
+    const row = result.rows[0];
+    if (!row) {
+      throw new Error('Ranking request queue status query returned no row');
+    }
+    return {
+      pendingCount: Number(row.pending_count),
+      claimedCount: Number(row.claimed_count),
+      oldestPendingAt: row.oldest_pending_at ? toIso(row.oldest_pending_at) : null,
+      newestRequestId: row.newest_request_id,
+      newestRequestState: row.newest_request_state,
+    };
+  }
+
+  async requeueStaleClaims(staleBefore: Date): Promise<number> {
+    const result = await this.pool.query<{ id: string }>(
+      `UPDATE ranking_run_requests
+          SET state = 'pending',
+              claimed_by = NULL,
+              claimed_at = NULL,
+              not_before = NOW(),
+              failure = jsonb_build_object(
+                'name', 'StaleClaimRecovered',
+                'message', 'Claim recovered after worker termination'
+              )
+        WHERE state = 'claimed'
+          AND claimed_at < $1
+       RETURNING id::text`,
+      [staleBefore]
+    );
+    return result.rows.length;
+  }
+
+  private async transitionClaimed(
+    requestId: string,
+    workerId: string,
+    nextState: 'pending' | 'completed' | 'failed',
+    failure: Record<string, string> | null,
+    notBefore: Date | null
+  ): Promise<void> {
+    assertNonEmpty(requestId, 'requestId');
+    assertNonEmpty(workerId, 'workerId');
+    const result = await this.pool.query<{ id: string }>(
+      `UPDATE ranking_run_requests
+          SET state = $3,
+              completed_at = CASE WHEN $3 IN ('completed', 'failed') THEN NOW() ELSE NULL END,
+              failure = $4::jsonb,
+              not_before = COALESCE($5, not_before),
+              claimed_by = CASE WHEN $3 = 'pending' THEN NULL ELSE claimed_by END,
+              claimed_at = CASE WHEN $3 = 'pending' THEN NULL ELSE claimed_at END
+        WHERE id = $1
+          AND state = 'claimed'
+          AND claimed_by = $2
+       RETURNING id::text`,
+      [requestId, workerId, nextState, failure ? JSON.stringify(failure) : null, notBefore]
+    );
+    if (!result.rows[0]) {
+      throw new Error(
+        `Ranking request ${requestId} is not claimed by worker ${workerId}; cannot transition to ${nextState}`
+      );
+    }
+  }
+}
+
+export const rankingRequestQueue = new RankingRequestQueue(db);
+
+export function scheduledRequestKey(communityId: string, at: Date, intervalMs: number): string {
+  assertNonEmpty(communityId, 'communityId');
+  if (!Number.isInteger(intervalMs) || intervalMs < 1) {
+    throw new Error(`intervalMs must be a positive integer, got ${intervalMs}`);
+  }
+  return `scheduled:${communityId}:${Math.floor(at.getTime() / intervalMs)}`;
+}
+
+export function manualRequestKey(communityId: string, requestedBy: string, at: Date): string {
+  assertNonEmpty(communityId, 'communityId');
+  assertNonEmpty(requestedBy, 'requestedBy');
+  return `manual:${communityId}:${requestedBy}:${Math.floor(at.getTime() / 60_000)}`;
+}
+
+function mapRequest(row: RankingRequestRow): RankingRequest {
+  return {
+    id: row.id,
+    idempotencyKey: row.idempotency_key,
+    communityId: row.community_id,
+    requestKind: row.request_kind,
+    state: row.state,
+    requestedBy: row.requested_by,
+    requestedAt: toIso(row.requested_at),
+    notBefore: toIso(row.not_before),
+    claimedBy: row.claimed_by,
+    claimedAt: row.claimed_at ? toIso(row.claimed_at) : null,
+  };
+}
+
+async function rollback(client: PoolClient): Promise<void> {
+  try {
+    await client.query('ROLLBACK');
+  } catch (rollbackError) {
+    throw new Error('Ranking request transaction failed and rollback also failed', {
+      cause: rollbackError,
+    });
+  }
+}
+
+function toIso(value: Date | string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid ranking request timestamp ${String(value)}`);
+  }
+  return parsed.toISOString();
+}
+
+function assertNonEmpty(value: string, field: string): void {
+  if (!value.trim()) {
+    throw new Error(`${field} must be non-empty`);
+  }
+}

--- a/src/scoring/ranking-request-queue.ts
+++ b/src/scoring/ranking-request-queue.ts
@@ -84,8 +84,9 @@ export class RankingRequestQueue {
     }
   }
 
-  async claimNext(workerId: string): Promise<RankingRequest | null> {
+  async claimNext(workerId: string, communityId: string): Promise<RankingRequest | null> {
     assertNonEmpty(workerId, 'workerId');
+    assertNonEmpty(communityId, 'communityId');
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');
@@ -94,6 +95,7 @@ export class RankingRequestQueue {
            SELECT id
              FROM ranking_run_requests
             WHERE state = 'pending'
+              AND community_id = $2
               AND not_before <= NOW()
             ORDER BY not_before ASC, requested_at ASC, id ASC
             FOR UPDATE SKIP LOCKED
@@ -110,7 +112,7 @@ export class RankingRequestQueue {
                    request.community_id, request.request_kind, request.state,
                    request.requested_by, request.requested_at,
                    request.not_before, request.claimed_by, request.claimed_at`,
-        [workerId]
+        [workerId, communityId]
       );
       await client.query('COMMIT');
       return result.rows[0] ? mapRequest(result.rows[0]) : null;
@@ -138,11 +140,16 @@ export class RankingRequestQueue {
     await this.transitionClaimed(requestId, workerId, 'pending', null, notBefore);
   }
 
-  async status(): Promise<RankingQueueStatus> {
+  async status(communityId: string): Promise<RankingQueueStatus> {
+    assertNonEmpty(communityId, 'communityId');
     const result = await this.pool.query<QueueStatusRow>(
-      `WITH newest AS (
-         SELECT id::text, state
+      `WITH filtered AS (
+         SELECT *
            FROM ranking_run_requests
+          WHERE community_id = $1
+       ), newest AS (
+         SELECT id::text, state
+           FROM filtered
           ORDER BY requested_at DESC, id DESC
           LIMIT 1
        )
@@ -152,7 +159,8 @@ export class RankingRequestQueue {
          MIN(requested_at) FILTER (WHERE state = 'pending') AS oldest_pending_at,
          (SELECT id FROM newest) AS newest_request_id,
          (SELECT state FROM newest) AS newest_request_state
-       FROM ranking_run_requests`
+       FROM filtered`,
+      [communityId]
     );
     const row = result.rows[0];
     if (!row) {
@@ -167,7 +175,8 @@ export class RankingRequestQueue {
     };
   }
 
-  async requeueStaleClaims(staleBefore: Date): Promise<number> {
+  async requeueStaleClaims(staleBefore: Date, communityId: string): Promise<number> {
+    assertNonEmpty(communityId, 'communityId');
     const result = await this.pool.query<{ id: string }>(
       `UPDATE ranking_run_requests
           SET state = 'pending',
@@ -180,8 +189,9 @@ export class RankingRequestQueue {
               )
         WHERE state = 'claimed'
           AND claimed_at < $1
+          AND community_id = $2
        RETURNING id::text`,
-      [staleBefore]
+      [staleBefore, communityId]
     );
     return result.rows.length;
   }

--- a/src/scoring/ranking-worker.ts
+++ b/src/scoring/ranking-worker.ts
@@ -7,13 +7,14 @@ import type {
 } from './ranking-request-queue.js';
 import { scheduledRequestKey } from './ranking-request-queue.js';
 
-export const RANKING_WORKER_HEARTBEAT_KEY = 'corgi:ranking-worker:heartbeat';
+export const RANKING_WORKER_HEARTBEAT_KEY_PREFIX = 'corgi:ranking-worker:heartbeat';
 
 export type RankingWorkerState = 'starting' | 'idle' | 'running' | 'stopping' | 'failed';
 
 export interface RankingWorkerHeartbeat {
   schemaVersion: 1;
   workerId: string;
+  communityId: string;
   state: RankingWorkerState;
   updatedAt: string;
   currentRequestId: string | null;
@@ -52,12 +53,12 @@ export interface RankingWorkerQueue {
     requestedBy: string | null;
     notBefore: Date;
   }): Promise<EnqueuedRankingRequest>;
-  claimNext(workerId: string): Promise<RankingRequest | null>;
+  claimNext(workerId: string, communityId: string): Promise<RankingRequest | null>;
   complete(requestId: string, workerId: string): Promise<void>;
   fail(requestId: string, workerId: string, error: unknown): Promise<void>;
   defer(requestId: string, workerId: string, notBefore: Date): Promise<void>;
-  status(): Promise<RankingQueueStatus>;
-  requeueStaleClaims(staleBefore: Date): Promise<number>;
+  status(communityId: string): Promise<RankingQueueStatus>;
+  requeueStaleClaims(staleBefore: Date, communityId: string): Promise<number>;
 }
 
 export interface RankingWorkerLease {
@@ -107,7 +108,8 @@ export class RankingWorker {
     this.state = 'starting';
     await this.writeHeartbeat();
     const recoveredClaims = await this.options.queue.requeueStaleClaims(
-      new Date(this.options.now().getTime() - this.options.claimStaleAfterMs)
+      new Date(this.options.now().getTime() - this.options.claimStaleAfterMs),
+      this.options.communityId
     );
     if (recoveredClaims > 0) {
       logger.warn({ recoveredClaims }, 'Recovered stale ranking request claims');
@@ -225,7 +227,10 @@ export class RankingWorker {
   private async processNext(): Promise<void> {
     let request: RankingRequest | null = null;
     try {
-      request = await this.options.queue.claimNext(this.options.workerId);
+      request = await this.options.queue.claimNext(
+        this.options.workerId,
+        this.options.communityId
+      );
       if (!request) {
         this.state = 'idle';
         return;
@@ -337,6 +342,7 @@ export class RankingWorker {
     const heartbeat: RankingWorkerHeartbeat = {
       schemaVersion: 1,
       workerId: this.options.workerId,
+      communityId: this.options.communityId,
       state: this.state,
       updatedAt: this.options.now().toISOString(),
       currentRequestId: this.currentRequestId,
@@ -344,7 +350,7 @@ export class RankingWorker {
       lastError: this.lastError,
     };
     await this.options.redis.set(
-      RANKING_WORKER_HEARTBEAT_KEY,
+      rankingWorkerHeartbeatKey(this.options.communityId),
       JSON.stringify(heartbeat),
       'PX',
       this.options.heartbeatTtlMs
@@ -355,17 +361,23 @@ export class RankingWorker {
 export async function readRankingWorkerHealth(
   redisClient: RankingWorkerRedis,
   queue: RankingWorkerQueue,
+  communityId: string,
   now: Date,
   heartbeatTtlMs: number
 ): Promise<RankingWorkerHealth> {
   const [raw, queueStatus] = await Promise.all([
-    redisClient.get(RANKING_WORKER_HEARTBEAT_KEY),
-    queue.status(),
+    redisClient.get(rankingWorkerHeartbeatKey(communityId)),
+    queue.status(communityId),
   ]);
   if (!raw) {
     return { healthy: false, heartbeat: null, ageMs: null, queue: queueStatus };
   }
   const heartbeat = parseHeartbeat(raw);
+  if (heartbeat.communityId !== communityId) {
+    throw new Error(
+      `Ranking worker heartbeat community mismatch: expected ${communityId}, got ${heartbeat.communityId}`
+    );
+  }
   const ageMs = now.getTime() - new Date(heartbeat.updatedAt).getTime();
   return {
     healthy: ageMs >= 0 && ageMs <= heartbeatTtlMs && heartbeat.state !== 'failed',
@@ -379,11 +391,19 @@ export function createRankingWorkerId(): string {
   return `${hostname()}:${process.pid}`;
 }
 
+export function rankingWorkerHeartbeatKey(communityId: string): string {
+  if (!communityId.trim()) {
+    throw new Error('Ranking worker heartbeat communityId must be non-empty');
+  }
+  return `${RANKING_WORKER_HEARTBEAT_KEY_PREFIX}:${communityId}`;
+}
+
 function parseHeartbeat(raw: string): RankingWorkerHeartbeat {
   const parsed = JSON.parse(raw) as Partial<RankingWorkerHeartbeat>;
   if (
     parsed.schemaVersion !== 1
     || typeof parsed.workerId !== 'string'
+    || typeof parsed.communityId !== 'string'
     || !isWorkerState(parsed.state)
     || typeof parsed.updatedAt !== 'string'
     || (parsed.currentRequestId !== null && typeof parsed.currentRequestId !== 'string')

--- a/src/scoring/ranking-worker.ts
+++ b/src/scoring/ranking-worker.ts
@@ -6,6 +6,9 @@ import type {
   RankingRequest,
 } from './ranking-request-queue.js';
 import { scheduledRequestKey } from './ranking-request-queue.js';
+import { ScoringPipelineTimeoutError } from './scoring-pipeline-timeout-error.js';
+
+export { ScoringPipelineTimeoutError } from './scoring-pipeline-timeout-error.js';
 
 export const RANKING_WORKER_HEARTBEAT_KEY_PREFIX = 'corgi:ranking-worker:heartbeat';
 
@@ -76,15 +79,6 @@ export interface RankingWorkerRedis {
 interface QuarantinedLease {
   token: string;
   renewalTimer: NodeJS.Timeout;
-}
-
-export class ScoringPipelineTimeoutError extends Error {
-  readonly code = 'SCORING_PIPELINE_TIMEOUT';
-
-  constructor(cause: unknown) {
-    super('Scoring pipeline timed out', { cause });
-    this.name = 'ScoringPipelineTimeoutError';
-  }
 }
 
 export class RankingWorker {

--- a/src/scoring/ranking-worker.ts
+++ b/src/scoring/ranking-worker.ts
@@ -1,0 +1,442 @@
+import { hostname } from 'node:os';
+import { logger } from '../lib/logger.js';
+import type {
+  EnqueuedRankingRequest,
+  RankingQueueStatus,
+  RankingRequest,
+} from './ranking-request-queue.js';
+import { scheduledRequestKey } from './ranking-request-queue.js';
+
+export const RANKING_WORKER_HEARTBEAT_KEY = 'corgi:ranking-worker:heartbeat';
+
+export type RankingWorkerState = 'starting' | 'idle' | 'running' | 'stopping' | 'failed';
+
+export interface RankingWorkerHeartbeat {
+  schemaVersion: 1;
+  workerId: string;
+  state: RankingWorkerState;
+  updatedAt: string;
+  currentRequestId: string | null;
+  lastCompletedAt: string | null;
+  lastError: string | null;
+}
+
+export interface RankingWorkerHealth {
+  healthy: boolean;
+  heartbeat: RankingWorkerHeartbeat | null;
+  ageMs: number | null;
+  queue: RankingQueueStatus;
+}
+
+export interface RankingWorkerOptions {
+  queue: RankingWorkerQueue;
+  lease: RankingWorkerLease;
+  redis: RankingWorkerRedis;
+  workerId: string;
+  communityId: string;
+  scheduleIntervalMs: number;
+  pollIntervalMs: number;
+  leaseRenewIntervalMs: number;
+  heartbeatIntervalMs: number;
+  heartbeatTtlMs: number;
+  claimStaleAfterMs: number;
+  runRanking: () => Promise<void>;
+  now: () => Date;
+}
+
+export interface RankingWorkerQueue {
+  enqueue(input: {
+    idempotencyKey: string;
+    communityId: string;
+    requestKind: 'scheduled' | 'manual' | 'replacement' | 'reconciliation';
+    requestedBy: string | null;
+    notBefore: Date;
+  }): Promise<EnqueuedRankingRequest>;
+  claimNext(workerId: string): Promise<RankingRequest | null>;
+  complete(requestId: string, workerId: string): Promise<void>;
+  fail(requestId: string, workerId: string, error: unknown): Promise<void>;
+  defer(requestId: string, workerId: string, notBefore: Date): Promise<void>;
+  status(): Promise<RankingQueueStatus>;
+  requeueStaleClaims(staleBefore: Date): Promise<number>;
+}
+
+export interface RankingWorkerLease {
+  createToken(): string;
+  acquire(token: string): Promise<boolean>;
+  renew(token: string): Promise<boolean>;
+  release(token: string): Promise<boolean>;
+}
+
+export interface RankingWorkerRedis {
+  set(key: string, value: string, expiryMode: 'PX', ttlMs: number): Promise<unknown>;
+  get(key: string): Promise<string | null>;
+}
+
+interface QuarantinedLease {
+  token: string;
+  renewalTimer: NodeJS.Timeout;
+}
+
+export class RankingWorker {
+  private readonly options: RankingWorkerOptions;
+  private scheduleTimer: NodeJS.Timeout | null = null;
+  private pollTimer: NodeJS.Timeout | null = null;
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+  private currentRun: Promise<void> | null = null;
+  private quarantinedLease: QuarantinedLease | null = null;
+  private quarantined = false;
+  private running = false;
+  private stopping = false;
+  private state: RankingWorkerState = 'starting';
+  private currentRequestId: string | null = null;
+  private lastCompletedAt: string | null = null;
+  private lastError: string | null = null;
+
+  constructor(options: RankingWorkerOptions) {
+    assertOptions(options);
+    this.options = options;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) {
+      logger.warn({ workerId: this.options.workerId }, 'Ranking worker already running');
+      return;
+    }
+    this.running = true;
+    this.stopping = false;
+    this.state = 'starting';
+    await this.writeHeartbeat();
+    const recoveredClaims = await this.options.queue.requeueStaleClaims(
+      new Date(this.options.now().getTime() - this.options.claimStaleAfterMs)
+    );
+    if (recoveredClaims > 0) {
+      logger.warn({ recoveredClaims }, 'Recovered stale ranking request claims');
+    }
+    await this.enqueueScheduledRequest(this.options.now());
+
+    this.scheduleTimer = setInterval(() => {
+      void this.enqueueScheduledAndDrain();
+    }, this.options.scheduleIntervalMs);
+    this.pollTimer = setInterval(() => {
+      void this.drainOnce();
+    }, this.options.pollIntervalMs);
+    this.heartbeatTimer = setInterval(() => {
+      void this.writeHeartbeat().catch((error) => {
+        this.lastError = errorMessage(error);
+        logger.error({ err: error }, 'Ranking worker heartbeat failed');
+      });
+    }, this.options.heartbeatIntervalMs);
+    this.state = 'idle';
+    await this.writeHeartbeat();
+    logger.info({ workerId: this.options.workerId }, 'Ranking worker started');
+    void this.drainOnce();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) {
+      return;
+    }
+    this.stopping = true;
+    this.state = 'stopping';
+    clearTimer(this.scheduleTimer);
+    clearTimer(this.pollTimer);
+    this.scheduleTimer = null;
+    this.pollTimer = null;
+    await this.writeHeartbeat();
+    if (this.currentRun) {
+      await this.currentRun;
+    }
+    if (this.quarantinedLease) {
+      clearInterval(this.quarantinedLease.renewalTimer);
+      try {
+        const released = await this.options.lease.release(this.quarantinedLease.token);
+        if (!released) {
+          logger.warn('Quarantined ranking lease was no longer owned at process stop');
+        }
+      } catch (error) {
+        logger.error({ err: error }, 'Quarantined ranking lease release failed');
+      }
+      this.quarantinedLease = null;
+    }
+    clearTimer(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+    this.running = false;
+    logger.info({ workerId: this.options.workerId }, 'Ranking worker stopped');
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  isRanking(): boolean {
+    return this.currentRequestId !== null;
+  }
+
+  async enqueueManual(requestedBy: string, idempotencyKey: string): Promise<EnqueuedRankingRequest> {
+    return this.options.queue.enqueue({
+      idempotencyKey,
+      communityId: this.options.communityId,
+      requestKind: 'manual',
+      requestedBy,
+      notBefore: this.options.now(),
+    });
+  }
+
+  async drainOnce(): Promise<void> {
+    if (!this.running || this.stopping || this.currentRun || this.quarantined) {
+      return;
+    }
+    const run = this.processNext();
+    this.currentRun = run;
+    try {
+      await run;
+    } finally {
+      if (this.currentRun === run) {
+        this.currentRun = null;
+      }
+    }
+  }
+
+  private async enqueueScheduledAndDrain(): Promise<void> {
+    try {
+      await this.enqueueScheduledRequest(this.options.now());
+      await this.drainOnce();
+    } catch (error) {
+      this.lastError = errorMessage(error);
+      logger.error({ err: error }, 'Failed to enqueue scheduled ranking request');
+    }
+  }
+
+  private async enqueueScheduledRequest(at: Date): Promise<void> {
+    const idempotencyKey = scheduledRequestKey(
+      this.options.communityId,
+      at,
+      this.options.scheduleIntervalMs
+    );
+    await this.options.queue.enqueue({
+      idempotencyKey,
+      communityId: this.options.communityId,
+      requestKind: 'scheduled',
+      requestedBy: 'ranking-worker',
+      notBefore: at,
+    });
+  }
+
+  private async processNext(): Promise<void> {
+    let request: RankingRequest | null = null;
+    try {
+      request = await this.options.queue.claimNext(this.options.workerId);
+      if (!request) {
+        this.state = 'idle';
+        return;
+      }
+      this.currentRequestId = request.id;
+      this.state = 'running';
+      this.lastError = null;
+      await this.writeHeartbeat();
+      const processed = await this.processClaimedRequest(request);
+      if (processed) {
+        await this.options.queue.complete(request.id, this.options.workerId);
+        this.lastCompletedAt = this.options.now().toISOString();
+      }
+    } catch (error) {
+      this.lastError = errorMessage(error);
+      this.state = 'failed';
+      if (request) {
+        try {
+          await this.options.queue.fail(request.id, this.options.workerId, error);
+        } catch (markFailedError) {
+          logger.error(
+            { err: markFailedError, requestId: request.id },
+            'Failed to persist ranking request failure'
+          );
+        }
+      }
+      logger.error({ err: error, requestId: request?.id }, 'Ranking request failed');
+    } finally {
+      this.currentRequestId = null;
+      if (!this.stopping && !this.quarantined) {
+        this.state = 'idle';
+      }
+      await this.writeHeartbeat().catch((error) => {
+        logger.error({ err: error }, 'Failed to write ranking worker completion heartbeat');
+      });
+    }
+  }
+
+  private async processClaimedRequest(request: RankingRequest): Promise<boolean> {
+    const token = this.options.lease.createToken();
+    const acquired = await this.options.lease.acquire(token);
+    if (!acquired) {
+      await this.options.queue.defer(
+        request.id,
+        this.options.workerId,
+        new Date(this.options.now().getTime() + this.options.pollIntervalMs)
+      );
+      return false;
+    }
+
+    let leaseLost: Error | null = null;
+    let renewalInProgress = false;
+    const renewalTimer = setInterval(() => {
+      if (renewalInProgress || leaseLost) {
+        return;
+      }
+      renewalInProgress = true;
+      void this.options.lease.renew(token)
+        .then((renewed) => {
+          if (!renewed) {
+            leaseLost = new Error(`Ranking lease ownership lost for request ${request.id}`);
+          }
+        })
+        .catch((error) => {
+          leaseLost = error instanceof Error ? error : new Error(String(error));
+        })
+        .finally(() => {
+          renewalInProgress = false;
+        });
+    }, this.options.leaseRenewIntervalMs);
+
+    let preserveLeaseUntilStop = false;
+    try {
+      await this.options.runRanking();
+      if (leaseLost) {
+        this.quarantined = true;
+        throw leaseLost;
+      }
+    } catch (error) {
+      if (isScoringPipelineTimeout(error)) {
+        this.quarantined = true;
+        preserveLeaseUntilStop = true;
+        this.quarantinedLease = { token, renewalTimer };
+        logger.error(
+          { err: error, requestId: request.id },
+          'Ranking worker quarantined after pipeline timeout; lease retained until process stop'
+        );
+      } else if (leaseLost) {
+        this.quarantined = true;
+      }
+      throw error;
+    } finally {
+      if (!preserveLeaseUntilStop) {
+        clearInterval(renewalTimer);
+        try {
+          const released = await this.options.lease.release(token);
+          if (!released && !leaseLost) {
+            logger.warn({ requestId: request.id }, 'Ranking lease was no longer owned at release');
+          }
+        } catch (error) {
+          logger.error({ err: error, requestId: request.id }, 'Ranking lease release failed');
+        }
+      }
+    }
+    return true;
+  }
+
+  private async writeHeartbeat(): Promise<void> {
+    const heartbeat: RankingWorkerHeartbeat = {
+      schemaVersion: 1,
+      workerId: this.options.workerId,
+      state: this.state,
+      updatedAt: this.options.now().toISOString(),
+      currentRequestId: this.currentRequestId,
+      lastCompletedAt: this.lastCompletedAt,
+      lastError: this.lastError,
+    };
+    await this.options.redis.set(
+      RANKING_WORKER_HEARTBEAT_KEY,
+      JSON.stringify(heartbeat),
+      'PX',
+      this.options.heartbeatTtlMs
+    );
+  }
+}
+
+export async function readRankingWorkerHealth(
+  redisClient: RankingWorkerRedis,
+  queue: RankingWorkerQueue,
+  now: Date,
+  heartbeatTtlMs: number
+): Promise<RankingWorkerHealth> {
+  const [raw, queueStatus] = await Promise.all([
+    redisClient.get(RANKING_WORKER_HEARTBEAT_KEY),
+    queue.status(),
+  ]);
+  if (!raw) {
+    return { healthy: false, heartbeat: null, ageMs: null, queue: queueStatus };
+  }
+  const heartbeat = parseHeartbeat(raw);
+  const ageMs = now.getTime() - new Date(heartbeat.updatedAt).getTime();
+  return {
+    healthy: ageMs >= 0 && ageMs <= heartbeatTtlMs && heartbeat.state !== 'failed',
+    heartbeat,
+    ageMs,
+    queue: queueStatus,
+  };
+}
+
+export function createRankingWorkerId(): string {
+  return `${hostname()}:${process.pid}`;
+}
+
+function parseHeartbeat(raw: string): RankingWorkerHeartbeat {
+  const parsed = JSON.parse(raw) as Partial<RankingWorkerHeartbeat>;
+  if (
+    parsed.schemaVersion !== 1
+    || typeof parsed.workerId !== 'string'
+    || !isWorkerState(parsed.state)
+    || typeof parsed.updatedAt !== 'string'
+    || (parsed.currentRequestId !== null && typeof parsed.currentRequestId !== 'string')
+    || (parsed.lastCompletedAt !== null && typeof parsed.lastCompletedAt !== 'string')
+    || (parsed.lastError !== null && typeof parsed.lastError !== 'string')
+  ) {
+    throw new Error('Ranking worker heartbeat payload is invalid');
+  }
+  if (Number.isNaN(new Date(parsed.updatedAt).getTime())) {
+    throw new Error(`Ranking worker heartbeat updatedAt is invalid: ${parsed.updatedAt}`);
+  }
+  return parsed as RankingWorkerHeartbeat;
+}
+
+function isWorkerState(value: unknown): value is RankingWorkerState {
+  return value === 'starting'
+    || value === 'idle'
+    || value === 'running'
+    || value === 'stopping'
+    || value === 'failed';
+}
+
+function assertOptions(options: RankingWorkerOptions): void {
+  if (!options.workerId.trim() || !options.communityId.trim()) {
+    throw new Error('Ranking workerId and communityId must be non-empty');
+  }
+  for (const [name, value] of Object.entries({
+    scheduleIntervalMs: options.scheduleIntervalMs,
+    pollIntervalMs: options.pollIntervalMs,
+    leaseRenewIntervalMs: options.leaseRenewIntervalMs,
+    heartbeatIntervalMs: options.heartbeatIntervalMs,
+    heartbeatTtlMs: options.heartbeatTtlMs,
+    claimStaleAfterMs: options.claimStaleAfterMs,
+  })) {
+    if (!Number.isInteger(value) || value < 1) {
+      throw new Error(`${name} must be a positive integer, got ${value}`);
+    }
+  }
+  if (options.heartbeatIntervalMs >= options.heartbeatTtlMs) {
+    throw new Error('heartbeatIntervalMs must be less than heartbeatTtlMs');
+  }
+}
+
+function clearTimer(timer: NodeJS.Timeout | null): void {
+  if (timer) {
+    clearInterval(timer);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isScoringPipelineTimeout(error: unknown): boolean {
+  return error instanceof Error && error.message === 'Scoring pipeline timed out';
+}

--- a/src/scoring/ranking-worker.ts
+++ b/src/scoring/ranking-worker.ts
@@ -78,11 +78,22 @@ interface QuarantinedLease {
   renewalTimer: NodeJS.Timeout;
 }
 
+export class ScoringPipelineTimeoutError extends Error {
+  readonly code = 'SCORING_PIPELINE_TIMEOUT';
+
+  constructor(cause: unknown) {
+    super('Scoring pipeline timed out', { cause });
+    this.name = 'ScoringPipelineTimeoutError';
+  }
+}
+
 export class RankingWorker {
   private readonly options: RankingWorkerOptions;
   private scheduleTimer: NodeJS.Timeout | null = null;
   private pollTimer: NodeJS.Timeout | null = null;
   private heartbeatTimer: NodeJS.Timeout | null = null;
+  private startPromise: Promise<void> | null = null;
+  private stopPromise: Promise<void> | null = null;
   private currentRun: Promise<void> | null = null;
   private quarantinedLease: QuarantinedLease | null = null;
   private quarantined = false;
@@ -99,52 +110,113 @@ export class RankingWorker {
   }
 
   async start(): Promise<void> {
+    if (this.startPromise) {
+      await this.startPromise;
+      return;
+    }
     if (this.running) {
       logger.warn({ workerId: this.options.workerId }, 'Ranking worker already running');
       return;
     }
+    const startPromise = this.startInternal();
+    this.startPromise = startPromise;
+    try {
+      await startPromise;
+    } finally {
+      if (this.startPromise === startPromise) {
+        this.startPromise = null;
+      }
+    }
+  }
+
+  private async startInternal(): Promise<void> {
     this.running = true;
     this.stopping = false;
     this.state = 'starting';
-    await this.writeHeartbeat();
-    const recoveredClaims = await this.options.queue.requeueStaleClaims(
-      new Date(this.options.now().getTime() - this.options.claimStaleAfterMs),
-      this.options.communityId
-    );
-    if (recoveredClaims > 0) {
-      logger.warn({ recoveredClaims }, 'Recovered stale ranking request claims');
-    }
-    await this.enqueueScheduledRequest(this.options.now());
+    try {
+      await this.writeHeartbeat();
+      const recoveredClaims = await this.options.queue.requeueStaleClaims(
+        new Date(this.options.now().getTime() - this.options.claimStaleAfterMs),
+        this.options.communityId
+      );
+      if (recoveredClaims > 0) {
+        logger.warn({ recoveredClaims }, 'Recovered stale ranking request claims');
+      }
+      await this.enqueueScheduledRequest(this.options.now());
 
-    this.scheduleTimer = setInterval(() => {
-      void this.enqueueScheduledAndDrain();
-    }, this.options.scheduleIntervalMs);
-    this.pollTimer = setInterval(() => {
+      this.scheduleTimer = setInterval(() => {
+        void this.enqueueScheduledAndDrain();
+      }, this.options.scheduleIntervalMs);
+      this.pollTimer = setInterval(() => {
+        void this.drainOnce();
+      }, this.options.pollIntervalMs);
+      this.heartbeatTimer = setInterval(() => {
+        void this.writeHeartbeat().catch((error) => {
+          this.lastError = errorMessage(error);
+          logger.error({ err: error }, 'Ranking worker heartbeat failed');
+        });
+      }, this.options.heartbeatIntervalMs);
+      this.state = 'idle';
+      await this.writeHeartbeat();
+      logger.info({ workerId: this.options.workerId }, 'Ranking worker started');
       void this.drainOnce();
-    }, this.options.pollIntervalMs);
-    this.heartbeatTimer = setInterval(() => {
-      void this.writeHeartbeat().catch((error) => {
-        this.lastError = errorMessage(error);
-        logger.error({ err: error }, 'Ranking worker heartbeat failed');
+    } catch (error) {
+      clearTimer(this.scheduleTimer);
+      clearTimer(this.pollTimer);
+      clearTimer(this.heartbeatTimer);
+      this.scheduleTimer = null;
+      this.pollTimer = null;
+      this.heartbeatTimer = null;
+      this.lastError = errorMessage(error);
+      this.state = 'failed';
+      this.running = false;
+      this.stopping = false;
+      await this.writeHeartbeat().catch((heartbeatError) => {
+        logger.error({ err: heartbeatError }, 'Failed to persist ranking worker startup failure');
       });
-    }, this.options.heartbeatIntervalMs);
-    this.state = 'idle';
-    await this.writeHeartbeat();
-    logger.info({ workerId: this.options.workerId }, 'Ranking worker started');
-    void this.drainOnce();
+      throw error;
+    }
   }
 
   async stop(): Promise<void> {
+    if (this.stopPromise) {
+      await this.stopPromise;
+      return;
+    }
+    const pendingStart = this.startPromise;
+    if (pendingStart) {
+      await pendingStart;
+    }
     if (!this.running) {
       return;
     }
+    const stopPromise = this.stopInternal();
+    this.stopPromise = stopPromise;
+    try {
+      await stopPromise;
+    } finally {
+      if (this.stopPromise === stopPromise) {
+        this.stopPromise = null;
+      }
+    }
+  }
+
+  private async stopInternal(): Promise<void> {
     this.stopping = true;
     this.state = 'stopping';
     clearTimer(this.scheduleTimer);
     clearTimer(this.pollTimer);
     this.scheduleTimer = null;
     this.pollTimer = null;
-    await this.writeHeartbeat();
+    let stopError: unknown;
+    let stoppingHeartbeatFailed = false;
+    try {
+      await this.writeHeartbeat();
+    } catch (error) {
+      stopError = error;
+      stoppingHeartbeatFailed = true;
+      logger.error({ err: error }, 'Failed to persist ranking worker stopping heartbeat');
+    }
     if (this.currentRun) {
       await this.currentRun;
     }
@@ -164,6 +236,9 @@ export class RankingWorker {
     this.heartbeatTimer = null;
     this.running = false;
     logger.info({ workerId: this.options.workerId }, 'Ranking worker stopped');
+    if (stoppingHeartbeatFailed) {
+      throw stopError;
+    }
   }
 
   isRunning(): boolean {
@@ -458,5 +533,5 @@ function errorMessage(error: unknown): string {
 }
 
 function isScoringPipelineTimeout(error: unknown): boolean {
-  return error instanceof Error && error.message === 'Scoring pipeline timed out';
+  return error instanceof ScoringPipelineTimeoutError;
 }

--- a/src/scoring/scheduler.ts
+++ b/src/scoring/scheduler.ts
@@ -15,11 +15,7 @@ import {
   rankingRequestQueue,
   type EnqueuedRankingRequest,
 } from './ranking-request-queue.js';
-import {
-  createRankingWorkerId,
-  RankingWorker,
-  ScoringPipelineTimeoutError,
-} from './ranking-worker.js';
+import { createRankingWorkerId, RankingWorker } from './ranking-worker.js';
 import { runScoringPipeline } from './pipeline.js';
 
 let worker: RankingWorker | null = null;
@@ -47,7 +43,7 @@ export async function startScoring(): Promise<void> {
     heartbeatIntervalMs: config.RANKING_WORKER_HEARTBEAT_INTERVAL_MS,
     heartbeatTtlMs: config.RANKING_WORKER_HEARTBEAT_TTL_MS,
     claimStaleAfterMs: config.RANKING_CLAIM_STALE_MS,
-    runRanking: runScoringPipelineWithStableErrors,
+    runRanking: runScoringPipeline,
     now: () => new Date(),
   });
   await worker.start();
@@ -109,18 +105,4 @@ export function isSchedulerRunning(): boolean {
 
 export function isScoringInProgress(): boolean {
   return worker?.isRanking() ?? false;
-}
-
-async function runScoringPipelineWithStableErrors(): Promise<void> {
-  try {
-    await runScoringPipeline();
-  } catch (error) {
-    // The leased legacy pipeline currently exposes this timeout as a message.
-    // Translate it once at the compatibility boundary so worker safety logic
-    // depends on a stable error type rather than message matching.
-    if (error instanceof Error && error.message === 'Scoring pipeline timed out') {
-      throw new ScoringPipelineTimeoutError(error);
-    }
-    throw error;
-  }
 }

--- a/src/scoring/scheduler.ts
+++ b/src/scoring/scheduler.ts
@@ -32,7 +32,11 @@ export async function startScoring(): Promise<void> {
   isShuttingDown = false;
   worker = new RankingWorker({
     queue: rankingRequestQueue,
-    lease: createOwnedScoringLease(redis, config.RANKING_LEASE_TTL_MS),
+    lease: createOwnedScoringLease(
+      redis,
+      config.RANKING_COMMUNITY_ID,
+      config.RANKING_LEASE_TTL_MS
+    ),
     redis,
     workerId: createRankingWorkerId(),
     communityId: config.RANKING_COMMUNITY_ID,

--- a/src/scoring/scheduler.ts
+++ b/src/scoring/scheduler.ts
@@ -18,6 +18,7 @@ import {
 import {
   createRankingWorkerId,
   RankingWorker,
+  ScoringPipelineTimeoutError,
 } from './ranking-worker.js';
 import { runScoringPipeline } from './pipeline.js';
 
@@ -46,7 +47,7 @@ export async function startScoring(): Promise<void> {
     heartbeatIntervalMs: config.RANKING_WORKER_HEARTBEAT_INTERVAL_MS,
     heartbeatTtlMs: config.RANKING_WORKER_HEARTBEAT_TTL_MS,
     claimStaleAfterMs: config.RANKING_CLAIM_STALE_MS,
-    runRanking: runScoringPipeline,
+    runRanking: runScoringPipelineWithStableErrors,
     now: () => new Date(),
   });
   await worker.start();
@@ -108,4 +109,18 @@ export function isSchedulerRunning(): boolean {
 
 export function isScoringInProgress(): boolean {
   return worker?.isRanking() ?? false;
+}
+
+async function runScoringPipelineWithStableErrors(): Promise<void> {
+  try {
+    await runScoringPipeline();
+  } catch (error) {
+    // The leased legacy pipeline currently exposes this timeout as a message.
+    // Translate it once at the compatibility boundary so worker safety logic
+    // depends on a stable error type rather than message matching.
+    if (error instanceof Error && error.message === 'Scoring pipeline timed out') {
+      throw new ScoringPipelineTimeoutError(error);
+    }
+    throw error;
+  }
 }

--- a/src/scoring/scheduler.ts
+++ b/src/scoring/scheduler.ts
@@ -1,209 +1,107 @@
 /**
- * Scoring Scheduler
+ * Durable scoring scheduler and ranking-worker facade.
  *
- * Runs the scoring pipeline at regular intervals (default: every 5 minutes).
- * Uses simple setInterval - reliable and easy to understand.
- *
- * Features:
- * - Runs immediately on start (don't wait 5 minutes for first run)
- * - Prevents overlapping runs via Redis distributed lock
- * - Graceful shutdown (completes current run before stopping)
- * - Error isolation (failed runs don't crash the scheduler)
+ * Scheduled and manual work is first persisted in ranking_run_requests. Only
+ * the ranking-worker process consumes requests, and every execution requires
+ * a token-owned renewable Redis lease.
  */
 
 import { config } from '../config.js';
-import { logger } from '../lib/logger.js';
 import { redis } from '../db/redis.js';
+import { logger } from '../lib/logger.js';
+import { createOwnedScoringLease } from './owned-lease.js';
+import {
+  manualRequestKey,
+  rankingRequestQueue,
+  type EnqueuedRankingRequest,
+} from './ranking-request-queue.js';
+import {
+  createRankingWorkerId,
+  RankingWorker,
+} from './ranking-worker.js';
 import { runScoringPipeline } from './pipeline.js';
 
-const SCORING_LOCK_KEY = 'lock:scoring';
-const SCORING_LOCK_TTL = 300; // 5-minute safety TTL (auto-expires if process crashes)
-
-/** Whether the scheduler is currently running */
-let isRunning = false;
-
-/** Local mirror of lock state for synchronous health checks */
-let isScoring = false;
-
-/** The interval timer */
-let intervalId: NodeJS.Timeout | null = null;
-
-/** Whether we're in the middle of shutting down */
+let worker: RankingWorker | null = null;
 let isShuttingDown = false;
 
-/**
- * Start the scoring scheduler.
- * Runs immediately, then at SCORING_INTERVAL_MS intervals.
- */
 export async function startScoring(): Promise<void> {
-  if (isRunning) {
+  if (worker?.isRunning()) {
     logger.warn('Scoring scheduler already running');
     return;
   }
-
-  isRunning = true;
   isShuttingDown = false;
-
-  logger.info(
-    { intervalMs: config.SCORING_INTERVAL_MS },
-    'Starting scoring scheduler'
-  );
-
-  // Run immediately on start
-  await runWithGuard();
-
-  // Schedule recurring runs
-  intervalId = setInterval(runWithGuard, config.SCORING_INTERVAL_MS);
-
-  logger.info('Scoring scheduler started');
+  worker = new RankingWorker({
+    queue: rankingRequestQueue,
+    lease: createOwnedScoringLease(redis, config.RANKING_LEASE_TTL_MS),
+    redis,
+    workerId: createRankingWorkerId(),
+    communityId: config.RANKING_COMMUNITY_ID,
+    scheduleIntervalMs: config.SCORING_INTERVAL_MS,
+    pollIntervalMs: config.RANKING_WORKER_POLL_MS,
+    leaseRenewIntervalMs: config.RANKING_LEASE_RENEW_INTERVAL_MS,
+    heartbeatIntervalMs: config.RANKING_WORKER_HEARTBEAT_INTERVAL_MS,
+    heartbeatTtlMs: config.RANKING_WORKER_HEARTBEAT_TTL_MS,
+    claimStaleAfterMs: config.RANKING_CLAIM_STALE_MS,
+    runRanking: runScoringPipeline,
+    now: () => new Date(),
+  });
+  await worker.start();
 }
 
-/**
- * Stop the scoring scheduler.
- * Waits for any in-progress scoring run to complete.
- */
 export async function stopScoring(): Promise<void> {
-  if (!isRunning) {
-    return;
-  }
-
-  logger.info('Stopping scoring scheduler...');
   isShuttingDown = true;
-
-  // Clear the interval
-  if (intervalId) {
-    clearInterval(intervalId);
-    intervalId = null;
+  if (!worker) {
+    return;
   }
-
-  // Wait for any in-progress scoring to complete
-  while (isScoring) {
-    logger.info('Waiting for scoring run to complete...');
-    await sleep(1000);
-  }
-
-  isRunning = false;
-  logger.info('Scoring scheduler stopped');
+  await worker.stop();
+  worker = null;
 }
 
-/**
- * Run the scoring pipeline with guards against overlapping runs.
- */
-async function runWithGuard(): Promise<void> {
-  // Don't start if we're shutting down
+export async function enqueueManualScoringRun(
+  requestedBy: string,
+  requestedAt: Date
+): Promise<EnqueuedRankingRequest> {
   if (isShuttingDown) {
-    return;
+    throw new Error('Manual scoring request rejected because ranking is shutting down');
   }
-
-  // Don't start if previous run is still going (Redis distributed lock)
-  if (!(await acquireScoringLock())) {
-    logger.warn('Skipping scoring run - previous run still in progress');
-    return;
-  }
-
-  try {
-    await runScoringPipeline();
-  } catch (err) {
-    // Log error but don't crash - next run will try again
-    logger.error({ err }, 'Scoring pipeline failed');
-  } finally {
-    await releaseScoringLock().catch((err) => {
-      logger.error({ err }, 'Failed to release scoring lock (TTL will expire)');
-    });
-  }
+  const idempotencyKey = manualRequestKey(
+    config.RANKING_COMMUNITY_ID,
+    requestedBy,
+    requestedAt
+  );
+  const request = await rankingRequestQueue.enqueue({
+    idempotencyKey,
+    communityId: config.RANKING_COMMUNITY_ID,
+    requestKind: 'manual',
+    requestedBy,
+    notBefore: requestedAt,
+  });
+  logger.info(
+    { requestId: request.id, created: request.created, requestedBy },
+    'Manual scoring request queued'
+  );
+  return request;
 }
 
-/**
- * Try to trigger a manual scoring run without waiting for completion.
- * Returns false when a run is already in progress or scheduler is shutting down.
- */
+/** Backward-compatible adapter used by governance mutation routes. */
 export async function tryTriggerManualScoringRun(): Promise<boolean> {
-  if (isShuttingDown) {
-    logger.warn('Manual scoring run rejected - scheduler is shutting down');
+  try {
+    const request = await enqueueManualScoringRun('governance', new Date());
+    return request.id.length > 0;
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to queue governance scoring request');
     return false;
   }
-
-  if (!(await acquireScoringLock())) {
-    logger.warn('Manual scoring run rejected - scoring already in progress');
-    return false;
-  }
-
-  logger.info('Manual scoring run triggered');
-
-  void runScoringPipeline()
-    .catch((err) => {
-      logger.error({ err }, 'Manual scoring pipeline failed');
-    })
-    .finally(async () => {
-      await releaseScoringLock().catch((err) => {
-        logger.error({ err }, 'Failed to release scoring lock after manual run');
-      });
-    });
-
-  return true;
 }
 
-/**
- * Manually trigger a scoring run and wait for completion.
- * Respects the same guards as scheduled runs.
- */
 export async function triggerManualRun(): Promise<void> {
-  logger.info('Manual scoring run triggered');
-  await runWithGuard();
+  await enqueueManualScoringRun('internal', new Date());
 }
 
-/**
- * Check if the scheduler is running.
- */
 export function isSchedulerRunning(): boolean {
-  return isRunning;
+  return worker?.isRunning() ?? false;
 }
 
-/**
- * Check if a scoring run is in progress.
- * Uses local boolean mirror for synchronous health check compatibility.
- */
 export function isScoringInProgress(): boolean {
-  return isScoring;
-}
-
-/**
- * Sleep for a given number of milliseconds.
- */
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Acquire the scoring lock via Redis SET NX EX.
- * Returns true if lock was acquired, false if already held.
- */
-async function acquireScoringLock(): Promise<boolean> {
-  try {
-    const result = await redis.set(SCORING_LOCK_KEY, Date.now().toString(), 'EX', SCORING_LOCK_TTL, 'NX');
-    const acquired = result === 'OK';
-    if (acquired) {
-      isScoring = true;
-    }
-    return acquired;
-  } catch (err) {
-    // If Redis is down, fall back to local boolean to avoid deadlocking the scheduler
-    logger.warn({ err }, 'Redis lock acquire failed, using local fallback');
-    if (isScoring) return false;
-    isScoring = true;
-    return true;
-  }
-}
-
-/**
- * Release the scoring lock by deleting the Redis key.
- */
-async function releaseScoringLock(): Promise<void> {
-  isScoring = false;
-  try {
-    await redis.del(SCORING_LOCK_KEY);
-  } catch (err) {
-    // Lock will auto-expire via TTL; log and continue
-    logger.warn({ err }, 'Redis lock release failed (TTL will expire)');
-  }
+  return worker?.isRanking() ?? false;
 }

--- a/src/scoring/scoring-pipeline-timeout-error.ts
+++ b/src/scoring/scoring-pipeline-timeout-error.ts
@@ -1,0 +1,8 @@
+export class ScoringPipelineTimeoutError extends Error {
+  readonly code = 'SCORING_PIPELINE_TIMEOUT';
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ScoringPipelineTimeoutError';
+  }
+}

--- a/tests/feed-health-rescore.test.ts
+++ b/tests/feed-health-rescore.test.ts
@@ -166,6 +166,10 @@ describe('admin manual rescore overlap guard', () => {
       requestId: 'request-1',
     });
     expect(enqueueManualScoringRunMock).toHaveBeenCalledTimes(1);
+    expect(enqueueManualScoringRunMock).toHaveBeenCalledWith(
+      'did:plc:admin',
+      expect.any(Date)
+    );
     expect(dbQueryMock).toHaveBeenCalledTimes(1);
     expect(dbQueryMock.mock.calls[0]?.[0]).toContain('INSERT INTO governance_audit_log');
 

--- a/tests/feed-health-rescore.test.ts
+++ b/tests/feed-health-rescore.test.ts
@@ -97,8 +97,17 @@ describe('admin manual rescore overlap guard', () => {
     readRankingWorkerHealthMock.mockReset();
     readRankingWorkerHealthMock.mockResolvedValue({
       healthy: true,
-      heartbeat: null,
-      ageMs: null,
+      heartbeat: {
+        schemaVersion: 1,
+        workerId: 'worker-1',
+        communityId: 'community-gov',
+        state: 'idle',
+        updatedAt: '2026-07-12T05:00:00.000Z',
+        currentRequestId: null,
+        lastCompletedAt: '2026-07-12T04:59:00.000Z',
+        lastError: null,
+      },
+      ageMs: 1_000,
       queue: {
         pendingCount: 0,
         claimedCount: 0,
@@ -154,6 +163,34 @@ describe('admin manual rescore overlap guard', () => {
     expect(enqueueManualScoringRunMock).toHaveBeenCalledTimes(1);
     expect(dbQueryMock).toHaveBeenCalledTimes(1);
     expect(dbQueryMock.mock.calls[0]?.[0]).toContain('INSERT INTO governance_audit_log');
+
+    await app.close();
+  });
+
+  it('returns the queued receipt when auxiliary audit persistence fails', async () => {
+    enqueueManualScoringRunMock.mockResolvedValue({
+      id: 'request-2',
+      created: true,
+      idempotencyKey: 'manual:community-gov:did:plc:admin:2',
+    });
+    dbQueryMock.mockRejectedValue(new Error('audit database unavailable'));
+
+    const app = Fastify();
+    registerFeedHealthRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/feed/rescore',
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toMatchObject({
+      success: true,
+      queued: true,
+      requestId: 'request-2',
+    });
+    expect(enqueueManualScoringRunMock).toHaveBeenCalledTimes(1);
+    expect(dbQueryMock).toHaveBeenCalledTimes(1);
 
     await app.close();
   });

--- a/tests/feed-health-rescore.test.ts
+++ b/tests/feed-health-rescore.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
-  tryTriggerManualScoringRunMock,
+  enqueueManualScoringRunMock,
   getScoringStatusMock,
   isJetstreamConnectedMock,
   getLastEventReceivedAtMock,
@@ -12,9 +12,10 @@ const {
   triggerJetstreamReconnectMock,
   redisGetMock,
   redisZCardMock,
+  readRankingWorkerHealthMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
-  tryTriggerManualScoringRunMock: vi.fn(),
+  enqueueManualScoringRunMock: vi.fn(),
   getScoringStatusMock: vi.fn(),
   isJetstreamConnectedMock: vi.fn(),
   getLastEventReceivedAtMock: vi.fn(),
@@ -23,6 +24,7 @@ const {
   triggerJetstreamReconnectMock: vi.fn(),
   redisGetMock: vi.fn(),
   redisZCardMock: vi.fn(),
+  readRankingWorkerHealthMock: vi.fn(),
 }));
 
 vi.mock('../src/db/client.js', () => ({
@@ -47,7 +49,27 @@ vi.mock('../src/auth/admin.js', () => ({
 }));
 
 vi.mock('../src/scoring/scheduler.js', () => ({
-  tryTriggerManualScoringRun: tryTriggerManualScoringRunMock,
+  enqueueManualScoringRun: enqueueManualScoringRunMock,
+}));
+
+vi.mock('../src/scoring/ranking-request-queue.js', () => ({
+  rankingRequestQueue: {},
+}));
+
+vi.mock('../src/scoring/ranking-worker.js', () => ({
+  readRankingWorkerHealth: readRankingWorkerHealthMock,
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: { RANKING_WORKER_HEARTBEAT_TTL_MS: 30_000 },
+}));
+
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 vi.mock('../src/ingestion/jetstream.js', () => ({
@@ -63,7 +85,7 @@ import { registerFeedHealthRoutes } from '../src/admin/routes/feed-health.js';
 describe('admin manual rescore overlap guard', () => {
   beforeEach(() => {
     dbQueryMock.mockReset();
-    tryTriggerManualScoringRunMock.mockReset();
+    enqueueManualScoringRunMock.mockReset();
     getScoringStatusMock.mockReset();
     isJetstreamConnectedMock.mockReset();
     getLastEventReceivedAtMock.mockReset();
@@ -72,10 +94,23 @@ describe('admin manual rescore overlap guard', () => {
     triggerJetstreamReconnectMock.mockReset();
     redisGetMock.mockReset();
     redisZCardMock.mockReset();
+    readRankingWorkerHealthMock.mockReset();
+    readRankingWorkerHealthMock.mockResolvedValue({
+      healthy: true,
+      heartbeat: null,
+      ageMs: null,
+      queue: {
+        pendingCount: 0,
+        claimedCount: 0,
+        oldestPendingAt: null,
+        newestRequestId: null,
+        newestRequestState: null,
+      },
+    });
   });
 
-  it('returns 409 when scoring is already in progress', async () => {
-    tryTriggerManualScoringRunMock.mockReturnValue(false);
+  it('returns 503 and starts nothing when the durable queue is unavailable', async () => {
+    enqueueManualScoringRunMock.mockRejectedValue(new Error('database unavailable'));
 
     const app = Fastify();
     registerFeedHealthRoutes(app);
@@ -85,9 +120,9 @@ describe('admin manual rescore overlap guard', () => {
       url: '/feed/rescore',
     });
 
-    expect(response.statusCode).toBe(409);
+    expect(response.statusCode).toBe(503);
     expect(response.json()).toMatchObject({
-      error: 'Conflict',
+      error: 'RankingQueueUnavailable',
     });
     expect(dbQueryMock).not.toHaveBeenCalled();
 
@@ -95,7 +130,11 @@ describe('admin manual rescore overlap guard', () => {
   });
 
   it('starts manual scoring and writes audit log when idle', async () => {
-    tryTriggerManualScoringRunMock.mockReturnValue(true);
+    enqueueManualScoringRunMock.mockResolvedValue({
+      id: 'request-1',
+      created: true,
+      idempotencyKey: 'manual:community-gov:did:plc:admin:1',
+    });
     dbQueryMock.mockResolvedValue({ rows: [] });
 
     const app = Fastify();
@@ -106,11 +145,13 @@ describe('admin manual rescore overlap guard', () => {
       url: '/feed/rescore',
     });
 
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(202);
     expect(response.json()).toMatchObject({
       success: true,
+      queued: true,
+      requestId: 'request-1',
     });
-    expect(tryTriggerManualScoringRunMock).toHaveBeenCalledTimes(1);
+    expect(enqueueManualScoringRunMock).toHaveBeenCalledTimes(1);
     expect(dbQueryMock).toHaveBeenCalledTimes(1);
     expect(dbQueryMock.mock.calls[0]?.[0]).toContain('INSERT INTO governance_audit_log');
 

--- a/tests/feed-health-rescore.test.ts
+++ b/tests/feed-health-rescore.test.ts
@@ -13,6 +13,7 @@ const {
   redisGetMock,
   redisZCardMock,
   readRankingWorkerHealthMock,
+  rankingRequestQueueMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
   enqueueManualScoringRunMock: vi.fn(),
@@ -25,6 +26,7 @@ const {
   redisGetMock: vi.fn(),
   redisZCardMock: vi.fn(),
   readRankingWorkerHealthMock: vi.fn(),
+  rankingRequestQueueMock: {},
 }));
 
 vi.mock('../src/db/client.js', () => ({
@@ -53,7 +55,7 @@ vi.mock('../src/scoring/scheduler.js', () => ({
 }));
 
 vi.mock('../src/scoring/ranking-request-queue.js', () => ({
-  rankingRequestQueue: {},
+  rankingRequestQueue: rankingRequestQueueMock,
 }));
 
 vi.mock('../src/scoring/ranking-worker.js', () => ({
@@ -61,7 +63,10 @@ vi.mock('../src/scoring/ranking-worker.js', () => ({
 }));
 
 vi.mock('../src/config.js', () => ({
-  config: { RANKING_WORKER_HEARTBEAT_TTL_MS: 30_000 },
+  config: {
+    RANKING_COMMUNITY_ID: 'community-gov',
+    RANKING_WORKER_HEARTBEAT_TTL_MS: 30_000,
+  },
 }));
 
 vi.mock('../src/lib/logger.js', () => ({
@@ -260,6 +265,13 @@ describe('admin manual rescore overlap guard', () => {
       feedSize: 51,
     });
     expect(redisGetMock).not.toHaveBeenCalled();
+    expect(readRankingWorkerHealthMock).toHaveBeenCalledWith(
+      expect.objectContaining({ get: redisGetMock, zcard: redisZCardMock }),
+      rankingRequestQueueMock,
+      'community-gov',
+      expect.any(Date),
+      30_000
+    );
 
     await app.close();
   });

--- a/tests/harness/ranking-request-queue.sim.ts
+++ b/tests/harness/ranking-request-queue.sim.ts
@@ -38,8 +38,8 @@ describe('durable ranking request queue integration', () => {
     });
 
     const [first, second] = await Promise.all([
-      queue.claimNext('worker-a'),
-      queue.claimNext('worker-b'),
+      queue.claimNext('worker-a', 'community-gov'),
+      queue.claimNext('worker-b', 'community-gov'),
     ]);
 
     expect([first, second].filter((request) => request !== null)).toHaveLength(1);
@@ -54,7 +54,7 @@ describe('durable ranking request queue integration', () => {
       requestedBy: 'did:plc:admin',
       notBefore: new Date('2020-01-01T00:00:00.000Z'),
     });
-    const claimed = await queue.claimNext('worker-a');
+    const claimed = await queue.claimNext('worker-a', 'community-gov');
     expect(claimed).not.toBeNull();
 
     await expect(queue.complete(claimed!.id, 'worker-b')).rejects.toThrow(
@@ -77,11 +77,11 @@ describe('durable ranking request queue integration', () => {
       requestedBy: 'ranking-worker',
       notBefore: new Date('2020-01-01T00:00:00.000Z'),
     });
-    const firstClaim = await queue.claimNext('worker-a');
+    const firstClaim = await queue.claimNext('worker-a', 'community-gov');
     expect(firstClaim).not.toBeNull();
     await queue.defer(firstClaim!.id, 'worker-a', new Date('2020-01-01T00:00:01.000Z'));
 
-    const secondClaim = await queue.claimNext('worker-b');
+    const secondClaim = await queue.claimNext('worker-b', 'community-gov');
     expect(secondClaim?.id).toBe(firstClaim!.id);
     expect(secondClaim?.claimedBy).toBe('worker-b');
   });
@@ -94,7 +94,7 @@ describe('durable ranking request queue integration', () => {
       requestedBy: 'ranking-worker',
       notBefore: new Date('2020-01-01T00:00:00.000Z'),
     });
-    const claimed = await queue.claimNext('dead-worker');
+    const claimed = await queue.claimNext('dead-worker', 'community-gov');
     expect(claimed).not.toBeNull();
     await db.query(
       `UPDATE ranking_run_requests
@@ -103,10 +103,57 @@ describe('durable ranking request queue integration', () => {
       [claimed!.id]
     );
 
-    const recovered = await queue.requeueStaleClaims(new Date(Date.now() - 300_000));
-    const replacementClaim = await queue.claimNext('replacement-worker');
+    const recovered = await queue.requeueStaleClaims(
+      new Date(Date.now() - 300_000),
+      'community-gov'
+    );
+    const replacementClaim = await queue.claimNext('replacement-worker', 'community-gov');
 
     expect(recovered).toBe(1);
     expect(replacementClaim?.id).toBe(claimed!.id);
+  });
+
+  it('isolates claims, stale recovery, and health counts by community', async () => {
+    await queue.enqueue({
+      idempotencyKey: 'scheduled:community-gov:isolation',
+      communityId: 'community-gov',
+      requestKind: 'scheduled',
+      requestedBy: 'ranking-worker',
+      notBefore: new Date('2020-01-01T00:00:00.000Z'),
+    });
+    await queue.enqueue({
+      idempotencyKey: 'scheduled:future-feed:isolation',
+      communityId: 'future-feed',
+      requestKind: 'scheduled',
+      requestedBy: 'ranking-worker',
+      notBefore: new Date('2020-01-01T00:00:00.000Z'),
+    });
+
+    const communityClaim = await queue.claimNext('community-worker', 'community-gov');
+    expect(communityClaim?.communityId).toBe('community-gov');
+    expect(await queue.claimNext('community-worker-2', 'community-gov')).toBeNull();
+
+    const futureStatus = await queue.status('future-feed');
+    expect(futureStatus.pendingCount).toBe(1);
+    expect(futureStatus.claimedCount).toBe(0);
+
+    const futureClaim = await queue.claimNext('future-worker', 'future-feed');
+    expect(futureClaim?.communityId).toBe('future-feed');
+    await db.query(
+      `UPDATE ranking_run_requests
+          SET claimed_at = NOW() - INTERVAL '10 minutes'
+        WHERE id IN ($1, $2)`,
+      [communityClaim!.id, futureClaim!.id]
+    );
+
+    expect(await queue.requeueStaleClaims(
+      new Date(Date.now() - 300_000),
+      'community-gov'
+    )).toBe(1);
+    const futureClaimState = await db.query<{ state: string }>(
+      'SELECT state FROM ranking_run_requests WHERE id = $1',
+      [futureClaim!.id]
+    );
+    expect(futureClaimState.rows[0]?.state).toBe('claimed');
   });
 });

--- a/tests/harness/ranking-request-queue.sim.ts
+++ b/tests/harness/ranking-request-queue.sim.ts
@@ -46,6 +46,21 @@ describe('durable ranking request queue integration', () => {
     expect([first, second].filter((request) => request === null)).toHaveLength(1);
   });
 
+  it('installs the community-scoped due-work claim index', async () => {
+    const result = await db.query<{ indexdef: string }>(
+      `SELECT indexdef
+         FROM pg_indexes
+        WHERE schemaname = current_schema()
+          AND tablename = 'ranking_run_requests'
+          AND indexname = 'idx_ranking_run_requests_community_state_due'`
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.indexdef).toContain(
+      '(community_id, state, not_before, requested_at, id)'
+    );
+  });
+
   it('prevents stale workers from completing another worker claim', async () => {
     await queue.enqueue({
       idempotencyKey: 'manual:community-gov:did:plc:admin:456',

--- a/tests/harness/ranking-request-queue.sim.ts
+++ b/tests/harness/ranking-request-queue.sim.ts
@@ -111,7 +111,15 @@ describe('durable ranking request queue integration', () => {
     });
     const firstClaim = await queue.claimNext('worker-a', 'community-gov');
     expect(firstClaim).not.toBeNull();
-    await queue.defer(firstClaim!.id, 'worker-a', new Date('2020-01-01T00:00:01.000Z'));
+    await queue.defer(firstClaim!.id, 'worker-a', new Date('2999-01-01T00:00:00.000Z'));
+
+    await expect(queue.claimNext('worker-b', 'community-gov')).resolves.toBeNull();
+    await db.query(
+      `UPDATE ranking_run_requests
+          SET not_before = NOW() - INTERVAL '1 second'
+        WHERE id = $1`,
+      [firstClaim!.id]
+    );
 
     const secondClaim = await queue.claimNext('worker-b', 'community-gov');
     expect(secondClaim?.id).toBe(firstClaim!.id);

--- a/tests/harness/ranking-request-queue.sim.ts
+++ b/tests/harness/ranking-request-queue.sim.ts
@@ -69,6 +69,38 @@ describe('durable ranking request queue integration', () => {
     expect(state.rows[0]?.state).toBe('completed');
   });
 
+  it('persists structured failure evidence and rejects the wrong worker', async () => {
+    await queue.enqueue({
+      idempotencyKey: 'manual:community-gov:did:plc:admin:failed',
+      communityId: 'community-gov',
+      requestKind: 'manual',
+      requestedBy: 'did:plc:admin',
+      notBefore: new Date('2020-01-01T00:00:00.000Z'),
+    });
+    const claimed = await queue.claimNext('worker-a', 'community-gov');
+    expect(claimed).not.toBeNull();
+
+    await expect(queue.fail(claimed!.id, 'worker-b', new TypeError('publisher failed')))
+      .rejects.toThrow('is not claimed by worker worker-b');
+    await expect(queue.defer(claimed!.id, 'worker-b', new Date('2020-01-01T00:00:01.000Z')))
+      .rejects.toThrow('is not claimed by worker worker-b');
+    await queue.fail(claimed!.id, 'worker-a', new TypeError('publisher failed'));
+
+    const result = await db.query<{
+      state: string;
+      failure: { name: string; message: string };
+      completed_at: Date | null;
+    }>(
+      'SELECT state, failure, completed_at FROM ranking_run_requests WHERE id = $1',
+      [claimed!.id]
+    );
+    expect(result.rows[0]).toMatchObject({
+      state: 'failed',
+      failure: { name: 'TypeError', message: 'publisher failed' },
+    });
+    expect(result.rows[0]?.completed_at).toBeInstanceOf(Date);
+  });
+
   it('returns a deferred request to pending for another worker', async () => {
     await queue.enqueue({
       idempotencyKey: 'scheduled:community-gov:789',

--- a/tests/harness/ranking-request-queue.sim.ts
+++ b/tests/harness/ranking-request-queue.sim.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { db } from '../../src/db/client.js';
+import { RankingRequestQueue } from '../../src/scoring/ranking-request-queue.js';
+
+describe('durable ranking request queue integration', () => {
+  const queue = new RankingRequestQueue(db);
+
+  beforeEach(async () => {
+    await db.query('TRUNCATE TABLE ranking_run_requests CASCADE');
+  });
+
+  it('deduplicates scheduled and manual requests by immutable idempotency key', async () => {
+    const input = {
+      idempotencyKey: 'manual:community-gov:did:plc:admin:123',
+      communityId: 'community-gov',
+      requestKind: 'manual' as const,
+      requestedBy: 'did:plc:admin',
+      notBefore: new Date('2026-07-12T05:00:00.000Z'),
+    };
+
+    const first = await queue.enqueue(input);
+    const duplicate = await queue.enqueue(input);
+
+    expect(first.created).toBe(true);
+    expect(duplicate.created).toBe(false);
+    expect(duplicate.id).toBe(first.id);
+    const count = await db.query<{ count: string }>('SELECT COUNT(*)::text AS count FROM ranking_run_requests');
+    expect(count.rows[0]?.count).toBe('1');
+  });
+
+  it('allows exactly one concurrent worker to claim one request', async () => {
+    await queue.enqueue({
+      idempotencyKey: 'scheduled:community-gov:123',
+      communityId: 'community-gov',
+      requestKind: 'scheduled',
+      requestedBy: 'ranking-worker',
+      notBefore: new Date('2020-01-01T00:00:00.000Z'),
+    });
+
+    const [first, second] = await Promise.all([
+      queue.claimNext('worker-a'),
+      queue.claimNext('worker-b'),
+    ]);
+
+    expect([first, second].filter((request) => request !== null)).toHaveLength(1);
+    expect([first, second].filter((request) => request === null)).toHaveLength(1);
+  });
+
+  it('prevents stale workers from completing another worker claim', async () => {
+    await queue.enqueue({
+      idempotencyKey: 'manual:community-gov:did:plc:admin:456',
+      communityId: 'community-gov',
+      requestKind: 'manual',
+      requestedBy: 'did:plc:admin',
+      notBefore: new Date('2020-01-01T00:00:00.000Z'),
+    });
+    const claimed = await queue.claimNext('worker-a');
+    expect(claimed).not.toBeNull();
+
+    await expect(queue.complete(claimed!.id, 'worker-b')).rejects.toThrow(
+      'is not claimed by worker worker-b'
+    );
+    await queue.complete(claimed!.id, 'worker-a');
+
+    const state = await db.query<{ state: string }>(
+      'SELECT state FROM ranking_run_requests WHERE id = $1',
+      [claimed!.id]
+    );
+    expect(state.rows[0]?.state).toBe('completed');
+  });
+
+  it('returns a deferred request to pending for another worker', async () => {
+    await queue.enqueue({
+      idempotencyKey: 'scheduled:community-gov:789',
+      communityId: 'community-gov',
+      requestKind: 'scheduled',
+      requestedBy: 'ranking-worker',
+      notBefore: new Date('2020-01-01T00:00:00.000Z'),
+    });
+    const firstClaim = await queue.claimNext('worker-a');
+    expect(firstClaim).not.toBeNull();
+    await queue.defer(firstClaim!.id, 'worker-a', new Date('2020-01-01T00:00:01.000Z'));
+
+    const secondClaim = await queue.claimNext('worker-b');
+    expect(secondClaim?.id).toBe(firstClaim!.id);
+    expect(secondClaim?.claimedBy).toBe('worker-b');
+  });
+
+  it('recovers only stale claimed work after worker termination', async () => {
+    await queue.enqueue({
+      idempotencyKey: 'scheduled:community-gov:stale',
+      communityId: 'community-gov',
+      requestKind: 'scheduled',
+      requestedBy: 'ranking-worker',
+      notBefore: new Date('2020-01-01T00:00:00.000Z'),
+    });
+    const claimed = await queue.claimNext('dead-worker');
+    expect(claimed).not.toBeNull();
+    await db.query(
+      `UPDATE ranking_run_requests
+          SET claimed_at = NOW() - INTERVAL '10 minutes'
+        WHERE id = $1`,
+      [claimed!.id]
+    );
+
+    const recovered = await queue.requeueStaleClaims(new Date(Date.now() - 300_000));
+    const replacementClaim = await queue.claimNext('replacement-worker');
+
+    expect(recovered).toBe(1);
+    expect(replacementClaim?.id).toBe(claimed!.id);
+  });
+});

--- a/tests/process-role.test.ts
+++ b/tests/process-role.test.ts
@@ -42,6 +42,31 @@ describe('process-role configuration', () => {
     })).toThrow('must be less than half');
   });
 
+  it('accepts lease renewal immediately below the half-TTL boundary', () => {
+    const parsed = ConfigSchema.parse({
+      ...process.env,
+      SCORING_TIMEOUT_MS: '30000',
+      RANKING_LEASE_TTL_MS: '60000',
+      RANKING_LEASE_RENEW_INTERVAL_MS: '29999',
+    });
+    expect(parsed.RANKING_LEASE_RENEW_INTERVAL_MS).toBe(29_999);
+  });
+
+  it('rejects heartbeat interval equality and accepts the passing boundary', () => {
+    expect(() => ConfigSchema.parse({
+      ...process.env,
+      RANKING_WORKER_HEARTBEAT_INTERVAL_MS: '30000',
+      RANKING_WORKER_HEARTBEAT_TTL_MS: '30000',
+    })).toThrow('must be less than');
+
+    const parsed = ConfigSchema.parse({
+      ...process.env,
+      RANKING_WORKER_HEARTBEAT_INTERVAL_MS: '29999',
+      RANKING_WORKER_HEARTBEAT_TTL_MS: '30000',
+    });
+    expect(parsed.RANKING_WORKER_HEARTBEAT_INTERVAL_MS).toBe(29_999);
+  });
+
   it('does not reclaim a request before the ranking timeout can finish', () => {
     expect(() => ConfigSchema.parse({
       ...process.env,
@@ -56,5 +81,17 @@ describe('process-role configuration', () => {
       SCORING_TIMEOUT_MS: '240000',
       RANKING_LEASE_TTL_MS: '240000',
     })).toThrow('must exceed SCORING_TIMEOUT_MS');
+  });
+
+  it('accepts claim and lease windows one millisecond beyond the ranking timeout', () => {
+    const parsed = ConfigSchema.parse({
+      ...process.env,
+      SCORING_TIMEOUT_MS: '240000',
+      RANKING_CLAIM_STALE_MS: '240001',
+      RANKING_LEASE_TTL_MS: '240001',
+      RANKING_LEASE_RENEW_INTERVAL_MS: '60000',
+    });
+    expect(parsed.RANKING_CLAIM_STALE_MS).toBe(240_001);
+    expect(parsed.RANKING_LEASE_TTL_MS).toBe(240_001);
   });
 });

--- a/tests/process-role.test.ts
+++ b/tests/process-role.test.ts
@@ -1,9 +1,23 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 let ConfigSchema: typeof import('../src/config.js')['ConfigSchema'];
+const originalEnvironment = { ...process.env };
+const controlledEnvironmentKeys = [
+  'PROCESS_ROLE',
+  'SCORING_TIMEOUT_MS',
+  'RANKING_COMMUNITY_ID',
+  'RANKING_WORKER_POLL_MS',
+  'RANKING_CLAIM_STALE_MS',
+  'RANKING_LEASE_TTL_MS',
+  'RANKING_LEASE_RENEW_INTERVAL_MS',
+  'RANKING_WORKER_HEARTBEAT_INTERVAL_MS',
+  'RANKING_WORKER_HEARTBEAT_TTL_MS',
+] as const;
 
 beforeAll(async () => {
-  delete process.env.PROCESS_ROLE;
+  for (const key of controlledEnvironmentKeys) {
+    delete process.env[key];
+  }
   Object.assign(process.env, {
     FEEDGEN_SERVICE_DID: 'did:plc:corgitestservice0000000000',
     FEEDGEN_PUBLISHER_DID: 'did:plc:corgitestpublisher00000000',
@@ -18,6 +32,13 @@ beforeAll(async () => {
     NODE_ENV: 'test',
   });
   ({ ConfigSchema } = await import('../src/config.js'));
+});
+
+afterAll(() => {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, originalEnvironment);
 });
 
 describe('process-role configuration', () => {
@@ -93,5 +114,28 @@ describe('process-role configuration', () => {
     });
     expect(parsed.RANKING_CLAIM_STALE_MS).toBe(240_001);
     expect(parsed.RANKING_LEASE_TTL_MS).toBe(240_001);
+  });
+
+  it.each([
+    { field: 'RANKING_WORKER_POLL_MS', minimum: 100 },
+    { field: 'RANKING_CLAIM_STALE_MS', minimum: 30_000 },
+    { field: 'RANKING_LEASE_TTL_MS', minimum: 5_000 },
+    { field: 'RANKING_LEASE_RENEW_INTERVAL_MS', minimum: 1_000 },
+    { field: 'RANKING_WORKER_HEARTBEAT_INTERVAL_MS', minimum: 1_000 },
+    { field: 'RANKING_WORKER_HEARTBEAT_TTL_MS', minimum: 5_000 },
+  ] as const)('rejects malformed and out-of-range $field values', ({ field, minimum }) => {
+    const invalidValues: unknown[] = [
+      String(minimum - 1),
+      `${minimum}.5`,
+      'not-a-number',
+      null,
+    ];
+    for (const value of invalidValues) {
+      const result = ConfigSchema.safeParse({ ...process.env, [field]: value });
+      expect(result.success, `${field} unexpectedly accepted ${String(value)}`).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((issue) => issue.path[0] === field)).toBe(true);
+      }
+    }
   });
 });

--- a/tests/process-role.test.ts
+++ b/tests/process-role.test.ts
@@ -1,0 +1,60 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+let ConfigSchema: typeof import('../src/config.js')['ConfigSchema'];
+
+beforeAll(async () => {
+  delete process.env.PROCESS_ROLE;
+  Object.assign(process.env, {
+    FEEDGEN_SERVICE_DID: 'did:plc:corgitestservice0000000000',
+    FEEDGEN_PUBLISHER_DID: 'did:plc:corgitestpublisher00000000',
+    FEEDGEN_HOSTNAME: 'feed.test',
+    JETSTREAM_URL: 'wss://jetstream.test/subscribe',
+    JETSTREAM_FALLBACK_URL: 'wss://jetstream-fallback.test/subscribe',
+    JETSTREAM_COLLECTIONS: 'app.bsky.feed.post',
+    DATABASE_URL: 'postgresql://feed:feed@127.0.0.1:5432/bluesky_feed',
+    REDIS_URL: 'redis://127.0.0.1:6379',
+    BSKY_IDENTIFIER: 'test.bsky.social',
+    BSKY_APP_PASSWORD: 'test-password',
+    NODE_ENV: 'test',
+  });
+  ({ ConfigSchema } = await import('../src/config.js'));
+});
+
+describe('process-role configuration', () => {
+  it('retains all as the temporary rollback-compatible default', () => {
+    expect(ConfigSchema.parse(process.env).PROCESS_ROLE).toBe('all');
+  });
+
+  it.each(['api', 'ranking-worker', 'all'] as const)('accepts %s', (role) => {
+    expect(ConfigSchema.parse({ ...process.env, PROCESS_ROLE: role }).PROCESS_ROLE).toBe(role);
+  });
+
+  it('rejects an unknown process role', () => {
+    expect(() => ConfigSchema.parse({ ...process.env, PROCESS_ROLE: 'combined-api-worker' }))
+      .toThrow();
+  });
+
+  it('requires lease renewal comfortably before expiry', () => {
+    expect(() => ConfigSchema.parse({
+      ...process.env,
+      RANKING_LEASE_TTL_MS: '60000',
+      RANKING_LEASE_RENEW_INTERVAL_MS: '30000',
+    })).toThrow('must be less than half');
+  });
+
+  it('does not reclaim a request before the ranking timeout can finish', () => {
+    expect(() => ConfigSchema.parse({
+      ...process.env,
+      SCORING_TIMEOUT_MS: '240000',
+      RANKING_CLAIM_STALE_MS: '240000',
+    })).toThrow('must exceed SCORING_TIMEOUT_MS');
+  });
+
+  it('keeps lease ownership longer than the maximum ranking run', () => {
+    expect(() => ConfigSchema.parse({
+      ...process.env,
+      SCORING_TIMEOUT_MS: '240000',
+      RANKING_LEASE_TTL_MS: '240000',
+    })).toThrow('must exceed SCORING_TIMEOUT_MS');
+  });
+});

--- a/tests/ranking-worker.test.ts
+++ b/tests/ranking-worker.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   RankingWorker,
   readRankingWorkerHealth,
+  ScoringPipelineTimeoutError,
   type RankingWorkerLease,
   type RankingWorkerQueue,
   type RankingWorkerRedis,
@@ -30,6 +31,7 @@ class FakeQueue implements RankingWorkerQueue {
   readonly completed: string[] = [];
   readonly failed: string[] = [];
   readonly deferred: string[] = [];
+  staleClaimsRecovered = 0;
   private nextId = 1;
 
   async enqueue(input: {
@@ -57,39 +59,77 @@ class FakeQueue implements RankingWorkerQueue {
   }
 
   async claimNext(workerId: string, communityId: string): Promise<RankingRequest | null> {
-    const request = this.requests.shift();
+    const request = this.requests.find((candidate) => (
+      candidate.state === 'pending'
+      && candidate.communityId === communityId
+      && new Date(candidate.notBefore).getTime() <= new Date('2026-07-12T05:00:00.000Z').getTime()
+    ));
     if (!request) {
       return null;
     }
-    expect(request.communityId).toBe(communityId);
-    return { ...request, state: 'claimed', claimedBy: workerId };
+    request.state = 'claimed';
+    request.claimedBy = workerId;
+    request.claimedAt = '2026-07-12T05:00:00.000Z';
+    return { ...request };
   }
 
-  async complete(requestId: string): Promise<void> {
+  async complete(requestId: string, workerId: string): Promise<void> {
+    const request = this.requireOwnedClaim(requestId, workerId);
+    request.state = 'completed';
     this.completed.push(requestId);
   }
 
-  async fail(requestId: string): Promise<void> {
+  async fail(requestId: string, workerId: string): Promise<void> {
+    const request = this.requireOwnedClaim(requestId, workerId);
+    request.state = 'failed';
     this.failed.push(requestId);
   }
 
-  async defer(requestId: string): Promise<void> {
+  async defer(requestId: string, workerId: string, notBefore: Date): Promise<void> {
+    const request = this.requireOwnedClaim(requestId, workerId);
+    request.state = 'pending';
+    request.claimedBy = null;
+    request.claimedAt = null;
+    request.notBefore = notBefore.toISOString();
     this.deferred.push(requestId);
   }
 
   async status(communityId: string): Promise<RankingQueueStatus> {
     const requests = this.requests.filter((request) => request.communityId === communityId);
+    const pending = requests.filter((request) => request.state === 'pending');
+    const claimed = requests.filter((request) => request.state === 'claimed');
+    const newest = requests.at(-1) ?? null;
     return {
-      pendingCount: requests.length,
-      claimedCount: 0,
-      oldestPendingAt: requests[0]?.requestedAt ?? null,
-      newestRequestId: requests.at(-1)?.id ?? null,
-      newestRequestState: requests.length > 0 ? 'pending' : null,
+      pendingCount: pending.length,
+      claimedCount: claimed.length,
+      oldestPendingAt: pending[0]?.requestedAt ?? null,
+      newestRequestId: newest?.id ?? null,
+      newestRequestState: newest?.state ?? null,
     };
   }
 
-  async requeueStaleClaims(_staleBefore: Date, _communityId: string): Promise<number> {
-    return 0;
+  async requeueStaleClaims(staleBefore: Date, communityId: string): Promise<number> {
+    const recovered = this.requests.filter((request) => (
+      request.state === 'claimed'
+      && request.communityId === communityId
+      && request.claimedAt !== null
+      && new Date(request.claimedAt).getTime() < staleBefore.getTime()
+    ));
+    for (const request of recovered) {
+      request.state = 'pending';
+      request.claimedBy = null;
+      request.claimedAt = null;
+    }
+    this.staleClaimsRecovered += recovered.length;
+    return recovered.length;
+  }
+
+  private requireOwnedClaim(requestId: string, workerId: string): RankingRequest {
+    const request = this.requests.find((candidate) => candidate.id === requestId);
+    if (!request || request.state !== 'claimed' || request.claimedBy !== workerId) {
+      throw new Error(`Request ${requestId} is not claimed by ${workerId}`);
+    }
+    return request;
   }
 }
 
@@ -118,13 +158,28 @@ function lease(overrides: Partial<RankingWorkerLease>): RankingWorkerLease {
   };
 }
 
+interface TestClock {
+  now: () => Date;
+  advance: (milliseconds: number) => void;
+}
+
+function createClock(): TestClock {
+  let currentMs = new Date('2026-07-12T05:00:00.000Z').getTime();
+  return {
+    now: () => new Date(currentMs),
+    advance: (milliseconds: number) => {
+      currentMs += milliseconds;
+    },
+  };
+}
+
 function workerOptions(input: {
   queue: FakeQueue;
   redis: FakeRedis;
   ownedLease: RankingWorkerLease;
   runRanking: () => Promise<void>;
+  clock: TestClock;
 }) {
-  const now = new Date('2026-07-12T05:00:00.000Z');
   return {
     queue: input.queue,
     redis: input.redis,
@@ -138,7 +193,7 @@ function workerOptions(input: {
     heartbeatTtlMs: 30_000,
     claimStaleAfterMs: 300_000,
     runRanking: input.runRanking,
-    now: () => new Date(now),
+    now: input.clock.now,
   };
 }
 
@@ -150,9 +205,10 @@ describe('ranking worker isolation', () => {
   it('persists, claims, leases, and completes scheduled work', async () => {
     const queue = new FakeQueue();
     const redis = new FakeRedis();
+    const clock = createClock();
     const runRanking = vi.fn().mockResolvedValue(undefined);
     const ownedLease = lease({});
-    const worker = new RankingWorker(workerOptions({ queue, redis, ownedLease, runRanking }));
+    const worker = new RankingWorker(workerOptions({ queue, redis, ownedLease, runRanking, clock }));
 
     await worker.start();
     await worker.stop();
@@ -165,12 +221,14 @@ describe('ranking worker isolation', () => {
   it('never starts ranking without the distributed lease', async () => {
     const queue = new FakeQueue();
     const redis = new FakeRedis();
+    const clock = createClock();
     const runRanking = vi.fn().mockResolvedValue(undefined);
     const worker = new RankingWorker(workerOptions({
       queue,
       redis,
       ownedLease: lease({ acquire: async () => false }),
       runRanking,
+      clock,
     }));
 
     await worker.start();
@@ -185,6 +243,7 @@ describe('ranking worker isolation', () => {
     vi.useFakeTimers();
     const queue = new FakeQueue();
     const redis = new FakeRedis();
+    const clock = createClock();
     let finishRanking: (() => void) | undefined;
     const runRanking = vi.fn(() => new Promise<void>((resolve) => {
       finishRanking = resolve;
@@ -194,6 +253,7 @@ describe('ranking worker isolation', () => {
       redis,
       ownedLease: lease({ renew: async () => false, release: async () => false }),
       runRanking,
+      clock,
     }));
 
     const starting = worker.start();
@@ -210,6 +270,7 @@ describe('ranking worker isolation', () => {
     vi.useFakeTimers();
     const queue = new FakeQueue();
     const redis = new FakeRedis();
+    const clock = createClock();
     let finishRanking: (() => void) | undefined;
     const runRanking = vi.fn(() => new Promise<void>((resolve) => {
       finishRanking = resolve;
@@ -219,21 +280,24 @@ describe('ranking worker isolation', () => {
       redis,
       ownedLease: lease({}),
       runRanking,
+      clock,
     }));
 
     await worker.start();
+    clock.advance(40_000);
     await vi.advanceTimersByTimeAsync(40_000);
     const health = await readRankingWorkerHealth(
       redis,
       queue,
       'community-gov',
-      new Date('2026-07-12T05:00:00.000Z'),
+      clock.now(),
       30_000
     );
 
     expect(health.healthy).toBe(true);
     expect(health.heartbeat?.state).toBe('running');
-    expect(redis.writeCount).toBeGreaterThanOrEqual(7);
+    expect(health.heartbeat?.updatedAt).toBe('2026-07-12T05:00:40.000Z');
+    expect(health.ageMs).toBe(0);
     finishRanking?.();
     await worker.stop();
   });
@@ -241,13 +305,17 @@ describe('ranking worker isolation', () => {
   it('quarantines a timed-out publisher and retains its lease until process stop', async () => {
     const queue = new FakeQueue();
     const redis = new FakeRedis();
+    const clock = createClock();
     const release = vi.fn().mockResolvedValue(true);
-    const runRanking = vi.fn().mockRejectedValue(new Error('Scoring pipeline timed out'));
+    const runRanking = vi.fn().mockRejectedValue(
+      new ScoringPipelineTimeoutError(new Error('legacy timeout'))
+    );
     const worker = new RankingWorker(workerOptions({
       queue,
       redis,
       ownedLease: lease({ release }),
       runRanking,
+      clock,
     }));
 
     await worker.start();
@@ -268,11 +336,13 @@ describe('ranking worker isolation', () => {
   it('reports heartbeat age and queue state independently', async () => {
     const queue = new FakeQueue();
     const redis = new FakeRedis();
+    const clock = createClock();
     const worker = new RankingWorker(workerOptions({
       queue,
       redis,
       ownedLease: lease({}),
       runRanking: async () => undefined,
+      clock,
     }));
     await worker.start();
 
@@ -314,5 +384,193 @@ describe('ranking worker isolation', () => {
 
     expect(health.healthy).toBe(false);
     expect(health.ageMs).toBe(-60_000);
+  });
+
+  it('treats the exact heartbeat TTL as healthy and one millisecond beyond as stale', async () => {
+    const queue = new FakeQueue();
+    const redis = new FakeRedis();
+    await redis.set('corgi:ranking-worker:heartbeat:community-gov', JSON.stringify({
+      schemaVersion: 1,
+      workerId: 'worker-1',
+      communityId: 'community-gov',
+      state: 'idle',
+      updatedAt: '2026-07-12T05:00:00.000Z',
+      currentRequestId: null,
+      lastCompletedAt: null,
+      lastError: null,
+    }));
+
+    const atBoundary = await readRankingWorkerHealth(
+      redis,
+      queue,
+      'community-gov',
+      new Date('2026-07-12T05:00:30.000Z'),
+      30_000
+    );
+    const beyondBoundary = await readRankingWorkerHealth(
+      redis,
+      queue,
+      'community-gov',
+      new Date('2026-07-12T05:00:30.001Z'),
+      30_000
+    );
+
+    expect(atBoundary.healthy).toBe(true);
+    expect(beyondBoundary.healthy).toBe(false);
+  });
+
+  it('rejects malformed and cross-community heartbeat payloads', async () => {
+    const queue = new FakeQueue();
+    const redis = new FakeRedis();
+    await redis.set('corgi:ranking-worker:heartbeat:community-gov', '{invalid-json');
+    await expect(readRankingWorkerHealth(
+      redis,
+      queue,
+      'community-gov',
+      new Date('2026-07-12T05:00:00.000Z'),
+      30_000
+    )).rejects.toBeInstanceOf(SyntaxError);
+
+    await redis.set('corgi:ranking-worker:heartbeat:community-gov', JSON.stringify({
+      schemaVersion: 1,
+      workerId: 'worker-2',
+      communityId: 'future-feed',
+      state: 'idle',
+      updatedAt: '2026-07-12T05:00:00.000Z',
+      currentRequestId: null,
+      lastCompletedAt: null,
+      lastError: null,
+    }));
+    await expect(readRankingWorkerHealth(
+      redis,
+      queue,
+      'community-gov',
+      new Date('2026-07-12T05:00:00.000Z'),
+      30_000
+    )).rejects.toThrow('community mismatch');
+  });
+
+  it('fails startup cleanly when Redis or stale-claim recovery is unavailable', async () => {
+    const redisFailureQueue = new FakeQueue();
+    const redisFailure = new FakeRedis();
+    vi.spyOn(redisFailure, 'set').mockRejectedValue(new Error('redis unavailable'));
+    const redisFailureWorker = new RankingWorker(workerOptions({
+      queue: redisFailureQueue,
+      redis: redisFailure,
+      ownedLease: lease({}),
+      runRanking: async () => undefined,
+      clock: createClock(),
+    }));
+    await expect(redisFailureWorker.start()).rejects.toThrow('redis unavailable');
+    expect(redisFailureWorker.isRunning()).toBe(false);
+
+    const queueFailure = new FakeQueue();
+    vi.spyOn(queueFailure, 'requeueStaleClaims').mockRejectedValue(
+      new Error('queue unavailable')
+    );
+    const queueFailureRedis = new FakeRedis();
+    const queueFailureWorker = new RankingWorker(workerOptions({
+      queue: queueFailure,
+      redis: queueFailureRedis,
+      ownedLease: lease({}),
+      runRanking: async () => undefined,
+      clock: createClock(),
+    }));
+    await expect(queueFailureWorker.start()).rejects.toThrow('queue unavailable');
+    expect(queueFailureWorker.isRunning()).toBe(false);
+    expect(JSON.parse(
+      queueFailureRedis.values.get('corgi:ranking-worker:heartbeat:community-gov') ?? '{}'
+    )).toEqual(expect.objectContaining({ state: 'failed', lastError: 'queue unavailable' }));
+  });
+
+  it('recovers stale work only for its configured community', async () => {
+    const queue = new FakeQueue();
+    queue.requests.push({
+      id: 'stale-community-request',
+      idempotencyKey: 'scheduled:community-gov:stale',
+      communityId: 'community-gov',
+      requestKind: 'scheduled',
+      state: 'claimed',
+      requestedBy: 'ranking-worker',
+      requestedAt: '2026-07-12T04:00:00.000Z',
+      notBefore: '2026-07-12T04:00:00.000Z',
+      claimedBy: 'dead-worker',
+      claimedAt: '2026-07-12T04:00:00.000Z',
+    }, {
+      id: 'stale-future-feed-request',
+      idempotencyKey: 'scheduled:future-feed:stale',
+      communityId: 'future-feed',
+      requestKind: 'scheduled',
+      state: 'claimed',
+      requestedBy: 'ranking-worker',
+      requestedAt: '2026-07-12T04:00:00.000Z',
+      notBefore: '2026-07-12T04:00:00.000Z',
+      claimedBy: 'dead-worker',
+      claimedAt: '2026-07-12T04:00:00.000Z',
+    });
+    const worker = new RankingWorker(workerOptions({
+      queue,
+      redis: new FakeRedis(),
+      ownedLease: lease({}),
+      runRanking: async () => undefined,
+      clock: createClock(),
+    }));
+
+    await worker.start();
+    await worker.stop();
+
+    expect(queue.staleClaimsRecovered).toBe(1);
+    expect(queue.completed).toContain('stale-community-request');
+    expect(queue.requests.find((request) => request.id === 'stale-future-feed-request'))
+      .toEqual(expect.objectContaining({ state: 'claimed', claimedBy: 'dead-worker' }));
+  });
+
+  it('serializes concurrent start and stop calls', async () => {
+    const queue = new FakeQueue();
+    const runRanking = vi.fn().mockResolvedValue(undefined);
+    const worker = new RankingWorker(workerOptions({
+      queue,
+      redis: new FakeRedis(),
+      ownedLease: lease({}),
+      runRanking,
+      clock: createClock(),
+    }));
+
+    await Promise.all([worker.start(), worker.start()]);
+    await Promise.all([worker.stop(), worker.stop()]);
+
+    expect(runRanking).toHaveBeenCalledTimes(1);
+    expect(worker.isRunning()).toBe(false);
+  });
+
+  it('waits for an active ranking run before stop completes', async () => {
+    const queue = new FakeQueue();
+    let finishRanking: (() => void) | undefined;
+    const runRanking = vi.fn(() => new Promise<void>((resolve) => {
+      finishRanking = resolve;
+    }));
+    const worker = new RankingWorker(workerOptions({
+      queue,
+      redis: new FakeRedis(),
+      ownedLease: lease({}),
+      runRanking,
+      clock: createClock(),
+    }));
+    await worker.start();
+    await vi.waitFor(() => {
+      expect(finishRanking).toBeTypeOf('function');
+    });
+
+    let stopped = false;
+    const stopping = worker.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    finishRanking?.();
+    await stopping;
+
+    expect(stopped).toBe(true);
+    expect(worker.isRunning()).toBe(false);
   });
 });

--- a/tests/ranking-worker.test.ts
+++ b/tests/ranking-worker.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  RankingWorker,
+  readRankingWorkerHealth,
+  type RankingWorkerLease,
+  type RankingWorkerQueue,
+  type RankingWorkerRedis,
+} from '../src/scoring/ranking-worker.js';
+import type {
+  EnqueuedRankingRequest,
+  RankingQueueStatus,
+  RankingRequest,
+} from '../src/scoring/ranking-request-queue.js';
+
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../src/scoring/ranking-request-queue.js', () => ({
+  scheduledRequestKey: (communityId: string, at: Date, intervalMs: number) =>
+    `scheduled:${communityId}:${Math.floor(at.getTime() / intervalMs)}`,
+}));
+
+class FakeQueue implements RankingWorkerQueue {
+  readonly requests: RankingRequest[] = [];
+  readonly completed: string[] = [];
+  readonly failed: string[] = [];
+  readonly deferred: string[] = [];
+  private nextId = 1;
+
+  async enqueue(input: {
+    idempotencyKey: string;
+    communityId: string;
+    requestKind: 'scheduled' | 'manual' | 'replacement' | 'reconciliation';
+    requestedBy: string | null;
+    notBefore: Date;
+  }): Promise<EnqueuedRankingRequest> {
+    const id = `request-${this.nextId}`;
+    this.nextId += 1;
+    this.requests.push({
+      id,
+      idempotencyKey: input.idempotencyKey,
+      communityId: input.communityId,
+      requestKind: input.requestKind,
+      state: 'pending',
+      requestedBy: input.requestedBy,
+      requestedAt: input.notBefore.toISOString(),
+      notBefore: input.notBefore.toISOString(),
+      claimedBy: null,
+      claimedAt: null,
+    });
+    return { id, created: true, idempotencyKey: input.idempotencyKey };
+  }
+
+  async claimNext(workerId: string): Promise<RankingRequest | null> {
+    const request = this.requests.shift();
+    return request ? { ...request, state: 'claimed', claimedBy: workerId } : null;
+  }
+
+  async complete(requestId: string): Promise<void> {
+    this.completed.push(requestId);
+  }
+
+  async fail(requestId: string): Promise<void> {
+    this.failed.push(requestId);
+  }
+
+  async defer(requestId: string): Promise<void> {
+    this.deferred.push(requestId);
+  }
+
+  async status(): Promise<RankingQueueStatus> {
+    return {
+      pendingCount: this.requests.length,
+      claimedCount: 0,
+      oldestPendingAt: this.requests[0]?.requestedAt ?? null,
+      newestRequestId: this.requests.at(-1)?.id ?? null,
+      newestRequestState: this.requests.length > 0 ? 'pending' : null,
+    };
+  }
+
+  async requeueStaleClaims(): Promise<number> {
+    return 0;
+  }
+}
+
+class FakeRedis implements RankingWorkerRedis {
+  readonly values = new Map<string, string>();
+  writeCount = 0;
+
+  async set(key: string, value: string): Promise<'OK'> {
+    this.writeCount += 1;
+    this.values.set(key, value);
+    return 'OK';
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null;
+  }
+}
+
+function lease(overrides: Partial<RankingWorkerLease>): RankingWorkerLease {
+  return {
+    createToken: () => 'owner-token',
+    acquire: async () => true,
+    renew: async () => true,
+    release: async () => true,
+    ...overrides,
+  };
+}
+
+function workerOptions(input: {
+  queue: FakeQueue;
+  redis: FakeRedis;
+  ownedLease: RankingWorkerLease;
+  runRanking: () => Promise<void>;
+}) {
+  const now = new Date('2026-07-12T05:00:00.000Z');
+  return {
+    queue: input.queue,
+    redis: input.redis,
+    lease: input.ownedLease,
+    workerId: 'worker-1',
+    communityId: 'community-gov',
+    scheduleIntervalMs: 300_000,
+    pollIntervalMs: 1_000,
+    leaseRenewIntervalMs: 20_000,
+    heartbeatIntervalMs: 10_000,
+    heartbeatTtlMs: 30_000,
+    claimStaleAfterMs: 300_000,
+    runRanking: input.runRanking,
+    now: () => new Date(now),
+  };
+}
+
+describe('ranking worker isolation', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('persists, claims, leases, and completes scheduled work', async () => {
+    const queue = new FakeQueue();
+    const redis = new FakeRedis();
+    const runRanking = vi.fn().mockResolvedValue(undefined);
+    const ownedLease = lease({});
+    const worker = new RankingWorker(workerOptions({ queue, redis, ownedLease, runRanking }));
+
+    await worker.start();
+    await worker.stop();
+
+    expect(runRanking).toHaveBeenCalledTimes(1);
+    expect(queue.completed).toEqual(['request-1']);
+    expect(queue.failed).toEqual([]);
+  });
+
+  it('never starts ranking without the distributed lease', async () => {
+    const queue = new FakeQueue();
+    const redis = new FakeRedis();
+    const runRanking = vi.fn().mockResolvedValue(undefined);
+    const worker = new RankingWorker(workerOptions({
+      queue,
+      redis,
+      ownedLease: lease({ acquire: async () => false }),
+      runRanking,
+    }));
+
+    await worker.start();
+    await worker.stop();
+
+    expect(runRanking).not.toHaveBeenCalled();
+    expect(queue.deferred).toEqual(['request-1']);
+    expect(queue.completed).toEqual([]);
+  });
+
+  it('fails the durable request when ownership is lost during ranking', async () => {
+    vi.useFakeTimers();
+    const queue = new FakeQueue();
+    const redis = new FakeRedis();
+    let finishRanking: (() => void) | undefined;
+    const runRanking = vi.fn(() => new Promise<void>((resolve) => {
+      finishRanking = resolve;
+    }));
+    const worker = new RankingWorker(workerOptions({
+      queue,
+      redis,
+      ownedLease: lease({ renew: async () => false, release: async () => false }),
+      runRanking,
+    }));
+
+    const starting = worker.start();
+    await vi.advanceTimersByTimeAsync(20_000);
+    finishRanking?.();
+    await starting;
+    await worker.stop();
+
+    expect(queue.failed).toEqual(['request-1']);
+    expect(queue.completed).toEqual([]);
+  });
+
+  it('keeps heartbeating while the first ranking run is still active', async () => {
+    vi.useFakeTimers();
+    const queue = new FakeQueue();
+    const redis = new FakeRedis();
+    let finishRanking: (() => void) | undefined;
+    const runRanking = vi.fn(() => new Promise<void>((resolve) => {
+      finishRanking = resolve;
+    }));
+    const worker = new RankingWorker(workerOptions({
+      queue,
+      redis,
+      ownedLease: lease({}),
+      runRanking,
+    }));
+
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(40_000);
+    const health = await readRankingWorkerHealth(
+      redis,
+      queue,
+      new Date('2026-07-12T05:00:00.000Z'),
+      30_000
+    );
+
+    expect(health.healthy).toBe(true);
+    expect(health.heartbeat?.state).toBe('running');
+    expect(redis.writeCount).toBeGreaterThanOrEqual(7);
+    finishRanking?.();
+    await worker.stop();
+  });
+
+  it('quarantines a timed-out publisher and retains its lease until process stop', async () => {
+    const queue = new FakeQueue();
+    const redis = new FakeRedis();
+    const release = vi.fn().mockResolvedValue(true);
+    const runRanking = vi.fn().mockRejectedValue(new Error('Scoring pipeline timed out'));
+    const worker = new RankingWorker(workerOptions({
+      queue,
+      redis,
+      ownedLease: lease({ release }),
+      runRanking,
+    }));
+
+    await worker.start();
+    await vi.waitFor(() => {
+      expect(queue.failed).toEqual(['request-1']);
+    });
+    await worker.drainOnce();
+
+    expect(runRanking).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+    expect(JSON.parse(redis.values.get('corgi:ranking-worker:heartbeat') ?? '{}'))
+      .toEqual(expect.objectContaining({ state: 'failed' }));
+
+    await worker.stop();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports heartbeat age and queue state independently', async () => {
+    const queue = new FakeQueue();
+    const redis = new FakeRedis();
+    const worker = new RankingWorker(workerOptions({
+      queue,
+      redis,
+      ownedLease: lease({}),
+      runRanking: async () => undefined,
+    }));
+    await worker.start();
+
+    const health = await readRankingWorkerHealth(
+      redis,
+      queue,
+      new Date('2026-07-12T05:00:05.000Z'),
+      30_000
+    );
+
+    expect(health.healthy).toBe(true);
+    expect(health.ageMs).toBe(5_000);
+    expect(health.heartbeat?.workerId).toBe('worker-1');
+    await worker.stop();
+  });
+
+  it('rejects a heartbeat timestamp from the future', async () => {
+    const queue = new FakeQueue();
+    const redis = new FakeRedis();
+    await redis.set('corgi:ranking-worker:heartbeat', JSON.stringify({
+      schemaVersion: 1,
+      workerId: 'worker-1',
+      state: 'idle',
+      updatedAt: '2026-07-12T05:01:00.000Z',
+      currentRequestId: null,
+      lastCompletedAt: null,
+      lastError: null,
+    }));
+
+    const health = await readRankingWorkerHealth(
+      redis,
+      queue,
+      new Date('2026-07-12T05:00:00.000Z'),
+      30_000
+    );
+
+    expect(health.healthy).toBe(false);
+    expect(health.ageMs).toBe(-60_000);
+  });
+});

--- a/tests/ranking-worker.test.ts
+++ b/tests/ranking-worker.test.ts
@@ -56,9 +56,13 @@ class FakeQueue implements RankingWorkerQueue {
     return { id, created: true, idempotencyKey: input.idempotencyKey };
   }
 
-  async claimNext(workerId: string): Promise<RankingRequest | null> {
+  async claimNext(workerId: string, communityId: string): Promise<RankingRequest | null> {
     const request = this.requests.shift();
-    return request ? { ...request, state: 'claimed', claimedBy: workerId } : null;
+    if (!request) {
+      return null;
+    }
+    expect(request.communityId).toBe(communityId);
+    return { ...request, state: 'claimed', claimedBy: workerId };
   }
 
   async complete(requestId: string): Promise<void> {
@@ -73,17 +77,18 @@ class FakeQueue implements RankingWorkerQueue {
     this.deferred.push(requestId);
   }
 
-  async status(): Promise<RankingQueueStatus> {
+  async status(communityId: string): Promise<RankingQueueStatus> {
+    const requests = this.requests.filter((request) => request.communityId === communityId);
     return {
-      pendingCount: this.requests.length,
+      pendingCount: requests.length,
       claimedCount: 0,
-      oldestPendingAt: this.requests[0]?.requestedAt ?? null,
-      newestRequestId: this.requests.at(-1)?.id ?? null,
-      newestRequestState: this.requests.length > 0 ? 'pending' : null,
+      oldestPendingAt: requests[0]?.requestedAt ?? null,
+      newestRequestId: requests.at(-1)?.id ?? null,
+      newestRequestState: requests.length > 0 ? 'pending' : null,
     };
   }
 
-  async requeueStaleClaims(): Promise<number> {
+  async requeueStaleClaims(_staleBefore: Date, _communityId: string): Promise<number> {
     return 0;
   }
 }
@@ -221,6 +226,7 @@ describe('ranking worker isolation', () => {
     const health = await readRankingWorkerHealth(
       redis,
       queue,
+      'community-gov',
       new Date('2026-07-12T05:00:00.000Z'),
       30_000
     );
@@ -252,7 +258,7 @@ describe('ranking worker isolation', () => {
 
     expect(runRanking).toHaveBeenCalledTimes(1);
     expect(release).not.toHaveBeenCalled();
-    expect(JSON.parse(redis.values.get('corgi:ranking-worker:heartbeat') ?? '{}'))
+    expect(JSON.parse(redis.values.get('corgi:ranking-worker:heartbeat:community-gov') ?? '{}'))
       .toEqual(expect.objectContaining({ state: 'failed' }));
 
     await worker.stop();
@@ -273,6 +279,7 @@ describe('ranking worker isolation', () => {
     const health = await readRankingWorkerHealth(
       redis,
       queue,
+      'community-gov',
       new Date('2026-07-12T05:00:05.000Z'),
       30_000
     );
@@ -286,9 +293,10 @@ describe('ranking worker isolation', () => {
   it('rejects a heartbeat timestamp from the future', async () => {
     const queue = new FakeQueue();
     const redis = new FakeRedis();
-    await redis.set('corgi:ranking-worker:heartbeat', JSON.stringify({
+    await redis.set('corgi:ranking-worker:heartbeat:community-gov', JSON.stringify({
       schemaVersion: 1,
       workerId: 'worker-1',
+      communityId: 'community-gov',
       state: 'idle',
       updatedAt: '2026-07-12T05:01:00.000Z',
       currentRequestId: null,
@@ -299,6 +307,7 @@ describe('ranking worker isolation', () => {
     const health = await readRankingWorkerHealth(
       redis,
       queue,
+      'community-gov',
       new Date('2026-07-12T05:00:00.000Z'),
       30_000
     );

--- a/tests/ranking-worker.test.ts
+++ b/tests/ranking-worker.test.ts
@@ -34,6 +34,8 @@ class FakeQueue implements RankingWorkerQueue {
   staleClaimsRecovered = 0;
   private nextId = 1;
 
+  constructor(private readonly clock: TestClock) {}
+
   async enqueue(input: {
     idempotencyKey: string;
     communityId: string;
@@ -62,14 +64,14 @@ class FakeQueue implements RankingWorkerQueue {
     const request = this.requests.find((candidate) => (
       candidate.state === 'pending'
       && candidate.communityId === communityId
-      && new Date(candidate.notBefore).getTime() <= new Date('2026-07-12T05:00:00.000Z').getTime()
+      && new Date(candidate.notBefore).getTime() <= this.clock.now().getTime()
     ));
     if (!request) {
       return null;
     }
     request.state = 'claimed';
     request.claimedBy = workerId;
-    request.claimedAt = '2026-07-12T05:00:00.000Z';
+    request.claimedAt = this.clock.now().toISOString();
     return { ...request };
   }
 
@@ -203,9 +205,9 @@ describe('ranking worker isolation', () => {
   });
 
   it('persists, claims, leases, and completes scheduled work', async () => {
-    const queue = new FakeQueue();
-    const redis = new FakeRedis();
     const clock = createClock();
+    const queue = new FakeQueue(clock);
+    const redis = new FakeRedis();
     const runRanking = vi.fn().mockResolvedValue(undefined);
     const ownedLease = lease({});
     const worker = new RankingWorker(workerOptions({ queue, redis, ownedLease, runRanking, clock }));
@@ -218,10 +220,31 @@ describe('ranking worker isolation', () => {
     expect(queue.failed).toEqual([]);
   });
 
-  it('never starts ranking without the distributed lease', async () => {
-    const queue = new FakeQueue();
-    const redis = new FakeRedis();
+  it('claims deferred work only after the shared clock reaches notBefore', async () => {
     const clock = createClock();
+    const queue = new FakeQueue(clock);
+    const notBefore = new Date(clock.now().getTime() + 1_000);
+    await queue.enqueue({
+      idempotencyKey: 'scheduled:community-gov:future',
+      communityId: 'community-gov',
+      requestKind: 'scheduled',
+      requestedBy: 'ranking-worker',
+      notBefore,
+    });
+
+    await expect(queue.claimNext('worker-1', 'community-gov')).resolves.toBeNull();
+    clock.advance(999);
+    await expect(queue.claimNext('worker-1', 'community-gov')).resolves.toBeNull();
+    clock.advance(1);
+    await expect(queue.claimNext('worker-1', 'community-gov')).resolves.toEqual(
+      expect.objectContaining({ id: 'request-1', claimedBy: 'worker-1' })
+    );
+  });
+
+  it('never starts ranking without the distributed lease', async () => {
+    const clock = createClock();
+    const queue = new FakeQueue(clock);
+    const redis = new FakeRedis();
     const runRanking = vi.fn().mockResolvedValue(undefined);
     const worker = new RankingWorker(workerOptions({
       queue,
@@ -241,9 +264,9 @@ describe('ranking worker isolation', () => {
 
   it('fails the durable request when ownership is lost during ranking', async () => {
     vi.useFakeTimers();
-    const queue = new FakeQueue();
-    const redis = new FakeRedis();
     const clock = createClock();
+    const queue = new FakeQueue(clock);
+    const redis = new FakeRedis();
     let finishRanking: (() => void) | undefined;
     const runRanking = vi.fn(() => new Promise<void>((resolve) => {
       finishRanking = resolve;
@@ -268,9 +291,9 @@ describe('ranking worker isolation', () => {
 
   it('keeps heartbeating while the first ranking run is still active', async () => {
     vi.useFakeTimers();
-    const queue = new FakeQueue();
-    const redis = new FakeRedis();
     const clock = createClock();
+    const queue = new FakeQueue(clock);
+    const redis = new FakeRedis();
     let finishRanking: (() => void) | undefined;
     const runRanking = vi.fn(() => new Promise<void>((resolve) => {
       finishRanking = resolve;
@@ -303,12 +326,12 @@ describe('ranking worker isolation', () => {
   });
 
   it('quarantines a timed-out publisher and retains its lease until process stop', async () => {
-    const queue = new FakeQueue();
-    const redis = new FakeRedis();
     const clock = createClock();
+    const queue = new FakeQueue(clock);
+    const redis = new FakeRedis();
     const release = vi.fn().mockResolvedValue(true);
     const runRanking = vi.fn().mockRejectedValue(
-      new ScoringPipelineTimeoutError(new Error('legacy timeout'))
+      new ScoringPipelineTimeoutError('timeout wording changed')
     );
     const worker = new RankingWorker(workerOptions({
       queue,
@@ -334,9 +357,9 @@ describe('ranking worker isolation', () => {
   });
 
   it('reports heartbeat age and queue state independently', async () => {
-    const queue = new FakeQueue();
-    const redis = new FakeRedis();
     const clock = createClock();
+    const queue = new FakeQueue(clock);
+    const redis = new FakeRedis();
     const worker = new RankingWorker(workerOptions({
       queue,
       redis,
@@ -361,7 +384,7 @@ describe('ranking worker isolation', () => {
   });
 
   it('rejects a heartbeat timestamp from the future', async () => {
-    const queue = new FakeQueue();
+    const queue = new FakeQueue(createClock());
     const redis = new FakeRedis();
     await redis.set('corgi:ranking-worker:heartbeat:community-gov', JSON.stringify({
       schemaVersion: 1,
@@ -387,7 +410,7 @@ describe('ranking worker isolation', () => {
   });
 
   it('treats the exact heartbeat TTL as healthy and one millisecond beyond as stale', async () => {
-    const queue = new FakeQueue();
+    const queue = new FakeQueue(createClock());
     const redis = new FakeRedis();
     await redis.set('corgi:ranking-worker:heartbeat:community-gov', JSON.stringify({
       schemaVersion: 1,
@@ -420,7 +443,7 @@ describe('ranking worker isolation', () => {
   });
 
   it('rejects malformed and cross-community heartbeat payloads', async () => {
-    const queue = new FakeQueue();
+    const queue = new FakeQueue(createClock());
     const redis = new FakeRedis();
     await redis.set('corgi:ranking-worker:heartbeat:community-gov', '{invalid-json');
     await expect(readRankingWorkerHealth(
@@ -451,7 +474,8 @@ describe('ranking worker isolation', () => {
   });
 
   it('fails startup cleanly when Redis or stale-claim recovery is unavailable', async () => {
-    const redisFailureQueue = new FakeQueue();
+    const redisFailureClock = createClock();
+    const redisFailureQueue = new FakeQueue(redisFailureClock);
     const redisFailure = new FakeRedis();
     vi.spyOn(redisFailure, 'set').mockRejectedValue(new Error('redis unavailable'));
     const redisFailureWorker = new RankingWorker(workerOptions({
@@ -459,12 +483,13 @@ describe('ranking worker isolation', () => {
       redis: redisFailure,
       ownedLease: lease({}),
       runRanking: async () => undefined,
-      clock: createClock(),
+      clock: redisFailureClock,
     }));
     await expect(redisFailureWorker.start()).rejects.toThrow('redis unavailable');
     expect(redisFailureWorker.isRunning()).toBe(false);
 
-    const queueFailure = new FakeQueue();
+    const queueFailureClock = createClock();
+    const queueFailure = new FakeQueue(queueFailureClock);
     vi.spyOn(queueFailure, 'requeueStaleClaims').mockRejectedValue(
       new Error('queue unavailable')
     );
@@ -474,7 +499,7 @@ describe('ranking worker isolation', () => {
       redis: queueFailureRedis,
       ownedLease: lease({}),
       runRanking: async () => undefined,
-      clock: createClock(),
+      clock: queueFailureClock,
     }));
     await expect(queueFailureWorker.start()).rejects.toThrow('queue unavailable');
     expect(queueFailureWorker.isRunning()).toBe(false);
@@ -484,7 +509,8 @@ describe('ranking worker isolation', () => {
   });
 
   it('recovers stale work only for its configured community', async () => {
-    const queue = new FakeQueue();
+    const clock = createClock();
+    const queue = new FakeQueue(clock);
     queue.requests.push({
       id: 'stale-community-request',
       idempotencyKey: 'scheduled:community-gov:stale',
@@ -513,7 +539,7 @@ describe('ranking worker isolation', () => {
       redis: new FakeRedis(),
       ownedLease: lease({}),
       runRanking: async () => undefined,
-      clock: createClock(),
+      clock,
     }));
 
     await worker.start();
@@ -526,14 +552,15 @@ describe('ranking worker isolation', () => {
   });
 
   it('serializes concurrent start and stop calls', async () => {
-    const queue = new FakeQueue();
+    const clock = createClock();
+    const queue = new FakeQueue(clock);
     const runRanking = vi.fn().mockResolvedValue(undefined);
     const worker = new RankingWorker(workerOptions({
       queue,
       redis: new FakeRedis(),
       ownedLease: lease({}),
       runRanking,
-      clock: createClock(),
+      clock,
     }));
 
     await Promise.all([worker.start(), worker.start()]);
@@ -544,7 +571,8 @@ describe('ranking worker isolation', () => {
   });
 
   it('waits for an active ranking run before stop completes', async () => {
-    const queue = new FakeQueue();
+    const clock = createClock();
+    const queue = new FakeQueue(clock);
     let finishRanking: (() => void) | undefined;
     const runRanking = vi.fn(() => new Promise<void>((resolve) => {
       finishRanking = resolve;
@@ -554,7 +582,7 @@ describe('ranking worker isolation', () => {
       redis: new FakeRedis(),
       ownedLease: lease({}),
       runRanking,
-      clock: createClock(),
+      clock,
     }));
     await worker.start();
     await vi.waitFor(() => {

--- a/tests/scoring-lock.test.ts
+++ b/tests/scoring-lock.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   OwnedRedisLease,
   RedisLeaseUnavailableError,
+  scoringLeaseKey,
   type LeaseRedisClient,
 } from '../src/scoring/owned-lease.js';
 
@@ -65,5 +66,11 @@ describe('token-owned Redis scoring lease', () => {
     evalScript.mockRejectedValue(new Error('connection reset'));
 
     await expect(lease.release('owner-a')).rejects.toBeInstanceOf(RedisLeaseUnavailableError);
+  });
+
+  it('isolates lease ownership by community', () => {
+    expect(scoringLeaseKey('community-gov')).toBe('lock:scoring:community-gov');
+    expect(scoringLeaseKey('future-feed')).toBe('lock:scoring:future-feed');
+    expect(() => scoringLeaseKey('')).toThrow('must be non-empty');
   });
 });

--- a/tests/scoring-lock.test.ts
+++ b/tests/scoring-lock.test.ts
@@ -73,4 +73,29 @@ describe('token-owned Redis scoring lease', () => {
     expect(scoringLeaseKey('future-feed')).toBe('lock:scoring:future-feed');
     expect(() => scoringLeaseKey('')).toThrow('must be non-empty');
   });
+
+  it('rejects invalid TTL and empty ownership tokens at every operation', async () => {
+    expect(() => new OwnedRedisLease(client, 'lock:scoring', 999)).toThrow('>= 1000');
+    await expect(lease.acquire('')).rejects.toThrow('token must be non-empty');
+    await expect(lease.renew('  ')).rejects.toThrow('token must be non-empty');
+    await expect(lease.release('')).rejects.toThrow('token must be non-empty');
+  });
+
+  it('allows only one of two concurrent contenders to acquire ownership', async () => {
+    set.mockResolvedValueOnce('OK').mockResolvedValueOnce(null);
+
+    const results = await Promise.all([
+      lease.acquire('owner-a'),
+      lease.acquire('owner-b'),
+    ]);
+
+    expect(results).toEqual([true, false]);
+    expect(set).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed when Redis cannot renew ownership', async () => {
+    evalScript.mockRejectedValue(new Error('connection reset'));
+
+    await expect(lease.renew('owner-a')).rejects.toBeInstanceOf(RedisLeaseUnavailableError);
+  });
 });

--- a/tests/scoring-lock.test.ts
+++ b/tests/scoring-lock.test.ts
@@ -76,6 +76,7 @@ describe('token-owned Redis scoring lease', () => {
 
   it('rejects invalid TTL and empty ownership tokens at every operation', async () => {
     expect(() => new OwnedRedisLease(client, 'lock:scoring', 999)).toThrow('>= 1000');
+    expect(() => new OwnedRedisLease(client, 'lock:scoring', 1_000)).not.toThrow();
     await expect(lease.acquire('')).rejects.toThrow('token must be non-empty');
     await expect(lease.renew('  ')).rejects.toThrow('token must be non-empty');
     await expect(lease.release('')).rejects.toThrow('token must be non-empty');

--- a/tests/scoring-lock.test.ts
+++ b/tests/scoring-lock.test.ts
@@ -1,147 +1,69 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// --- Mocks (vi.hoisted runs before imports) ---
-const { redisSetMock, redisDelMock, runScoringPipelineMock } = vi.hoisted(() => ({
-  redisSetMock: vi.fn(),
-  redisDelMock: vi.fn(),
-  runScoringPipelineMock: vi.fn(),
-}));
-
-vi.mock('../src/db/redis.js', () => ({
-  redis: {
-    set: redisSetMock,
-    del: redisDelMock,
-  },
-}));
-
-vi.mock('../src/lib/logger.js', () => ({
-  logger: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
-
-vi.mock('../src/config.js', () => ({
-  config: {
-    SCORING_INTERVAL_MS: 300_000,
-  },
-}));
-
-vi.mock('../src/scoring/pipeline.js', () => ({
-  runScoringPipeline: runScoringPipelineMock,
-}));
-
 import {
-  startScoring,
-  stopScoring,
-  tryTriggerManualScoringRun,
-  isScoringInProgress,
-} from '../src/scoring/scheduler.js';
+  OwnedRedisLease,
+  RedisLeaseUnavailableError,
+  type LeaseRedisClient,
+} from '../src/scoring/owned-lease.js';
 
-describe('scoring Redis distributed lock', () => {
+describe('token-owned Redis scoring lease', () => {
+  const set = vi.fn<LeaseRedisClient['set']>();
+  const evalScript = vi.fn<LeaseRedisClient['eval']>();
+  const client: LeaseRedisClient = { set, eval: evalScript };
+  let lease: OwnedRedisLease;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    runScoringPipelineMock.mockResolvedValue(undefined);
+    lease = new OwnedRedisLease(client, 'lock:scoring', 60_000);
   });
 
-  it('acquires lock via Redis SET NX EX', async () => {
-    // First call: SET NX succeeds (lock acquired)
-    redisSetMock.mockResolvedValue('OK');
-    redisDelMock.mockResolvedValue(1);
+  it('acquires with one unique token, PX expiry, and NX ownership', async () => {
+    set.mockResolvedValue('OK');
 
-    const triggered = await tryTriggerManualScoringRun();
+    await expect(lease.acquire('owner-a')).resolves.toBe(true);
 
-    expect(triggered).toBe(true);
-    expect(redisSetMock).toHaveBeenCalledWith(
+    expect(set).toHaveBeenCalledWith('lock:scoring', 'owner-a', 'PX', 60_000, 'NX');
+  });
+
+  it('returns false when another owner already holds the lease', async () => {
+    set.mockResolvedValue(null);
+
+    await expect(lease.acquire('owner-b')).resolves.toBe(false);
+  });
+
+  it('fails closed when Redis cannot establish ownership', async () => {
+    set.mockRejectedValue(new Error('redis unavailable'));
+
+    await expect(lease.acquire('owner-a')).rejects.toBeInstanceOf(RedisLeaseUnavailableError);
+  });
+
+  it('renews only when the stored token still matches', async () => {
+    evalScript.mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+
+    await expect(lease.renew('owner-a')).resolves.toBe(true);
+    await expect(lease.renew('stale-owner')).resolves.toBe(false);
+
+    expect(evalScript.mock.calls[0]?.[0]).toContain("redis.call('pexpire'");
+    expect(evalScript.mock.calls[0]?.slice(1)).toEqual([
+      1,
       'lock:scoring',
-      expect.any(String),
-      'EX',
-      300,
-      'NX'
-    );
+      'owner-a',
+      60_000,
+    ]);
   });
 
-  it('returns false when Redis SET NX returns null (lock held)', async () => {
-    // SET NX returns null when key already exists
-    redisSetMock.mockResolvedValue(null);
+  it('releases only when the stored token still matches', async () => {
+    evalScript.mockResolvedValueOnce(1).mockResolvedValueOnce(0);
 
-    const triggered = await tryTriggerManualScoringRun();
+    await expect(lease.release('owner-a')).resolves.toBe(true);
+    await expect(lease.release('stale-owner')).resolves.toBe(false);
 
-    expect(triggered).toBe(false);
+    expect(evalScript.mock.calls[0]?.[0]).toContain("redis.call('del'");
+    expect(evalScript.mock.calls[0]?.slice(1)).toEqual([1, 'lock:scoring', 'owner-a']);
   });
 
-  it('releases lock by deleting the Redis key', async () => {
-    redisSetMock.mockResolvedValue('OK');
-    redisDelMock.mockResolvedValue(1);
-    runScoringPipelineMock.mockResolvedValue(undefined);
+  it('rejects stale-owner release attempts without falling back', async () => {
+    evalScript.mockRejectedValue(new Error('connection reset'));
 
-    // Use triggerManualRun (awaitable) via startScoring + stopScoring
-    // Or just trigger and wait for the fire-and-forget to settle
-    await tryTriggerManualScoringRun();
-
-    // Give the fire-and-forget pipeline time to complete
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(redisDelMock).toHaveBeenCalledWith('lock:scoring');
-  });
-
-  it('releases lock even when scoring pipeline throws', async () => {
-    redisSetMock.mockResolvedValue('OK');
-    redisDelMock.mockResolvedValue(1);
-    runScoringPipelineMock.mockRejectedValue(new Error('pipeline crashed'));
-
-    await tryTriggerManualScoringRun();
-
-    // Give the fire-and-forget pipeline time to complete
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    // Lock should still be released despite pipeline failure
-    expect(redisDelMock).toHaveBeenCalledWith('lock:scoring');
-  });
-
-  it('falls back to local boolean when Redis SET fails', async () => {
-    redisSetMock.mockRejectedValue(new Error('redis connection refused'));
-    redisDelMock.mockResolvedValue(1);
-
-    // Should still acquire (local fallback)
-    const triggered = await tryTriggerManualScoringRun();
-    expect(triggered).toBe(true);
-  });
-
-  it('updates local isScoring mirror for health checks', async () => {
-    redisSetMock.mockResolvedValue('OK');
-    redisDelMock.mockResolvedValue(1);
-
-    // Create a long-running pipeline to check isScoring mid-run
-    let resolvePipeline: () => void;
-    runScoringPipelineMock.mockImplementation(
-      () => new Promise<void>((resolve) => { resolvePipeline = resolve; })
-    );
-
-    await tryTriggerManualScoringRun();
-
-    // While pipeline is running, isScoring should be true
-    expect(isScoringInProgress()).toBe(true);
-
-    // Complete the pipeline
-    resolvePipeline!();
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    // After completion, isScoring should be false
-    expect(isScoringInProgress()).toBe(false);
-  });
-
-  it('rejects when scheduler is shutting down', async () => {
-    redisSetMock.mockResolvedValue('OK');
-    redisDelMock.mockResolvedValue(1);
-
-    // Start and immediately stop to set isShuttingDown = true
-    await startScoring();
-    await stopScoring();
-
-    const triggered = await tryTriggerManualScoringRun();
-    expect(triggered).toBe(false);
+    await expect(lease.release('owner-a')).rejects.toBeInstanceOf(RedisLeaseUnavailableError);
   });
 });

--- a/tests/stress/feed-skeleton-memory-server.ts
+++ b/tests/stress/feed-skeleton-memory-server.ts
@@ -15,6 +15,11 @@ import {
   type FeedRequestTrackerStats,
 } from '../../src/feed/request-tracker.js';
 
+// A 20,000-request burst can leave bounded asynchronous attribution work after
+// the HTTP load has completed. Keep the post-load collection window finite but
+// long enough to prove that the production-safe 45-operation cap drains it.
+const FEED_REQUEST_TRACKER_DRAIN_TIMEOUT_MS = 30_000;
+
 interface ServerOptions {
   mode: 'normal' | 'noop';
   diagnostic: boolean;
@@ -283,7 +288,7 @@ async function waitForConnectionDrain(app: ReturnType<typeof Fastify>, timeoutMs
 }
 
 async function settleServerBeforeSnapshot(app: ReturnType<typeof Fastify>, gc: () => void): Promise<DrainDiagnosticStats> {
-  const tracker = await drainFeedRequestTracker(10_000);
+  const tracker = await drainFeedRequestTracker(FEED_REQUEST_TRACKER_DRAIN_TIMEOUT_MS);
   const serverWithIdleClose = app.server as typeof app.server & { closeIdleConnections?: () => void };
   if (typeof serverWithIdleClose.closeIdleConnections === 'function') {
     serverWithIdleClose.closeIdleConnections();

--- a/tests/worker-health.test.ts
+++ b/tests/worker-health.test.ts
@@ -1,5 +1,7 @@
 import { execFileSync } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { feedHealthSummary } from '../cli/src/commands/feed.js';
 
@@ -11,6 +13,25 @@ async function source(path: string): Promise<string> {
   return readFile(new URL(path, ROOT), 'utf8');
 }
 
+function runReadinessCommand(
+  readinessLibrary: string,
+  command: string,
+  environment: Record<string, string>
+): boolean {
+  try {
+    execFileSync('bash', ['-c', `${readinessLibrary}
+${command}
+`], {
+      env: { ...process.env, ...environment },
+      stdio: 'pipe',
+      timeout: 2_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function probeWatchdogFunction(
   watchdog: string,
   functionName: 'worker_heartbeat_healthy' | 'feed_snapshot_healthy',
@@ -18,7 +39,13 @@ function probeWatchdogFunction(
   dockerFunction: string,
   timeoutFunction: string
 ): boolean {
-  const definitions = watchdog.slice(0, watchdog.indexOf('# ── Disk space check'));
+  let definitions = watchdog.slice(0, watchdog.indexOf('# ── Disk space check'));
+  if (environment.TEST_NOW) {
+    definitions = definitions.replaceAll(
+      'datetime.datetime.now(datetime.timezone.utc)',
+      'datetime.datetime.fromisoformat(os.environ["TEST_NOW"])'
+    );
+  }
   const script = `${definitions}
 ${timeoutFunction}
 ${dockerFunction}
@@ -36,23 +63,19 @@ if ${functionName}; then exit 0; else exit 1; fi
   }
 }
 
-function validateDeployHeartbeat(
-  deployScript: string,
+function validateRankingWorkerHeartbeat(
+  readinessLibrary: string,
   heartbeat: Record<string, unknown>,
   restartEpochMs: number
 ): boolean {
-  const validator = deployScript.match(
-    /HEARTBEAT_JSON="\$[^\"]+" WORKER_RESTART_EPOCH_MS="\$[^\"]+" python3 -c '([^']+)'/
-  )?.[1];
-  if (!validator) {
-    throw new Error('Deploy heartbeat validator was not found');
-  }
   try {
-    execFileSync('python3', ['-c', validator], {
+    execFileSync('bash', ['-c', `${readinessLibrary}
+ranking_worker_heartbeat_is_healthy "$FAKE_HEARTBEAT" "$FAKE_RESTART_EPOCH_MS"
+`], {
       env: {
         ...process.env,
-        HEARTBEAT_JSON: JSON.stringify(heartbeat),
-        WORKER_RESTART_EPOCH_MS: String(restartEpochMs),
+        FAKE_HEARTBEAT: JSON.stringify(heartbeat),
+        FAKE_RESTART_EPOCH_MS: String(restartEpochMs),
       },
       stdio: 'pipe',
       timeout: 2_000,
@@ -65,16 +88,60 @@ function validateDeployHeartbeat(
 
 describe('ranking worker deployment contracts', () => {
   it('gives API and worker independent process roles and memory boundaries', async () => {
-    const [apiUnit, workerUnit] = await Promise.all([
-      source('ops/bluesky-feed.service'),
-      source('ops/corgi-ranking-worker.service'),
-    ]);
+    const [apiUnit, workerUnit, installScript, deployScript, workflow, operability] =
+      await Promise.all([
+        source('ops/bluesky-feed.service'),
+        source('ops/corgi-ranking-worker.service'),
+        source('ops/install.sh'),
+        source('ops/deploy'),
+        source('.github/workflows/deploy.yml'),
+        source('docs/OPERABILITY.md'),
+      ]);
 
     expect(apiUnit).toContain('Environment=PROCESS_ROLE=api');
     expect(workerUnit).toContain('Environment=PROCESS_ROLE=ranking-worker');
     expect(workerUnit).toContain('MemoryMax=1G');
     expect(workerUnit).toContain('TimeoutStopSec=300');
     expect(workerUnit).toContain('ExecStart=/usr/bin/node dist/index.js');
+    expect(apiUnit).toContain('PROCESS_ROLE must never be set in the shared .env');
+    expect(workerUnit).toContain('PROCESS_ROLE must never be set in the shared .env');
+    for (const deploymentPath of [installScript, deployScript, workflow]) {
+      expect(deploymentPath).toContain('reject_shared_process_role');
+    }
+    expect(operability).toContain('must never define `PROCESS_ROLE`');
+    expect(operability).toContain('at least 60 seconds');
+  });
+
+  it('rejects shared role overrides and unsafe worker stop-timeout drift', async () => {
+    const readinessLibrary = await source('ops/lib/ranking-worker-readiness.sh');
+    const directory = await mkdtemp(join(tmpdir(), 'corgi-worker-readiness-'));
+    const envFile = join(directory, '.env');
+    const unitFile = join(directory, 'corgi-ranking-worker.service');
+    try {
+      await writeFile(unitFile, '[Service]\nTimeoutStopSec=300\n', 'utf8');
+      await writeFile(envFile, 'PROCESS_ROLE=all\n', 'utf8');
+      expect(runReadinessCommand(
+        readinessLibrary,
+        'reject_shared_process_role "$TEST_ENV_FILE"',
+        { TEST_ENV_FILE: envFile }
+      )).toBe(false);
+
+      await writeFile(envFile, 'SCORING_TIMEOUT_MS=240000\n', 'utf8');
+      expect(runReadinessCommand(
+        readinessLibrary,
+        'validate_ranking_worker_stop_timeout "$TEST_UNIT_FILE" "$TEST_ENV_FILE"',
+        { TEST_ENV_FILE: envFile, TEST_UNIT_FILE: unitFile }
+      )).toBe(true);
+
+      await writeFile(envFile, 'SCORING_TIMEOUT_MS=240001\n', 'utf8');
+      expect(runReadinessCommand(
+        readinessLibrary,
+        'validate_ranking_worker_stop_timeout "$TEST_UNIT_FILE" "$TEST_ENV_FILE"',
+        { TEST_ENV_FILE: envFile, TEST_UNIT_FILE: unitFile }
+      )).toBe(false);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
   });
 
   it('runs backup verification and migrations before either process restart', async () => {
@@ -120,33 +187,63 @@ describe('ranking worker deployment contracts', () => {
         script.indexOf('WORKER_RESTART_EPOCH_MS=$(date +%s%3N)'),
         script.indexOf('worker_restart_epoch_ms=$(date +%s%3N)')
       );
-      const heartbeatPassed = script.indexOf('Ranking worker heartbeat passed');
+      const heartbeatPassed = script.indexOf('wait_for_ranking_worker_ready');
       const apiRestart = script.indexOf('restart bluesky-feed');
       expect(workerRestart).toBeGreaterThan(0);
-      expect(restartCutoff).toBeGreaterThan(workerRestart);
+      expect(restartCutoff).toBeLessThan(workerRestart);
       expect(heartbeatPassed).toBeGreaterThan(workerRestart);
       expect(apiRestart).toBeGreaterThan(heartbeatPassed);
       expect(script).toContain('API was not touched');
-      expect(script).toContain('WORKER_RESTART_EPOCH_MS');
+      expect(script).toMatch(/WORKER_RESTART_EPOCH_MS|worker_restart_epoch_ms/);
     }
   });
 
   it('requires the heartbeat to come from the newly restarted worker', async () => {
-    const [workflow, deploy] = await Promise.all([
+    const [workflow, deploy, readinessLibrary] = await Promise.all([
       source('.github/workflows/deploy.yml'),
       source('ops/deploy'),
+      source('ops/lib/ranking-worker-readiness.sh'),
     ]);
     const updatedAt = new Date();
     const heartbeat = { updatedAt: updatedAt.toISOString(), state: 'idle' };
     for (const script of [workflow, deploy]) {
-      expect(validateDeployHeartbeat(script, heartbeat, updatedAt.getTime() - 1)).toBe(true);
-      expect(validateDeployHeartbeat(script, heartbeat, updatedAt.getTime() + 1)).toBe(false);
-      expect(validateDeployHeartbeat(
-        script,
-        { ...heartbeat, state: 'failed' },
-        updatedAt.getTime() - 1
-      )).toBe(false);
+      expect(script).toContain('source "$RANKING_READINESS_LIBRARY"');
+      expect(script).toContain('wait_for_ranking_worker_ready');
     }
+    expect(validateRankingWorkerHeartbeat(
+      readinessLibrary,
+      heartbeat,
+      updatedAt.getTime() - 1
+    )).toBe(true);
+    expect(validateRankingWorkerHeartbeat(
+      readinessLibrary,
+      heartbeat,
+      updatedAt.getTime() + 1
+    )).toBe(false);
+    expect(validateRankingWorkerHeartbeat(
+      readinessLibrary,
+      { ...heartbeat, state: 'failed' },
+      updatedAt.getTime() - 1
+    )).toBe(false);
+  });
+
+  it('bounds heartbeat probes in both deployment paths', async () => {
+    const [workflow, deploy, readinessLibrary] = await Promise.all([
+      source('.github/workflows/deploy.yml'),
+      source('ops/deploy'),
+      source('ops/lib/ranking-worker-readiness.sh'),
+    ]);
+
+    expect(readinessLibrary).toContain(
+      'timeout "$timeout_seconds" sudo docker compose'
+    );
+    expect(readinessLibrary).toContain(
+      'timeout "$timeout_seconds" docker exec'
+    );
+    expect(workflow).toContain('probe_ranking_worker_heartbeat_with_compose');
+    expect(deploy).toContain('probe_ranking_worker_heartbeat_with_docker');
+    expect(workflow).toContain('<(sudo systemctl cat corgi-ranking-worker.service)');
+    expect(deploy).toContain('<(systemctl cat corgi-ranking-worker.service)');
   });
 
   it('checks and restarts worker health without restarting the API', async () => {
@@ -211,12 +308,14 @@ describe('ranking worker deployment contracts', () => {
       esac
     }`;
     const nowMs = Date.now();
+    const testNow = new Date(nowMs).toISOString();
 
     expect(probeWatchdogFunction(
       watchdog,
       'feed_snapshot_healthy',
       {
         RANKING_COMMUNITY_ID: 'community-gov',
+        TEST_NOW: testNow,
         FAKE_COUNT: '1000',
         FAKE_UPDATED_AT: new Date(nowMs - 599_000).toISOString(),
       },
@@ -228,6 +327,7 @@ describe('ranking worker deployment contracts', () => {
       'feed_snapshot_healthy',
       {
         RANKING_COMMUNITY_ID: 'community-gov',
+        TEST_NOW: testNow,
         FAKE_COUNT: '0',
         FAKE_UPDATED_AT: new Date(nowMs).toISOString(),
       },
@@ -239,6 +339,19 @@ describe('ranking worker deployment contracts', () => {
       'feed_snapshot_healthy',
       {
         RANKING_COMMUNITY_ID: 'community-gov',
+        TEST_NOW: testNow,
+        FAKE_COUNT: '1000',
+        FAKE_UPDATED_AT: new Date(nowMs - 600_000).toISOString(),
+      },
+      dockerFunction,
+      PASS_THROUGH_TIMEOUT
+    )).toBe(true);
+    expect(probeWatchdogFunction(
+      watchdog,
+      'feed_snapshot_healthy',
+      {
+        RANKING_COMMUNITY_ID: 'community-gov',
+        TEST_NOW: testNow,
         FAKE_COUNT: '1000',
         FAKE_UPDATED_AT: new Date(nowMs - 601_000).toISOString(),
       },

--- a/tests/worker-health.test.ts
+++ b/tests/worker-health.test.ts
@@ -1,0 +1,48 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = new URL('../', import.meta.url);
+
+async function source(path: string): Promise<string> {
+  return readFile(new URL(path, ROOT), 'utf8');
+}
+
+describe('ranking worker deployment contracts', () => {
+  it('gives API and worker independent process roles and memory boundaries', async () => {
+    const [apiUnit, workerUnit] = await Promise.all([
+      source('ops/bluesky-feed.service'),
+      source('ops/corgi-ranking-worker.service'),
+    ]);
+
+    expect(apiUnit).toContain('Environment=PROCESS_ROLE=api');
+    expect(workerUnit).toContain('Environment=PROCESS_ROLE=ranking-worker');
+    expect(workerUnit).toContain('MemoryMax=1G');
+    expect(workerUnit).toContain('TimeoutStopSec=300');
+    expect(workerUnit).toContain('ExecStart=/usr/bin/node dist/index.js');
+  });
+
+  it('runs backup verification and migrations before either process restart', async () => {
+    const deploy = await source('.github/workflows/deploy.yml');
+    const backupIndex = deploy.indexOf('sudo gzip -t "$LATEST_BACKUP"');
+    const migrationIndex = deploy.indexOf('npm run migrate');
+    const workerRestartIndex = deploy.indexOf('sudo systemctl restart corgi-ranking-worker');
+    const apiRestartIndex = deploy.indexOf('sudo systemctl restart bluesky-feed');
+
+    expect(backupIndex).toBeGreaterThan(0);
+    expect(migrationIndex).toBeGreaterThan(backupIndex);
+    expect(workerRestartIndex).toBeGreaterThan(migrationIndex);
+    expect(apiRestartIndex).toBeGreaterThan(workerRestartIndex);
+  });
+
+  it('checks and restarts worker health without restarting the API', async () => {
+    const watchdog = await source('ops/health-watchdog');
+    const workerChecks = watchdog.slice(
+      watchdog.indexOf('if worker_unit_installed; then'),
+      watchdog.indexOf('# Try health check with retries')
+    );
+
+    expect(watchdog).toContain('corgi:ranking-worker:heartbeat');
+    expect(workerChecks).toContain('systemctl restart "$WORKER_SERVICE"');
+    expect(workerChecks).not.toContain('systemctl restart "$SERVICE"');
+  });
+});

--- a/tests/worker-health.test.ts
+++ b/tests/worker-health.test.ts
@@ -41,7 +41,7 @@ describe('ranking worker deployment contracts', () => {
       watchdog.indexOf('# Try health check with retries')
     );
 
-    expect(watchdog).toContain('corgi:ranking-worker:heartbeat');
+    expect(watchdog).toContain('corgi:ranking-worker:heartbeat:community-gov');
     expect(workerChecks).toContain('systemctl restart "$WORKER_SERVICE"');
     expect(workerChecks).not.toContain('systemctl restart "$SERVICE"');
   });

--- a/tests/worker-health.test.ts
+++ b/tests/worker-health.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 
@@ -5,6 +6,29 @@ const ROOT = new URL('../', import.meta.url);
 
 async function source(path: string): Promise<string> {
   return readFile(new URL(path, ROOT), 'utf8');
+}
+
+function probeWatchdogFunction(
+  watchdog: string,
+  functionName: 'worker_heartbeat_healthy' | 'feed_snapshot_healthy',
+  environment: Record<string, string>,
+  dockerFunction: string
+): boolean {
+  const definitions = watchdog.slice(0, watchdog.indexOf('# ── Disk space check'));
+  const script = `${definitions}
+timeout() { shift; "$@"; }
+${dockerFunction}
+if ${functionName}; then exit 0; else exit 1; fi
+`;
+  try {
+    execFileSync('bash', ['-c', script], {
+      env: { ...process.env, ...environment },
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 describe('ranking worker deployment contracts', () => {
@@ -32,6 +56,41 @@ describe('ranking worker deployment contracts', () => {
     expect(migrationIndex).toBeGreaterThan(backupIndex);
     expect(workerRestartIndex).toBeGreaterThan(migrationIndex);
     expect(apiRestartIndex).toBeGreaterThan(workerRestartIndex);
+    expect(deploy).toContain('if ! BACKUP_TARGET=$(findmnt');
+    expect(deploy).toContain('if ! LATEST_BACKUP=$(sudo find');
+    expect(deploy).not.toContain('| head -1 |');
+  });
+
+  it('keeps every remote command inside the workflow YAML block scalar', async () => {
+    const workflow = await source('.github/workflows/deploy.yml');
+    const lines = workflow.split('\n');
+    const scriptLine = lines.findIndex((line) => line === '          script: |');
+    const nextStep = lines.findIndex((line, index) => (
+      index > scriptLine && line.startsWith('      - name:')
+    ));
+    expect(scriptLine).toBeGreaterThan(0);
+    expect(nextStep).toBeGreaterThan(scriptLine);
+    for (const line of lines.slice(scriptLine + 1, nextStep)) {
+      if (line.trim()) {
+        expect(line.startsWith('            '), `misindented workflow line: ${line}`).toBe(true);
+      }
+    }
+  });
+
+  it('proves worker readiness before touching the API in both deploy paths', async () => {
+    const [workflow, deploy] = await Promise.all([
+      source('.github/workflows/deploy.yml'),
+      source('ops/deploy'),
+    ]);
+    for (const script of [workflow, deploy]) {
+      const workerRestart = script.indexOf('restart corgi-ranking-worker');
+      const heartbeatPassed = script.indexOf('Ranking worker heartbeat passed');
+      const apiRestart = script.indexOf('restart bluesky-feed');
+      expect(workerRestart).toBeGreaterThan(0);
+      expect(heartbeatPassed).toBeGreaterThan(workerRestart);
+      expect(apiRestart).toBeGreaterThan(heartbeatPassed);
+      expect(script).toContain('API was not touched');
+    }
   });
 
   it('checks and restarts worker health without restarting the API', async () => {
@@ -41,8 +100,89 @@ describe('ranking worker deployment contracts', () => {
       watchdog.indexOf('# Try health check with retries')
     );
 
-    expect(watchdog).toContain('corgi:ranking-worker:heartbeat:community-gov');
+    expect(watchdog).toContain('corgi:ranking-worker:heartbeat:${RANKING_COMMUNITY_ID}');
+    expect(watchdog).toContain('timeout "$PROBE_TIMEOUT_SECONDS" docker exec');
     expect(workerChecks).toContain('systemctl restart "$WORKER_SERVICE"');
+    expect(workerChecks.match(/systemctl restart "\$WORKER_SERVICE"/g)).toHaveLength(1);
     expect(workerChecks).not.toContain('systemctl restart "$SERVICE"');
+  });
+
+  it('rejects malformed worker heartbeats and accepts a fresh configured-community heartbeat', async () => {
+    const watchdog = await source('ops/health-watchdog');
+    const updatedAt = new Date().toISOString();
+    const dockerFunction = `docker() {
+      if [ "\${*: -1}" != "corgi:ranking-worker:heartbeat:future-feed" ]; then return 2; fi
+      printf '%s' "$FAKE_HEARTBEAT"
+    }`;
+
+    expect(probeWatchdogFunction(
+      watchdog,
+      'worker_heartbeat_healthy',
+      {
+        RANKING_COMMUNITY_ID: 'future-feed',
+        FAKE_HEARTBEAT: JSON.stringify({ updatedAt, state: 'idle' }),
+      },
+      dockerFunction
+    )).toBe(true);
+    expect(probeWatchdogFunction(
+      watchdog,
+      'worker_heartbeat_healthy',
+      { RANKING_COMMUNITY_ID: 'future-feed', FAKE_HEARTBEAT: '{malformed' },
+      dockerFunction
+    )).toBe(false);
+  });
+
+  it('enforces feed snapshot count and freshness boundaries', async () => {
+    const watchdog = await source('ops/health-watchdog');
+    const dockerFunction = `docker() {
+      case "$*" in
+        *"ZCARD feed:current") printf '%s' "$FAKE_COUNT" ;;
+        *"GET feed:updated_at") printf '%s' "$FAKE_UPDATED_AT" ;;
+        *) return 2 ;;
+      esac
+    }`;
+    const nowMs = Date.now();
+
+    expect(probeWatchdogFunction(
+      watchdog,
+      'feed_snapshot_healthy',
+      {
+        RANKING_COMMUNITY_ID: 'community-gov',
+        FAKE_COUNT: '1000',
+        FAKE_UPDATED_AT: new Date(nowMs - 599_000).toISOString(),
+      },
+      dockerFunction
+    )).toBe(true);
+    expect(probeWatchdogFunction(
+      watchdog,
+      'feed_snapshot_healthy',
+      {
+        RANKING_COMMUNITY_ID: 'community-gov',
+        FAKE_COUNT: '0',
+        FAKE_UPDATED_AT: new Date(nowMs).toISOString(),
+      },
+      dockerFunction
+    )).toBe(false);
+    expect(probeWatchdogFunction(
+      watchdog,
+      'feed_snapshot_healthy',
+      {
+        RANKING_COMMUNITY_ID: 'community-gov',
+        FAKE_COUNT: '1000',
+        FAKE_UPDATED_AT: new Date(nowMs - 601_000).toISOString(),
+      },
+      dockerFunction
+    )).toBe(false);
+  });
+
+  it('fails installation instead of claiming an unenabled worker', async () => {
+    const installScript = await source('ops/install.sh');
+    const workerEnable = installScript.slice(
+      installScript.indexOf('if ! systemctl list-unit-files corgi-ranking-worker.service'),
+      installScript.indexOf('echo "✓ corgi-ranking-worker enabled')
+    );
+
+    expect(workerEnable).toContain('exit 1');
+    expect(workerEnable).not.toContain('|| true');
   });
 });

--- a/tests/worker-health.test.ts
+++ b/tests/worker-health.test.ts
@@ -1,8 +1,11 @@
 import { execFileSync } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
+import { feedHealthSummary } from '../cli/src/commands/feed.js';
 
 const ROOT = new URL('../', import.meta.url);
+const PASS_THROUGH_TIMEOUT = 'timeout() { shift; "$@"; }';
+const FAILING_TIMEOUT = 'timeout() { return 124; }';
 
 async function source(path: string): Promise<string> {
   return readFile(new URL(path, ROOT), 'utf8');
@@ -12,11 +15,12 @@ function probeWatchdogFunction(
   watchdog: string,
   functionName: 'worker_heartbeat_healthy' | 'feed_snapshot_healthy',
   environment: Record<string, string>,
-  dockerFunction: string
+  dockerFunction: string,
+  timeoutFunction: string
 ): boolean {
   const definitions = watchdog.slice(0, watchdog.indexOf('# ── Disk space check'));
   const script = `${definitions}
-timeout() { shift; "$@"; }
+${timeoutFunction}
 ${dockerFunction}
 if ${functionName}; then exit 0; else exit 1; fi
 `;
@@ -24,6 +28,34 @@ if ${functionName}; then exit 0; else exit 1; fi
     execFileSync('bash', ['-c', script], {
       env: { ...process.env, ...environment },
       stdio: 'pipe',
+      timeout: 2_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function validateDeployHeartbeat(
+  deployScript: string,
+  heartbeat: Record<string, unknown>,
+  restartEpochMs: number
+): boolean {
+  const validator = deployScript.match(
+    /HEARTBEAT_JSON="\$[^\"]+" WORKER_RESTART_EPOCH_MS="\$[^\"]+" python3 -c '([^']+)'/
+  )?.[1];
+  if (!validator) {
+    throw new Error('Deploy heartbeat validator was not found');
+  }
+  try {
+    execFileSync('python3', ['-c', validator], {
+      env: {
+        ...process.env,
+        HEARTBEAT_JSON: JSON.stringify(heartbeat),
+        WORKER_RESTART_EPOCH_MS: String(restartEpochMs),
+      },
+      stdio: 'pipe',
+      timeout: 2_000,
     });
     return true;
   } catch {
@@ -84,12 +116,36 @@ describe('ranking worker deployment contracts', () => {
     ]);
     for (const script of [workflow, deploy]) {
       const workerRestart = script.indexOf('restart corgi-ranking-worker');
+      const restartCutoff = Math.max(
+        script.indexOf('WORKER_RESTART_EPOCH_MS=$(date +%s%3N)'),
+        script.indexOf('worker_restart_epoch_ms=$(date +%s%3N)')
+      );
       const heartbeatPassed = script.indexOf('Ranking worker heartbeat passed');
       const apiRestart = script.indexOf('restart bluesky-feed');
       expect(workerRestart).toBeGreaterThan(0);
+      expect(restartCutoff).toBeGreaterThan(workerRestart);
       expect(heartbeatPassed).toBeGreaterThan(workerRestart);
       expect(apiRestart).toBeGreaterThan(heartbeatPassed);
       expect(script).toContain('API was not touched');
+      expect(script).toContain('WORKER_RESTART_EPOCH_MS');
+    }
+  });
+
+  it('requires the heartbeat to come from the newly restarted worker', async () => {
+    const [workflow, deploy] = await Promise.all([
+      source('.github/workflows/deploy.yml'),
+      source('ops/deploy'),
+    ]);
+    const updatedAt = new Date();
+    const heartbeat = { updatedAt: updatedAt.toISOString(), state: 'idle' };
+    for (const script of [workflow, deploy]) {
+      expect(validateDeployHeartbeat(script, heartbeat, updatedAt.getTime() - 1)).toBe(true);
+      expect(validateDeployHeartbeat(script, heartbeat, updatedAt.getTime() + 1)).toBe(false);
+      expect(validateDeployHeartbeat(
+        script,
+        { ...heartbeat, state: 'failed' },
+        updatedAt.getTime() - 1
+      )).toBe(false);
     }
   });
 
@@ -122,13 +178,26 @@ describe('ranking worker deployment contracts', () => {
         RANKING_COMMUNITY_ID: 'future-feed',
         FAKE_HEARTBEAT: JSON.stringify({ updatedAt, state: 'idle' }),
       },
-      dockerFunction
+      dockerFunction,
+      PASS_THROUGH_TIMEOUT
     )).toBe(true);
     expect(probeWatchdogFunction(
       watchdog,
       'worker_heartbeat_healthy',
       { RANKING_COMMUNITY_ID: 'future-feed', FAKE_HEARTBEAT: '{malformed' },
-      dockerFunction
+      dockerFunction,
+      PASS_THROUGH_TIMEOUT
+    )).toBe(false);
+  });
+
+  it('treats a timeout exit as unhealthy without allowing the fixture to hang', async () => {
+    const watchdog = await source('ops/health-watchdog');
+    expect(probeWatchdogFunction(
+      watchdog,
+      'worker_heartbeat_healthy',
+      { RANKING_COMMUNITY_ID: 'community-gov' },
+      'docker() { while true; do :; done; }',
+      FAILING_TIMEOUT
     )).toBe(false);
   });
 
@@ -151,7 +220,8 @@ describe('ranking worker deployment contracts', () => {
         FAKE_COUNT: '1000',
         FAKE_UPDATED_AT: new Date(nowMs - 599_000).toISOString(),
       },
-      dockerFunction
+      dockerFunction,
+      PASS_THROUGH_TIMEOUT
     )).toBe(true);
     expect(probeWatchdogFunction(
       watchdog,
@@ -161,7 +231,8 @@ describe('ranking worker deployment contracts', () => {
         FAKE_COUNT: '0',
         FAKE_UPDATED_AT: new Date(nowMs).toISOString(),
       },
-      dockerFunction
+      dockerFunction,
+      PASS_THROUGH_TIMEOUT
     )).toBe(false);
     expect(probeWatchdogFunction(
       watchdog,
@@ -171,18 +242,43 @@ describe('ranking worker deployment contracts', () => {
         FAKE_COUNT: '1000',
         FAKE_UPDATED_AT: new Date(nowMs - 601_000).toISOString(),
       },
-      dockerFunction
+      dockerFunction,
+      PASS_THROUGH_TIMEOUT
     )).toBe(false);
   });
 
-  it('fails installation instead of claiming an unenabled worker', async () => {
+  it('keeps worker installation opt-in and fails approved activation explicitly', async () => {
     const installScript = await source('ops/install.sh');
-    const workerEnable = installScript.slice(
-      installScript.indexOf('if ! systemctl list-unit-files corgi-ranking-worker.service'),
-      installScript.indexOf('echo "✓ corgi-ranking-worker enabled')
-    );
+    expect(installScript).toContain('INSTALL_RANKING_WORKER="${INSTALL_RANKING_WORKER:-false}"');
+    expect(installScript).toContain('installation skipped (set INSTALL_RANKING_WORKER=true after approval)');
+    expect(installScript).toContain('approved worker activation requested but source unit is missing');
+    expect(installScript).toContain('ERROR: failed to enable corgi-ranking-worker.service');
+    expect(installScript).toContain('enable skipped pending approved activation');
+    expect(installScript).not.toContain('systemctl enable corgi-ranking-worker 2>/dev/null || true');
+  });
 
-    expect(workerEnable).toContain('exit 1');
-    expect(workerEnable).not.toContain('|| true');
+  it('reports scoring logs from rollback-compatible and split-worker modes', async () => {
+    const statusScript = await source('ops/status');
+    expect(statusScript).toContain(
+      'journalctl -u bluesky-feed -u corgi-ranking-worker --since "15 minutes ago"'
+    );
+  });
+
+  it('renders real feed-health values in the CLI summary', () => {
+    expect(feedHealthSummary({
+      database: { totalPosts: 1_000 },
+      scoring: { postsScored: 950, lastRun: '2026-07-12T07:00:00.000Z' },
+      jetstream: { connected: true },
+      subscribers: { total: 120 },
+      rankingWorker: { healthy: true, queue: { pendingCount: 2 } },
+    })).toEqual([
+      ['Total Posts', 1_000],
+      ['Scored Posts', 950],
+      ['Last Scored', '2026-07-12T07:00:00.000Z'],
+      ['Jetstream Connected', true],
+      ['Subscriber Count', 120],
+      ['Ranking Worker Healthy', true],
+      ['Queued Ranking Requests', 2],
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- split API and ranking responsibilities behind `PROCESS_ROLE=api|ranking-worker|all` while retaining `all` as the rollback-compatible default
- persist scheduled and manual work in `ranking_run_requests`, consumed only by a dedicated worker under a token-owned renewable Redis lease
- scope queue claiming, stale recovery, queue health, and heartbeats by `communityId` so future feeds cannot consume each other's work
- expose independent worker heartbeat and queue health through admin, CLI, MCP, watchdog, deploy, and status surfaces
- add a 1 GiB systemd worker unit, backup-verified pre-cutover migrations, and independent restart/rollback paths
- quarantine timed-out publishers while retaining their lease so detached legacy work cannot overlap a replacement run

## Safety and compatibility

- AT Protocol feed responses, feed URI, cursor behavior, and serving keys are unchanged
- failed/empty ranking preserves the last-known-good Redis snapshot
- Redis lease acquisition is fail-closed; renew/release are token-owned Lua operations
- production unit installation/activation remains explicitly gated by PROJ-1769 and `docs/OPERABILITY.md`; this PR does not activate the split worker
- Birders remains disabled

## Verification

- `npm run verify`: 140 files / 1,413 tests; backend, CLI, SDK, legacy web lint/build, and web-next production build passed
- `npm run sim:core`: 22 files / 237 real PostgreSQL/Redis simulation tests passed
- focused worker/lease/API/deployment contracts: 5 files / 28 tests passed
- dedicated two-community queue integration: 1 file / 6 real PostgreSQL/Redis tests passed
- `npm run docs:verify` passed
- backend audit allowlist passed; root audit found 0 vulnerabilities; frontend moderate gate passed with one existing low advisory
- TypeScript strict compile, shell syntax, and `git diff --check` passed
- governed staged-path lease validation passed all 13 rules (fencing token 139)

## Production gate

After merge/deploy in rollback-compatible `all` mode, the split unit is activated only through the documented backup, migration, heartbeat, snapshot, independent restart, and rollback evidence packet.

Current read-only production baseline: API ready; Community Governed Feed XRPC 200; Redis snapshot 1,000 and fresh; Birders returns disabled; backup mount and newest dump verified; disk 39%; worker unit not installed.