### PR TITLE
[PROJ-1795] Keep demo voting controls reachable

### DIFF
--- a/ops/receipts/2026-07-12/PROJ-1795/validation.md
+++ b/ops/receipts/2026-07-12/PROJ-1795/validation.md
@@ -1,0 +1,34 @@
+# PROJ-1795 validation receipt
+
+Date: 2026-07-12 (America/Los_Angeles)
+Repository: `andrewnordstrom-eng/bluesky-community-feed`
+Pull request: https://github.com/andrewnordstrom-eng/bluesky-community-feed/pull/346
+Validated implementation head before this receipt: `aded410bcdb12b0abc65d70aa1631494491def9b`
+
+## Delivered behavior
+
+The desktop demo vote panel is bounded to the available viewport. Its policy
+controls scroll independently when all 26 topics are open, while the vote
+action remains outside that scrolling area and stays reachable. Tablet and
+mobile keep the existing natural document flow.
+
+## Verification
+
+- Focused demo release-blocker suite: 7 tests passed.
+- Full deterministic repository verification: 142 files and 1,518 tests passed.
+- Root, CLI, SDK, legacy web, and `web-next` builds passed.
+- `web-next` lint and TypeScript checks passed.
+- Desktop QA at 1440x1100 measured 1,960px of topic content inside a 919px
+  scroll viewport; the vote action remained visible with 16px bottom clearance.
+- Tablet 756x762 and mobile 390x844 retained natural overflow and had no
+  horizontal page overflow.
+- Vote submission advanced to the 24-voter simulation step with no browser
+  console errors.
+- Hosted exact-head CodeRabbit, freshness/thread checks, backend/frontend CI,
+  CodeQL, security, secrets, docs, policy, and quality gates passed.
+
+## Safety
+
+This change does not alter demo APIs, governance math, corpora, receipts,
+production feed publication, or the separately leased deployment workflow.
+No review or merge gate was bypassed.

--- a/web-next/app/demo/__tests__/frontend-release-blockers.test.tsx
+++ b/web-next/app/demo/__tests__/frontend-release-blockers.test.tsx
@@ -31,6 +31,10 @@ const snapshotProvenance: ShadowDemoCorpusProvenance = {
 }
 
 const demoPageSource = readFileSync(new URL("../page.tsx", import.meta.url), "utf8")
+const votePanelSource = readFileSync(
+  new URL("../../../components/demo/vote-panel.tsx", import.meta.url),
+  "utf8",
+)
 
 function makeFeed(overrides: Partial<ShadowDemoFeed>): ShadowDemoFeed {
   return {
@@ -136,5 +140,13 @@ describe("demo v4 frontend release blockers", () => {
       /\[mobileView, receiptFocusRequest, reduceMotion, reranked, selectedUri\]/,
     )
     expect(demoPageSource).toMatch(/aria-live="polite" aria-atomic="true"[\s\S]*?\{receiptAnnouncement\}/)
+  })
+
+  it("keeps expanded desktop voting controls independently scrollable with the action visible", () => {
+    expect(votePanelSource).toMatch(/xl:max-h-\[calc\(100dvh-7rem\)\]/)
+    expect(votePanelSource).toMatch(/xl:overflow-y-auto/)
+    expect(votePanelSource).toMatch(/xl:overscroll-contain/)
+    expect(votePanelSource).toMatch(/xl:\[scrollbar-gutter:stable\]/)
+    expect(votePanelSource).toMatch(/xl:shrink-0[\s\S]*?STEP_PANELS\.vote\.cta/)
   })
 })

--- a/web-next/components/demo/vote-panel.tsx
+++ b/web-next/components/demo/vote-panel.tsx
@@ -94,102 +94,110 @@ export function VotePanel({
   }
 
   return (
-    <div>
-      <h2 className="font-display text-2xl font-bold leading-tight text-foreground">{STEP_PANELS.vote.heading}</h2>
-      <p className="mt-2 text-sm leading-relaxed text-foreground/60">{STEP_PANELS.vote.body}</p>
+    <div className="xl:flex xl:max-h-[calc(100dvh-7rem)] xl:min-h-0 xl:flex-col">
+      <div
+        role="region"
+        aria-label="Demo policy controls"
+        className="xl:min-h-0 xl:flex-1 xl:overflow-y-auto xl:overscroll-contain xl:pr-2 xl:[scrollbar-gutter:stable]"
+      >
+        <h2 className="font-display text-2xl font-bold leading-tight text-foreground">{STEP_PANELS.vote.heading}</h2>
+        <p className="mt-2 text-sm leading-relaxed text-foreground/60">{STEP_PANELS.vote.body}</p>
 
-      <div className="mt-5 grid gap-2 sm:grid-cols-2">
-        {DEMO_VOTE_PRESETS.map((entry) => {
-          const active = entry.id === presetId && custom === null
-          return (
-            <button key={entry.id} type="button" onClick={() => selectPreset(entry.id)} aria-pressed={active}
-              className={`rounded-2xl border px-4 py-3 text-left transition-colors ${FOCUS} ${active ? "border-primary/40 bg-primary/[0.075] text-foreground" : "border-border bg-background text-foreground/75 hover:border-primary/25 hover:text-foreground"}`}>
-              <span className="block text-sm font-bold">{entry.label}</span>
-              <span className="mt-1 block text-xs leading-relaxed text-foreground/55">{entry.summary}</span>
+        <div className="mt-5 grid gap-2 sm:grid-cols-2">
+          {DEMO_VOTE_PRESETS.map((entry) => {
+            const active = entry.id === presetId && custom === null
+            return (
+              <button key={entry.id} type="button" onClick={() => selectPreset(entry.id)} aria-pressed={active}
+                className={`rounded-2xl border px-4 py-3 text-left transition-colors ${FOCUS} ${active ? "border-primary/40 bg-primary/[0.075] text-foreground" : "border-border bg-background text-foreground/75 hover:border-primary/25 hover:text-foreground"}`}>
+                <span className="block text-sm font-bold">{entry.label}</span>
+                <span className="mt-1 block text-xs leading-relaxed text-foreground/55">{entry.summary}</span>
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="mt-5 rounded-2xl border border-border bg-biscuit/30 px-4 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-[10px] font-mono uppercase tracking-[0.2em] text-foreground/45">{custom === null ? "Preset policy" : "Your custom policy"}</p>
+            <button type="button" onClick={() => setShowFineTune((value) => !value)} aria-expanded={showFineTune}
+              className={`inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1 text-xs font-semibold text-foreground/70 transition-colors hover:text-foreground ${FOCUS}`}>
+              <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+              {showFineTune ? "Close fine-tune" : "Fine-tune"}
             </button>
-          )
-        })}
+          </div>
+          <div className="mt-3"><WeightBars weights={previewWeights} /></div>
+          <div className="mt-4 border-t border-border/60 pt-4">
+            <TopicPolicy topicIntent={topicIntent} baselineTopicIntent={baselineTopicIntent} catalog={topicCatalog} label={`Topic priorities · ${topicCatalog.length} available`} />
+          </div>
+
+          {showFineTune ? (
+            <div className="mt-4 border-t border-border/60 pt-4">
+              <div className="grid grid-cols-2 rounded-lg border border-border bg-background p-1">
+                <button type="button" onClick={() => setFineTuneTab("signals")} aria-pressed={fineTuneTab === "signals"}
+                  className={`min-h-10 rounded-md px-3 text-xs font-semibold ${FOCUS} ${fineTuneTab === "signals" ? "bg-biscuit/60 text-foreground" : "text-foreground/60"}`}>Signals (5)</button>
+                <button type="button" onClick={() => setFineTuneTab("topics")} aria-pressed={fineTuneTab === "topics"}
+                  className={`min-h-10 rounded-md px-3 text-xs font-semibold ${FOCUS} ${fineTuneTab === "topics" ? "bg-biscuit/60 text-foreground" : "text-foreground/60"}`}>Topics ({topicCatalog.length})</button>
+              </div>
+
+              {fineTuneTab === "signals" ? (
+                <div className="mt-4 flex flex-col gap-3">
+                  {SHADOW_DEMO_SIGNAL_KEYS.map((key) => (
+                    <label key={key} className="grid grid-cols-[104px_minmax(0,1fr)_44px] items-center gap-3">
+                      <span className="truncate text-xs font-semibold text-foreground/70">{SIGNAL_LABELS[key]}</span>
+                      <input type="range" min={0} max={1} step={0.01} value={rawWeights[key]} onChange={(event) => setSignal(key, Number(event.target.value))}
+                        style={{ accentColor: SIGNAL_COLORS[key] }} className={`w-full ${FOCUS}`} aria-label={`${SIGNAL_LABELS[key]} weight`} />
+                      <span className="text-right font-mono text-xs font-semibold text-foreground/55">{formatPercent(previewWeights[key])}</span>
+                    </label>
+                  ))}
+                  {sum <= 0 ? <p className="text-xs font-medium text-primary">Give at least one signal some weight to cast a vote.</p> : null}
+                </div>
+              ) : (
+                <div className="mt-4">
+                  <div className="flex flex-wrap gap-2">
+                    <label className="relative min-w-[180px] flex-1">
+                      <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-foreground/40" aria-hidden="true" />
+                      <input value={topicQuery} onChange={(event) => setTopicQuery(event.target.value)} placeholder="Search topics" aria-label="Search topics" className={`h-10 w-full rounded-lg border border-border bg-background pl-9 pr-3 text-xs ${FOCUS}`} />
+                    </label>
+                    <select value={topicSort} onChange={(event) => setTopicSort(event.target.value as "alphabetical" | "weight")} className={`h-10 rounded-lg border border-border bg-background px-3 text-xs ${FOCUS}`} aria-label="Sort topics">
+                      <option value="weight">Current weight</option><option value="alphabetical">Alphabetical</option>
+                    </select>
+                    <label className="inline-flex h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-xs font-medium text-foreground/70">
+                      <input type="checkbox" checked={changedOnly} onChange={(event) => setChangedOnly(event.target.checked)} />Changed only
+                    </label>
+                    <button type="button" onClick={resetTopics} className={`inline-flex h-10 items-center gap-1.5 rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground/70 ${FOCUS}`}>
+                      <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />Reset
+                    </button>
+                  </div>
+                  <div className="mt-4 grid gap-3 md:grid-cols-2">
+                    {visibleTopics.map((topic) => {
+                      const value = topicIntent.topicWeights[topic.slug] ?? topic.baselineWeight
+                      return (
+                        <label key={topic.slug} className="rounded-lg border border-border/70 bg-background px-3 py-2.5">
+                          <span className="flex items-center justify-between gap-2 text-xs"><span className="font-semibold text-foreground/75">{topicLabel(topic.slug, topicCatalog)}</span><span className="font-mono text-foreground/55">{formatPercent(value)}</span></span>
+                          <input type="range" min={0} max={1} step={0.01} value={value} onChange={(event) => setTopic(topic.slug, Number(event.target.value))} className={`mt-2 w-full ${FOCUS}`} aria-label={`${topic.name} topic weight`} />
+                        </label>
+                      )
+                    })}
+                  </div>
+                  {visibleTopics.length === 0 ? <p className="mt-4 text-xs text-foreground/55">No topics match these filters.</p> : null}
+                </div>
+              )}
+            </div>
+          ) : null}
+        </div>
       </div>
 
-      <div className="mt-5 rounded-2xl border border-border bg-biscuit/30 px-4 py-4">
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-[10px] font-mono uppercase tracking-[0.2em] text-foreground/45">{custom === null ? "Preset policy" : "Your custom policy"}</p>
-          <button type="button" onClick={() => setShowFineTune((value) => !value)} aria-expanded={showFineTune}
-            className={`inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1 text-xs font-semibold text-foreground/70 transition-colors hover:text-foreground ${FOCUS}`}>
-            <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
-            {showFineTune ? "Close fine-tune" : "Fine-tune"}
-          </button>
-        </div>
-        <div className="mt-3"><WeightBars weights={previewWeights} /></div>
-        <div className="mt-4 border-t border-border/60 pt-4">
-          <TopicPolicy topicIntent={topicIntent} baselineTopicIntent={baselineTopicIntent} catalog={topicCatalog} label={`Topic priorities · ${topicCatalog.length} available`} />
-        </div>
-
-        {showFineTune ? (
-          <div className="mt-4 border-t border-border/60 pt-4">
-            <div className="grid grid-cols-2 rounded-lg border border-border bg-background p-1">
-              <button type="button" onClick={() => setFineTuneTab("signals")} aria-pressed={fineTuneTab === "signals"}
-                className={`min-h-10 rounded-md px-3 text-xs font-semibold ${FOCUS} ${fineTuneTab === "signals" ? "bg-biscuit/60 text-foreground" : "text-foreground/60"}`}>Signals (5)</button>
-              <button type="button" onClick={() => setFineTuneTab("topics")} aria-pressed={fineTuneTab === "topics"}
-                className={`min-h-10 rounded-md px-3 text-xs font-semibold ${FOCUS} ${fineTuneTab === "topics" ? "bg-biscuit/60 text-foreground" : "text-foreground/60"}`}>Topics ({topicCatalog.length})</button>
-            </div>
-
-            {fineTuneTab === "signals" ? (
-              <div className="mt-4 flex flex-col gap-3">
-                {SHADOW_DEMO_SIGNAL_KEYS.map((key) => (
-                  <label key={key} className="grid grid-cols-[104px_minmax(0,1fr)_44px] items-center gap-3">
-                    <span className="truncate text-xs font-semibold text-foreground/70">{SIGNAL_LABELS[key]}</span>
-                    <input type="range" min={0} max={1} step={0.01} value={rawWeights[key]} onChange={(event) => setSignal(key, Number(event.target.value))}
-                      style={{ accentColor: SIGNAL_COLORS[key] }} className={`w-full ${FOCUS}`} aria-label={`${SIGNAL_LABELS[key]} weight`} />
-                    <span className="text-right font-mono text-xs font-semibold text-foreground/55">{formatPercent(previewWeights[key])}</span>
-                  </label>
-                ))}
-                {sum <= 0 ? <p className="text-xs font-medium text-primary">Give at least one signal some weight to cast a vote.</p> : null}
-              </div>
-            ) : (
-              <div className="mt-4">
-                <div className="flex flex-wrap gap-2">
-                  <label className="relative min-w-[180px] flex-1">
-                    <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-foreground/40" aria-hidden="true" />
-                    <input value={topicQuery} onChange={(event) => setTopicQuery(event.target.value)} placeholder="Search topics" aria-label="Search topics" className={`h-10 w-full rounded-lg border border-border bg-background pl-9 pr-3 text-xs ${FOCUS}`} />
-                  </label>
-                  <select value={topicSort} onChange={(event) => setTopicSort(event.target.value as "alphabetical" | "weight")} className={`h-10 rounded-lg border border-border bg-background px-3 text-xs ${FOCUS}`} aria-label="Sort topics">
-                    <option value="weight">Current weight</option><option value="alphabetical">Alphabetical</option>
-                  </select>
-                  <label className="inline-flex h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-xs font-medium text-foreground/70">
-                    <input type="checkbox" checked={changedOnly} onChange={(event) => setChangedOnly(event.target.checked)} />Changed only
-                  </label>
-                  <button type="button" onClick={resetTopics} className={`inline-flex h-10 items-center gap-1.5 rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground/70 ${FOCUS}`}>
-                    <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />Reset
-                  </button>
-                </div>
-                <div className="mt-4 grid gap-3 md:grid-cols-2">
-                  {visibleTopics.map((topic) => {
-                    const value = topicIntent.topicWeights[topic.slug] ?? topic.baselineWeight
-                    return (
-                      <label key={topic.slug} className="rounded-lg border border-border/70 bg-background px-3 py-2.5">
-                        <span className="flex items-center justify-between gap-2 text-xs"><span className="font-semibold text-foreground/75">{topicLabel(topic.slug, topicCatalog)}</span><span className="font-mono text-foreground/55">{formatPercent(value)}</span></span>
-                        <input type="range" min={0} max={1} step={0.01} value={value} onChange={(event) => setTopic(topic.slug, Number(event.target.value))} className={`mt-2 w-full ${FOCUS}`} aria-label={`${topic.name} topic weight`} />
-                      </label>
-                    )
-                  })}
-                </div>
-                {visibleTopics.length === 0 ? <p className="mt-4 text-xs text-foreground/55">No topics match these filters.</p> : null}
-              </div>
-            )}
-          </div>
+      <div className="mt-5 xl:mt-3 xl:shrink-0 xl:border-t xl:border-border/70 xl:bg-background xl:pt-3">
+        <button type="button" onClick={() => onSubmit(normalizeWeights(rawWeights), topicIntent)} disabled={!canSubmit}
+          className={`inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-[0_2px_8px_rgba(200,97,44,0.25)] transition-colors hover:bg-primary-dark disabled:opacity-60 ${FOCUS}`}>
+          {busy ? "Casting…" : STEP_PANELS.vote.cta}
+        </button>
+        {topicMismatch ? (
+          <p className="mt-2 text-xs font-medium text-primary" role="alert">
+            This snapshot&apos;s complete topic policy is unavailable. Start a new demo session to continue.
+          </p>
         ) : null}
       </div>
-
-      <button type="button" onClick={() => onSubmit(normalizeWeights(rawWeights), topicIntent)} disabled={!canSubmit}
-        className={`mt-5 inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-[0_2px_8px_rgba(200,97,44,0.25)] transition-colors hover:bg-primary-dark disabled:opacity-60 ${FOCUS}`}>
-        {busy ? "Casting…" : STEP_PANELS.vote.cta}
-      </button>
-      {topicMismatch ? (
-        <p className="mt-2 text-xs font-medium text-primary" role="alert">
-          This snapshot&apos;s complete topic policy is unavailable. Start a new demo session to continue.
-        </p>
-      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- bound the desktop demo voting panel to the available viewport
- scroll the policy controls independently while keeping the vote action visible
- preserve natural tablet/mobile document flow
- add a focused release-blocker regression assertion

## Verification
- focused demo release-blocker tests: 7 passed
- web-next lint and TypeScript: passed
- full repository verify: 142 files / 1,518 tests plus all builds passed
- browser QA at 1440x1100, 756x762, and 390x844
- expanded topics: 1,960px scroll content inside a 919px desktop control viewport; CTA remained fully visible
- no horizontal overflow; vote advanced to the 24-voter step; no browser errors

Linear: PROJ-1795