### PR TITLE
[PROJ-1755] Fix v4 demo Redis round trip

### DIFF
--- a/src/demo/store.ts
+++ b/src/demo/store.ts
@@ -160,6 +160,7 @@ const StoredCorpusSchema = z.object({
     publicationPolicy: z.object({
       urlDedupEnabled: z.boolean(),
       minimumOriginalTextLength: z.number().finite().nonnegative(),
+      minimumRelevance: z.number().finite().min(0).max(1),
       decay: z.array(z.number().finite().positive().max(1)).min(1),
     }).strict(),
   }).optional(),

--- a/tests/demo-shadow-store.test.ts
+++ b/tests/demo-shadow-store.test.ts
@@ -80,6 +80,44 @@ describe('Redis shadow demo store', () => {
     await expect(store.readSession('partial')).rejects.toBeInstanceOf(DemoStoreCorruptionError);
   });
 
+  it('round-trips the v4 publication policy from Redis', async () => {
+    const session = storedSession();
+    session.communityId = 'community_gov';
+    session.corpus.communityId = 'community_gov';
+    session.corpus.sourceSnapshot = {
+      feedName: 'Community Governed Feed',
+      digest: 'a'.repeat(64),
+      runId: 'run-v4',
+      updatedAt: '2026-07-10T00:00:00.000Z',
+      capturedAt: '2026-07-10T00:01:00.000Z',
+      reviewedAt: '2026-07-10T00:02:00.000Z',
+      sourcePostCount: 100,
+      selectionPolicyVersion: 'community-gov-reviewer-safe-v1',
+      baselineOrderDigest: 'b'.repeat(64),
+      publicationPolicy: {
+        urlDedupEnabled: true,
+        minimumOriginalTextLength: 200,
+        minimumRelevance: 0.25,
+        decay: [1, 0.7, 0.5, 0.3],
+      },
+    };
+    const { corpus, ...header } = session;
+    const get = vi.fn()
+      .mockResolvedValueOnce(JSON.stringify(header))
+      .mockResolvedValueOnce(JSON.stringify(corpus));
+    const store = new RedisDemoStore({ get } as unknown as Redis);
+
+    await expect(store.readSession(session.sessionId)).resolves.toMatchObject({
+      corpus: {
+        sourceSnapshot: {
+          publicationPolicy: {
+            minimumRelevance: 0.25,
+          },
+        },
+      },
+    });
+  });
+
   it('reads retry-safe session creation nonce mappings from Redis', async () => {
     const get = vi.fn()
       .mockResolvedValueOnce('demo-existing-session')


### PR DESCRIPTION
## Summary

Fix the production v4 demo session round trip. Session creation writes `sourceSnapshot.publicationPolicy.minimumRelevance`, but the strict Redis read schema omitted that field and rejected every subsequent session read.

## Changes

- accept the existing bounded `minimumRelevance` field in the stored publication policy schema
- add a Redis deserialize regression covering the full v4 publication policy

## Verification

- `set -a; source .env.example; set +a; npx vitest tests/demo-shadow-store.test.ts tests/demo-v4-routes.test.ts --run` — 31 passed
- `npm run build` — passed
- `git diff --check` — passed
- local CodeRabbit light review was bounded after three minutes of summarization; no findings were emitted or stored, so hosted exact-head review remains required

## Production receipt

The deployed v4 create endpoint returned `200`, then `GET` failed public-safely with correlation ID `88476e0b`. Journald identified `DemoStoreCorruptionError` on the omitted `minimumRelevance` key. Demo state remains isolated from production governance and feed keys.