### PR TITLE
[PROJ-1755] Align production smoke with v4 demo

### DIFF
--- a/web-next/e2e/production-hard-refresh.spec.ts
+++ b/web-next/e2e/production-hard-refresh.spec.ts
@@ -18,7 +18,7 @@ interface RouteFailure {
 
 const PUBLIC_ROUTES: readonly PublicRoute[] = [
   { path: "/", heading: /Make Bluesky care about what your community cares about/i },
-  { path: "/demo/", heading: /Watch a community re-rank its own feed/i },
+  { path: "/demo/", heading: /Re-rank a frozen Community Governed Feed snapshot/i },
   { path: "/how-it-works/", heading: /Watch the same posts become a different feed/i },
   { path: "/start/", heading: /Add the Corgi feed in Bluesky/i },
 ]


### PR DESCRIPTION
## Summary
- update the production hard-refresh smoke expectation to the shipped v4 demo heading
- keep the test aligned with the reviewer-safe Community Governed Feed narrative

## Verification
- web-next lint
- web-next TypeScript check
- production hard-refresh Playwright: 2 passed (desktop and mobile)

Linear: PROJ-1755