### PR TITLE
[PROJ-1798] Make demo topic sliders trustworthy

### DIFF
--- a/ops/receipts/2026-07-12/PROJ-1798/validation.md
+++ b/ops/receipts/2026-07-12/PROJ-1798/validation.md
@@ -25,14 +25,17 @@ outside the scrolling region.
 
 ## Deterministic Eval
 
-- Focused frontend release-blocker suite: 11 tests passed.
-- Full repository verification: 142 test files and 1,522 tests passed.
+- Focused frontend release-blocker suite: 13 tests passed.
+- Full repository verification: 142 test files and 1,524 tests passed.
 - Root, CLI, SDK, legacy web, and `web-next` builds passed.
 - `web-next` lint and TypeScript checks passed.
 - Documentation verification passed: 14 tracked docs and 37 Markdown files.
 - Contract tests prove ballots contain exactly the 26 catalog topics, preserve
   edited values, normalize the five signal weights, and fail closed for missing
   topics or out-of-range signal values.
+- Review follow-up locks the edit-threshold boundary, reset behavior, raw signal
+  readout semantics, shared ballot validity, friendly submission failure, and
+  multi-thumb Slider rendering.
 - Ballot validation lives in a React-free policy module so the root backend CI
   lane can verify the shared contract without installing frontend packages.
 

--- a/ops/receipts/2026-07-12/PROJ-1798/validation.md
+++ b/ops/receipts/2026-07-12/PROJ-1798/validation.md
@@ -1,0 +1,59 @@
+# PROJ-1798 validation receipt
+
+Date: 2026-07-12 (America/Los_Angeles)
+Repository: `andrewnordstrom-eng/bluesky-community-feed`
+
+## Delivered behavior
+
+The demo now uses one accessible Radix slider system for signal and topic
+policy controls. Topic edits immediately show their value and delta from the
+selected preset, mark the policy as custom, and submit the complete 26-topic
+vector expected by the shadow-governance API. Returning every value to its
+preset restores the preset state.
+
+The Topics tab is a single readable list inside the existing independently
+scrolling vote panel. Mobile controls use a full-width slider row, while tablet
+and desktop retain aligned labels, tracks, and values. The vote action remains
+outside the scrolling region.
+
+## Runtime Health Check
+
+- Local static-export proxy used the production `/api/demo/v4/*` endpoints.
+- An edited topic ballot was accepted and advanced to `Simulate 24 voters`.
+- Browser console remained free of warnings, hydration failures, CSP failures,
+  and raw endpoint errors during keyboard, pointer, reset, and submit checks.
+
+## Deterministic Eval
+
+- Focused frontend release-blocker suite: 11 tests passed.
+- Full repository verification: 142 test files and 1,522 tests passed.
+- Root, CLI, SDK, legacy web, and `web-next` builds passed.
+- `web-next` lint and TypeScript checks passed.
+- Documentation verification passed: 14 tracked docs and 37 Markdown files.
+- Contract tests prove ballots contain exactly the 26 catalog topics, preserve
+  edited values, normalize the five signal weights, and fail closed for missing
+  topics or out-of-range signal values.
+- Ballot validation lives in a React-free policy module so the root backend CI
+  lane can verify the shared contract without installing frontend packages.
+
+The first sandboxed full-suite run could not bind the repository load-test HTTP
+server to `127.0.0.1`. The exact command passed when rerun with local-network
+permission; no product code changed between those runs.
+
+## Live Acceptance
+
+- Keyboard topic edit: 1.00 to 0.99 with accessible value text `99%, -1 pp`.
+- Pointer topic edit: 1.00 to 0.50 with accessible value text `50%, -50 pp`.
+- Reset restored 1.00, `Preset policy`, and `Preset unchanged`.
+- Mobile 390x844: 300px topic slider track and no horizontal overflow.
+- Tablet 756x762: 444px topic slider track and no horizontal overflow.
+- Desktop 1440x1100: bounded independent policy scrolling, reachable vote CTA,
+  and no horizontal overflow.
+- Signals and Topics now share track, thumb, focus, spacing, value, and changed
+  state behavior while retaining signal-specific accent colors.
+
+## Safety
+
+This change is frontend-only. It does not alter demo APIs, governance math,
+corpora, receipts, production feed publication, or backend/deployment paths.
+The strict submission helper rejects malformed ballots before calling the API.

--- a/web-next/app/demo/__tests__/frontend-release-blockers.test.tsx
+++ b/web-next/app/demo/__tests__/frontend-release-blockers.test.tsx
@@ -10,7 +10,10 @@ import {
 import type { ShadowDemoCorpusProvenance, ShadowDemoFeed } from "../shadow-demo-view-model"
 import {
   createDemoVoteSubmission,
+  formatPolicySliderValue,
   getEditedTopicSlugs,
+  POLICY_EDIT_THRESHOLD,
+  validateDemoVoteSubmission,
 } from "../shadow-demo-vote-policy"
 
 const snapshotProvenance: ShadowDemoCorpusProvenance = {
@@ -37,6 +40,10 @@ const snapshotProvenance: ShadowDemoCorpusProvenance = {
 const demoPageSource = readFileSync(new URL("../page.tsx", import.meta.url), "utf8")
 const votePanelSource = readFileSync(
   new URL("../../../components/demo/vote-panel.tsx", import.meta.url),
+  "utf8",
+)
+const sliderSource = readFileSync(
+  new URL("../../../components/ui/slider.tsx", import.meta.url),
   "utf8",
 )
 
@@ -182,6 +189,54 @@ describe("demo v4 frontend release blockers", () => {
     expect(Object.values(submission.weights).reduce((total, value) => total + value, 0)).toBeCloseTo(1)
   })
 
+  it("uses one shared edit threshold and resets edited topics to the preset", () => {
+    const topicCatalog = [{
+      slug: "research",
+      name: "Research",
+      description: null,
+      baselineWeight: 0.5,
+    }]
+    const presetTopicIntent = { topicWeights: { research: 0.5 } }
+
+    expect(getEditedTopicSlugs(
+      { topicWeights: { research: 0.5 + POLICY_EDIT_THRESHOLD } },
+      presetTopicIntent,
+      topicCatalog,
+    )).toEqual(["research"])
+    expect(getEditedTopicSlugs(
+      { topicWeights: { research: 0.5049 } },
+      presetTopicIntent,
+      topicCatalog,
+    )).toEqual([])
+    expect(getEditedTopicSlugs(presetTopicIntent, presetTopicIntent, topicCatalog)).toEqual([])
+  })
+
+  it("shows the raw relative signal setting and validates with the shared ballot rules", () => {
+    const weights = {
+      recency: 0.4,
+      engagement: 0.2,
+      bridging: 0.2,
+      source_diversity: 0.1,
+      relevance: 0.1,
+    }
+    const topicCatalog = [{
+      slug: "research",
+      name: "Research",
+      description: null,
+      baselineWeight: 0.5,
+    }]
+    const validation = validateDemoVoteSubmission(
+      weights,
+      { topicWeights: { research: 0.5 } },
+      topicCatalog,
+    )
+
+    expect(formatPolicySliderValue(weights.recency)).toBe("40%")
+    expect(validation.valid).toBe(true)
+    expect(votePanelSource).toMatch(/displayValue=\{rawWeights\[key\]\}/)
+    expect(votePanelSource).toMatch(/Corgi normalizes them to 100%/)
+  })
+
   it("fails closed when a demo ballot omits a topic", () => {
     const topicCatalog = Array.from({ length: 26 }, (_, index) => ({
       slug: `topic-${index}`,
@@ -223,5 +278,7 @@ describe("demo v4 frontend release blockers", () => {
     expect(votePanelSource).not.toMatch(/<input type="range"/)
     expect(votePanelSource).toMatch(/Your custom policy/)
     expect(votePanelSource).toMatch(/Every ballot carries all/)
+    expect(votePanelSource).toMatch(/onClick=\{submitPolicy\}/)
+    expect(sliderSource).toMatch(/thumbValues\.map/)
   })
 })

--- a/web-next/app/demo/__tests__/frontend-release-blockers.test.tsx
+++ b/web-next/app/demo/__tests__/frontend-release-blockers.test.tsx
@@ -8,6 +8,10 @@ import {
   getReceiptSelectionAnnouncement,
 } from "@/components/demo/live-proof-panel"
 import type { ShadowDemoCorpusProvenance, ShadowDemoFeed } from "../shadow-demo-view-model"
+import {
+  createDemoVoteSubmission,
+  getEditedTopicSlugs,
+} from "../shadow-demo-vote-policy"
 
 const snapshotProvenance: ShadowDemoCorpusProvenance = {
   mode: "production_feed_snapshot_session_frozen",
@@ -148,5 +152,76 @@ describe("demo v4 frontend release blockers", () => {
     expect(votePanelSource).toMatch(/xl:overscroll-contain/)
     expect(votePanelSource).toMatch(/xl:\[scrollbar-gutter:stable\]/)
     expect(votePanelSource).toMatch(/xl:shrink-0[\s\S]*?STEP_PANELS\.vote\.cta/)
+  })
+
+  it("submits a complete 26-topic policy and preserves a fine-tuned value", () => {
+    const topicCatalog = Array.from({ length: 26 }, (_, index) => ({
+      slug: `topic-${index}`,
+      name: `Topic ${index}`,
+      description: null,
+      baselineWeight: 0.5,
+    }))
+    const presetTopicIntent = {
+      topicWeights: Object.fromEntries(topicCatalog.map((topic) => [topic.slug, 0.5])),
+    }
+    const editedTopicIntent = {
+      topicWeights: { ...presetTopicIntent.topicWeights, "topic-7": 0.83 },
+    }
+
+    expect(getEditedTopicSlugs(editedTopicIntent, presetTopicIntent, topicCatalog)).toEqual(["topic-7"])
+    expect(getEditedTopicSlugs(presetTopicIntent, presetTopicIntent, topicCatalog)).toEqual([])
+
+    const submission = createDemoVoteSubmission(
+      { recency: 0.4, engagement: 0.4, bridging: 0.4, source_diversity: 0.4, relevance: 0.4 },
+      editedTopicIntent,
+      topicCatalog,
+    )
+
+    expect(Object.keys(submission.topicIntent.topicWeights)).toHaveLength(26)
+    expect(submission.topicIntent.topicWeights["topic-7"]).toBe(0.83)
+    expect(Object.values(submission.weights).reduce((total, value) => total + value, 0)).toBeCloseTo(1)
+  })
+
+  it("fails closed when a demo ballot omits a topic", () => {
+    const topicCatalog = Array.from({ length: 26 }, (_, index) => ({
+      slug: `topic-${index}`,
+      name: `Topic ${index}`,
+      description: null,
+      baselineWeight: 0.5,
+    }))
+    const incompleteTopicIntent = {
+      topicWeights: Object.fromEntries(topicCatalog.slice(0, 25).map((topic) => [topic.slug, 0.5])),
+    }
+
+    expect(() => createDemoVoteSubmission(
+      { recency: 0.2, engagement: 0.2, bridging: 0.2, source_diversity: 0.2, relevance: 0.2 },
+      incompleteTopicIntent,
+      topicCatalog,
+    )).toThrow(/exactly the 26 catalog topics/i)
+  })
+
+  it("fails closed when a demo signal weight is outside the slider contract", () => {
+    const topicCatalog = Array.from({ length: 26 }, (_, index) => ({
+      slug: `topic-${index}`,
+      name: `Topic ${index}`,
+      description: null,
+      baselineWeight: 0.5,
+    }))
+    const topicIntent = {
+      topicWeights: Object.fromEntries(topicCatalog.map((topic) => [topic.slug, 0.5])),
+    }
+
+    expect(() => createDemoVoteSubmission(
+      { recency: -0.1, engagement: 0.2, bridging: 0.3, source_diversity: 0.3, relevance: 0.3 },
+      topicIntent,
+      topicCatalog,
+    )).toThrow(/signal recency has invalid weight/i)
+  })
+
+  it("uses one accessible slider system for signals and topics", () => {
+    expect(votePanelSource).toMatch(/import \{ Slider \} from "@\/components\/ui\/slider"/)
+    expect(votePanelSource).not.toMatch(/<input type="range"/)
+    expect(votePanelSource).toMatch(/Your custom policy/)
+    expect(votePanelSource).toMatch(/Every ballot carries all/)
   })
 })

--- a/web-next/app/demo/shadow-demo-vote-policy.ts
+++ b/web-next/app/demo/shadow-demo-vote-policy.ts
@@ -1,0 +1,62 @@
+import { normalizeWeights } from "./shadow-demo-fixtures"
+import {
+  SHADOW_DEMO_SIGNAL_KEYS,
+  type ShadowDemoTopicCatalogEntry,
+  type ShadowDemoTopicIntent,
+  type ShadowDemoWeights,
+} from "./shadow-demo-view-model"
+
+function weightSum(weights: ShadowDemoWeights): number {
+  return SHADOW_DEMO_SIGNAL_KEYS.reduce((total, key) => total + weights[key], 0)
+}
+
+export function getEditedTopicSlugs(
+  topicIntent: ShadowDemoTopicIntent,
+  presetTopicIntent: ShadowDemoTopicIntent,
+  topicCatalog: readonly ShadowDemoTopicCatalogEntry[],
+): readonly string[] {
+  return topicCatalog
+    .filter((topic) => Math.abs(
+      (topicIntent.topicWeights[topic.slug] ?? topic.baselineWeight)
+      - (presetTopicIntent.topicWeights[topic.slug] ?? topic.baselineWeight),
+    ) >= 0.005)
+    .map((topic) => topic.slug)
+}
+
+export function createDemoVoteSubmission(
+  rawWeights: ShadowDemoWeights,
+  topicIntent: ShadowDemoTopicIntent,
+  topicCatalog: readonly ShadowDemoTopicCatalogEntry[],
+): { readonly weights: ShadowDemoWeights; readonly topicIntent: ShadowDemoTopicIntent } {
+  for (const key of SHADOW_DEMO_SIGNAL_KEYS) {
+    const value = rawWeights[key]
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new RangeError(`Demo vote signal ${key} has invalid weight: ${String(value)}`)
+    }
+  }
+  if (weightSum(rawWeights) <= 0) {
+    throw new RangeError("Demo vote signal weights must include at least one positive value")
+  }
+
+  const submittedSlugs = Object.keys(topicIntent.topicWeights)
+  const catalogSlugs = new Set(topicCatalog.map((topic) => topic.slug))
+  if (submittedSlugs.length !== topicCatalog.length
+    || submittedSlugs.some((slug) => !catalogSlugs.has(slug))) {
+    throw new RangeError(
+      `Demo vote topic policy must contain exactly the ${topicCatalog.length} catalog topics`,
+    )
+  }
+
+  const topicWeights = Object.fromEntries(topicCatalog.map((topic) => {
+    const value = topicIntent.topicWeights[topic.slug]
+    if (value === undefined || !Number.isFinite(value) || value < 0 || value > 1) {
+      throw new RangeError(`Demo vote topic ${topic.slug} has invalid weight: ${String(value)}`)
+    }
+    return [topic.slug, value]
+  }))
+
+  return {
+    weights: normalizeWeights(rawWeights),
+    topicIntent: { topicWeights },
+  }
+}

--- a/web-next/app/demo/shadow-demo-vote-policy.ts
+++ b/web-next/app/demo/shadow-demo-vote-policy.ts
@@ -1,4 +1,4 @@
-import { normalizeWeights } from "./shadow-demo-fixtures"
+import { formatPercent, normalizeWeights } from "./shadow-demo-fixtures"
 import {
   SHADOW_DEMO_SIGNAL_KEYS,
   type ShadowDemoTopicCatalogEntry,
@@ -6,8 +6,26 @@ import {
   type ShadowDemoWeights,
 } from "./shadow-demo-view-model"
 
+export const POLICY_EDIT_THRESHOLD = 0.005
+
+export type DemoVoteSubmission = {
+  readonly weights: ShadowDemoWeights
+  readonly topicIntent: ShadowDemoTopicIntent
+}
+
+export type DemoVoteSubmissionValidation =
+  | { readonly valid: true; readonly submission: DemoVoteSubmission }
+  | { readonly valid: false; readonly reason: string }
+
 function weightSum(weights: ShadowDemoWeights): number {
   return SHADOW_DEMO_SIGNAL_KEYS.reduce((total, key) => total + weights[key], 0)
+}
+
+export function formatPolicySliderValue(value: number): string {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new RangeError(`Policy slider has invalid value: ${String(value)}`)
+  }
+  return formatPercent(value)
 }
 
 export function getEditedTopicSlugs(
@@ -19,44 +37,64 @@ export function getEditedTopicSlugs(
     .filter((topic) => Math.abs(
       (topicIntent.topicWeights[topic.slug] ?? topic.baselineWeight)
       - (presetTopicIntent.topicWeights[topic.slug] ?? topic.baselineWeight),
-    ) >= 0.005)
+    ) >= POLICY_EDIT_THRESHOLD)
     .map((topic) => topic.slug)
 }
 
-export function createDemoVoteSubmission(
+export function validateDemoVoteSubmission(
   rawWeights: ShadowDemoWeights,
   topicIntent: ShadowDemoTopicIntent,
   topicCatalog: readonly ShadowDemoTopicCatalogEntry[],
-): { readonly weights: ShadowDemoWeights; readonly topicIntent: ShadowDemoTopicIntent } {
+): DemoVoteSubmissionValidation {
   for (const key of SHADOW_DEMO_SIGNAL_KEYS) {
     const value = rawWeights[key]
     if (!Number.isFinite(value) || value < 0 || value > 1) {
-      throw new RangeError(`Demo vote signal ${key} has invalid weight: ${String(value)}`)
+      return { valid: false, reason: `Demo vote signal ${key} has invalid weight: ${String(value)}` }
     }
   }
   if (weightSum(rawWeights) <= 0) {
-    throw new RangeError("Demo vote signal weights must include at least one positive value")
+    return { valid: false, reason: "Demo vote signal weights must include at least one positive value" }
   }
 
   const submittedSlugs = Object.keys(topicIntent.topicWeights)
   const catalogSlugs = new Set(topicCatalog.map((topic) => topic.slug))
   if (submittedSlugs.length !== topicCatalog.length
     || submittedSlugs.some((slug) => !catalogSlugs.has(slug))) {
-    throw new RangeError(
-      `Demo vote topic policy must contain exactly the ${topicCatalog.length} catalog topics`,
-    )
+    return {
+      valid: false,
+      reason: `Demo vote topic policy must contain exactly the ${topicCatalog.length} catalog topics`,
+    }
   }
 
-  const topicWeights = Object.fromEntries(topicCatalog.map((topic) => {
+  const topicWeights: Record<string, number> = {}
+  for (const topic of topicCatalog) {
     const value = topicIntent.topicWeights[topic.slug]
     if (value === undefined || !Number.isFinite(value) || value < 0 || value > 1) {
-      throw new RangeError(`Demo vote topic ${topic.slug} has invalid weight: ${String(value)}`)
+      return {
+        valid: false,
+        reason: `Demo vote topic ${topic.slug} has invalid weight: ${String(value)}`,
+      }
     }
-    return [topic.slug, value]
-  }))
+    topicWeights[topic.slug] = value
+  }
 
   return {
-    weights: normalizeWeights(rawWeights),
-    topicIntent: { topicWeights },
+    valid: true,
+    submission: {
+      weights: normalizeWeights(rawWeights),
+      topicIntent: { topicWeights },
+    },
   }
+}
+
+export function createDemoVoteSubmission(
+  rawWeights: ShadowDemoWeights,
+  topicIntent: ShadowDemoTopicIntent,
+  topicCatalog: readonly ShadowDemoTopicCatalogEntry[],
+): DemoVoteSubmission {
+  const validation = validateDemoVoteSubmission(rawWeights, topicIntent, topicCatalog)
+  if (!validation.valid) {
+    throw new RangeError(validation.reason)
+  }
+  return validation.submission
 }

--- a/web-next/components/demo/vote-panel.tsx
+++ b/web-next/components/demo/vote-panel.tsx
@@ -16,6 +16,11 @@ import {
   normalizeWeights,
 } from "@/app/demo/shadow-demo-fixtures"
 import { STEP_PANELS } from "@/app/demo/shadow-demo-copy"
+import {
+  createDemoVoteSubmission,
+  getEditedTopicSlugs,
+} from "@/app/demo/shadow-demo-vote-policy"
+import { Slider } from "@/components/ui/slider"
 import { TopicPolicy, topicLabel } from "./topic-policy"
 import { WeightBars } from "./weight-bars"
 
@@ -31,6 +36,63 @@ function mergeTopicPolicy(
   overrides: ShadowDemoTopicIntent,
 ): ShadowDemoTopicIntent {
   return { topicWeights: { ...baseline.topicWeights, ...overrides.topicWeights } }
+}
+
+function singleSliderValue(values: readonly number[], label: string): number {
+  const value = values[0]
+  if (values.length !== 1 || value === undefined || !Number.isFinite(value)) {
+    throw new RangeError(`${label} slider produced an invalid value: ${JSON.stringify(values)}`)
+  }
+  return value
+}
+
+function formatPointDelta(value: number): string {
+  const points = Math.round(value * 100)
+  return `${points > 0 ? "+" : ""}${points} pp`
+}
+
+function PolicySlider({
+  label,
+  ariaLabel,
+  value,
+  displayValue,
+  accentColor,
+  detail,
+  changed,
+  onChange,
+}: {
+  readonly label: string
+  readonly ariaLabel: string
+  readonly value: number
+  readonly displayValue: number
+  readonly accentColor: string
+  readonly detail: string | null
+  readonly changed: boolean
+  readonly onChange: (value: number) => void
+}) {
+  const percent = formatPercent(displayValue)
+  return (
+    <div className={`grid grid-cols-[minmax(0,1fr)_58px] items-center gap-x-3 rounded-lg px-2 py-1 transition-colors sm:grid-cols-[minmax(0,140px)_minmax(0,1fr)_58px] ${changed ? "bg-primary/[0.07]" : "bg-transparent"}`}>
+      <span className="col-start-1 row-start-1 min-w-0 text-xs font-semibold leading-tight text-foreground/70">{label}</span>
+      <Slider
+        min={0}
+        max={1}
+        step={0.01}
+        value={[value]}
+        onValueChange={(values) => onChange(singleSliderValue(values, ariaLabel))}
+        accentColor={accentColor}
+        ariaLabel={ariaLabel}
+        ariaValueText={`${percent}${detail === null ? "" : `, ${detail}`}`}
+        className="col-span-2 col-start-1 row-start-2 sm:col-span-1 sm:col-start-2 sm:row-start-1"
+      />
+      <span className="col-start-2 row-start-1 text-right font-mono text-xs font-semibold leading-tight text-foreground/60 sm:col-start-3">
+        <span className="block">{percent}</span>
+        {detail === null ? null : (
+          <span className="mt-0.5 block text-[9px] font-medium text-primary">{detail}</span>
+        )}
+      </span>
+    </div>
+  )
 }
 
 export function VotePanel({
@@ -55,6 +117,10 @@ export function VotePanel({
   const [changedOnly, setChangedOnly] = useState(false)
 
   const preset = DEMO_VOTE_PRESETS.find((entry) => entry.id === presetId) ?? DEMO_VOTE_PRESETS[0]
+  const presetTopicIntent = useMemo(
+    () => mergeTopicPolicy(baselineTopicIntent, preset.topicIntent),
+    [baselineTopicIntent, preset.topicIntent],
+  )
   const rawWeights = custom ?? preset.weights
   const sum = weightSum(rawWeights)
   const topicSlugs = new Set(topicCatalog.map((topic) => topic.slug))
@@ -65,6 +131,15 @@ export function VotePanel({
     && !busy
     && !topicMismatch
   const previewWeights = useMemo(() => (sum > 0 ? normalizeWeights(rawWeights) : rawWeights), [rawWeights, sum])
+  const editedTopicSlugs = useMemo(
+    () => getEditedTopicSlugs(topicIntent, presetTopicIntent, topicCatalog),
+    [presetTopicIntent, topicCatalog, topicIntent],
+  )
+  const editedTopicSlugSet = useMemo(() => new Set(editedTopicSlugs), [editedTopicSlugs])
+  const editedSignalKeys = SHADOW_DEMO_SIGNAL_KEYS.filter(
+    (key) => Math.abs(rawWeights[key] - preset.weights[key]) >= 0.005,
+  )
+  const customPolicy = editedSignalKeys.length > 0 || editedTopicSlugs.length > 0
   const visibleTopics = useMemo(() => topicCatalog
     .filter((topic) => topic.name.toLowerCase().includes(topicQuery.toLowerCase()) || topic.slug.includes(topicQuery.toLowerCase()))
     .filter((topic) => !changedOnly || Math.abs((topicIntent.topicWeights[topic.slug] ?? topic.baselineWeight) - topic.baselineWeight) >= 0.005)
@@ -105,7 +180,7 @@ export function VotePanel({
 
         <div className="mt-5 grid gap-2 sm:grid-cols-2">
           {DEMO_VOTE_PRESETS.map((entry) => {
-            const active = entry.id === presetId && custom === null
+            const active = entry.id === presetId && !customPolicy
             return (
               <button key={entry.id} type="button" onClick={() => selectPreset(entry.id)} aria-pressed={active}
                 className={`rounded-2xl border px-4 py-3 text-left transition-colors ${FOCUS} ${active ? "border-primary/40 bg-primary/[0.075] text-foreground" : "border-border bg-background text-foreground/75 hover:border-primary/25 hover:text-foreground"}`}>
@@ -118,7 +193,7 @@ export function VotePanel({
 
         <div className="mt-5 rounded-2xl border border-border bg-biscuit/30 px-4 py-4">
           <div className="flex items-center justify-between gap-3">
-            <p className="text-[10px] font-mono uppercase tracking-[0.2em] text-foreground/45">{custom === null ? "Preset policy" : "Your custom policy"}</p>
+            <p className="text-[10px] font-mono uppercase tracking-[0.2em] text-foreground/45">{customPolicy ? "Your custom policy" : "Preset policy"}</p>
             <button type="button" onClick={() => setShowFineTune((value) => !value)} aria-expanded={showFineTune}
               className={`inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1 text-xs font-semibold text-foreground/70 transition-colors hover:text-foreground ${FOCUS}`}>
               <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
@@ -140,19 +215,30 @@ export function VotePanel({
               </div>
 
               {fineTuneTab === "signals" ? (
-                <div className="mt-4 flex flex-col gap-3">
+                <div className="mt-4 flex flex-col gap-1">
                   {SHADOW_DEMO_SIGNAL_KEYS.map((key) => (
-                    <label key={key} className="grid grid-cols-[104px_minmax(0,1fr)_44px] items-center gap-3">
-                      <span className="truncate text-xs font-semibold text-foreground/70">{SIGNAL_LABELS[key]}</span>
-                      <input type="range" min={0} max={1} step={0.01} value={rawWeights[key]} onChange={(event) => setSignal(key, Number(event.target.value))}
-                        style={{ accentColor: SIGNAL_COLORS[key] }} className={`w-full ${FOCUS}`} aria-label={`${SIGNAL_LABELS[key]} weight`} />
-                      <span className="text-right font-mono text-xs font-semibold text-foreground/55">{formatPercent(previewWeights[key])}</span>
-                    </label>
+                    <PolicySlider
+                      key={key}
+                      label={SIGNAL_LABELS[key]}
+                      ariaLabel={`${SIGNAL_LABELS[key]} weight`}
+                      value={rawWeights[key]}
+                      displayValue={previewWeights[key]}
+                      accentColor={SIGNAL_COLORS[key]}
+                      detail={null}
+                      changed={editedSignalKeys.includes(key)}
+                      onChange={(value) => setSignal(key, value)}
+                    />
                   ))}
                   {sum <= 0 ? <p className="text-xs font-medium text-primary">Give at least one signal some weight to cast a vote.</p> : null}
                 </div>
               ) : (
                 <div className="mt-4">
+                  <div className="mb-3 flex items-start justify-between gap-4 text-xs leading-relaxed text-foreground/55">
+                    <p>Topic weights shape the relevance signal. Every ballot carries all {topicCatalog.length} values.</p>
+                    <p className="shrink-0 font-mono text-[10px] uppercase tracking-[0.12em] text-primary">
+                      {editedTopicSlugs.length === 0 ? "Preset unchanged" : `${editedTopicSlugs.length} fine-tuned`}
+                    </p>
+                  </div>
                   <div className="flex flex-wrap gap-2">
                     <label className="relative min-w-[180px] flex-1">
                       <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-foreground/40" aria-hidden="true" />
@@ -162,20 +248,29 @@ export function VotePanel({
                       <option value="weight">Current weight</option><option value="alphabetical">Alphabetical</option>
                     </select>
                     <label className="inline-flex h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-xs font-medium text-foreground/70">
-                      <input type="checkbox" checked={changedOnly} onChange={(event) => setChangedOnly(event.target.checked)} />Changed only
+                      <input type="checkbox" checked={changedOnly} onChange={(event) => setChangedOnly(event.target.checked)} aria-label="Show topics different from live policy" />Different from live
                     </label>
                     <button type="button" onClick={resetTopics} className={`inline-flex h-10 items-center gap-1.5 rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground/70 ${FOCUS}`}>
-                      <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />Reset
+                      <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />Reset preset
                     </button>
                   </div>
-                  <div className="mt-4 grid gap-3 md:grid-cols-2">
+                  <div className="mt-3 grid gap-y-1">
                     {visibleTopics.map((topic) => {
                       const value = topicIntent.topicWeights[topic.slug] ?? topic.baselineWeight
+                      const presetValue = presetTopicIntent.topicWeights[topic.slug] ?? topic.baselineWeight
+                      const edited = editedTopicSlugSet.has(topic.slug)
                       return (
-                        <label key={topic.slug} className="rounded-lg border border-border/70 bg-background px-3 py-2.5">
-                          <span className="flex items-center justify-between gap-2 text-xs"><span className="font-semibold text-foreground/75">{topicLabel(topic.slug, topicCatalog)}</span><span className="font-mono text-foreground/55">{formatPercent(value)}</span></span>
-                          <input type="range" min={0} max={1} step={0.01} value={value} onChange={(event) => setTopic(topic.slug, Number(event.target.value))} className={`mt-2 w-full ${FOCUS}`} aria-label={`${topic.name} topic weight`} />
-                        </label>
+                        <PolicySlider
+                          key={topic.slug}
+                          label={topicLabel(topic.slug, topicCatalog)}
+                          ariaLabel={`${topic.name} topic weight`}
+                          value={value}
+                          displayValue={value}
+                          accentColor="hsl(var(--primary))"
+                          detail={edited ? formatPointDelta(value - presetValue) : null}
+                          changed={edited}
+                          onChange={(nextValue) => setTopic(topic.slug, nextValue)}
+                        />
                       )
                     })}
                   </div>
@@ -188,7 +283,10 @@ export function VotePanel({
       </div>
 
       <div className="mt-5 xl:mt-3 xl:shrink-0 xl:border-t xl:border-border/70 xl:bg-background xl:pt-3">
-        <button type="button" onClick={() => onSubmit(normalizeWeights(rawWeights), topicIntent)} disabled={!canSubmit}
+        <button type="button" onClick={() => {
+          const submission = createDemoVoteSubmission(rawWeights, topicIntent, topicCatalog)
+          onSubmit(submission.weights, submission.topicIntent)
+        }} disabled={!canSubmit}
           className={`inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-[0_2px_8px_rgba(200,97,44,0.25)] transition-colors hover:bg-primary-dark disabled:opacity-60 ${FOCUS}`}>
           {busy ? "Casting…" : STEP_PANELS.vote.cta}
         </button>

--- a/web-next/components/demo/vote-panel.tsx
+++ b/web-next/components/demo/vote-panel.tsx
@@ -12,13 +12,15 @@ import {
   DEMO_VOTE_PRESETS,
   SIGNAL_COLORS,
   SIGNAL_LABELS,
-  formatPercent,
   normalizeWeights,
 } from "@/app/demo/shadow-demo-fixtures"
 import { STEP_PANELS } from "@/app/demo/shadow-demo-copy"
 import {
   createDemoVoteSubmission,
+  formatPolicySliderValue,
   getEditedTopicSlugs,
+  POLICY_EDIT_THRESHOLD,
+  validateDemoVoteSubmission,
 } from "@/app/demo/shadow-demo-vote-policy"
 import { Slider } from "@/components/ui/slider"
 import { TopicPolicy, topicLabel } from "./topic-policy"
@@ -70,7 +72,7 @@ function PolicySlider({
   readonly changed: boolean
   readonly onChange: (value: number) => void
 }) {
-  const percent = formatPercent(displayValue)
+  const percent = formatPolicySliderValue(displayValue)
   return (
     <div className={`grid grid-cols-[minmax(0,1fr)_58px] items-center gap-x-3 rounded-lg px-2 py-1 transition-colors sm:grid-cols-[minmax(0,140px)_minmax(0,1fr)_58px] ${changed ? "bg-primary/[0.07]" : "bg-transparent"}`}>
       <span className="col-start-1 row-start-1 min-w-0 text-xs font-semibold leading-tight text-foreground/70">{label}</span>
@@ -115,6 +117,7 @@ export function VotePanel({
   const [topicQuery, setTopicQuery] = useState("")
   const [topicSort, setTopicSort] = useState<"alphabetical" | "weight">("weight")
   const [changedOnly, setChangedOnly] = useState(false)
+  const [submissionError, setSubmissionError] = useState<string | null>(null)
 
   const preset = DEMO_VOTE_PRESETS.find((entry) => entry.id === presetId) ?? DEMO_VOTE_PRESETS[0]
   const presetTopicIntent = useMemo(
@@ -123,13 +126,11 @@ export function VotePanel({
   )
   const rawWeights = custom ?? preset.weights
   const sum = weightSum(rawWeights)
-  const topicSlugs = new Set(topicCatalog.map((topic) => topic.slug))
-  const submittedTopicSlugs = Object.keys(topicIntent.topicWeights)
-  const topicMismatch = submittedTopicSlugs.length !== topicCatalog.length
-    || submittedTopicSlugs.some((slug) => !topicSlugs.has(slug))
-  const canSubmit = sum > 0
-    && !busy
-    && !topicMismatch
+  const ballotValidation = useMemo(
+    () => validateDemoVoteSubmission(rawWeights, topicIntent, topicCatalog),
+    [rawWeights, topicCatalog, topicIntent],
+  )
+  const canSubmit = !busy && ballotValidation.valid
   const previewWeights = useMemo(() => (sum > 0 ? normalizeWeights(rawWeights) : rawWeights), [rawWeights, sum])
   const editedTopicSlugs = useMemo(
     () => getEditedTopicSlugs(topicIntent, presetTopicIntent, topicCatalog),
@@ -137,12 +138,12 @@ export function VotePanel({
   )
   const editedTopicSlugSet = useMemo(() => new Set(editedTopicSlugs), [editedTopicSlugs])
   const editedSignalKeys = SHADOW_DEMO_SIGNAL_KEYS.filter(
-    (key) => Math.abs(rawWeights[key] - preset.weights[key]) >= 0.005,
+    (key) => Math.abs(rawWeights[key] - preset.weights[key]) >= POLICY_EDIT_THRESHOLD,
   )
   const customPolicy = editedSignalKeys.length > 0 || editedTopicSlugs.length > 0
   const visibleTopics = useMemo(() => topicCatalog
     .filter((topic) => topic.name.toLowerCase().includes(topicQuery.toLowerCase()) || topic.slug.includes(topicQuery.toLowerCase()))
-    .filter((topic) => !changedOnly || Math.abs((topicIntent.topicWeights[topic.slug] ?? topic.baselineWeight) - topic.baselineWeight) >= 0.005)
+    .filter((topic) => !changedOnly || Math.abs((topicIntent.topicWeights[topic.slug] ?? topic.baselineWeight) - topic.baselineWeight) >= POLICY_EDIT_THRESHOLD)
     .sort((left, right) => topicSort === "alphabetical"
       ? left.name.localeCompare(right.name)
       : (topicIntent.topicWeights[right.slug] ?? right.baselineWeight) - (topicIntent.topicWeights[left.slug] ?? left.baselineWeight)),
@@ -154,18 +155,37 @@ export function VotePanel({
     setPresetId(id)
     setCustom(null)
     setTopicIntent(mergeTopicPolicy(baselineTopicIntent, next.topicIntent))
+    setSubmissionError(null)
   }
 
   function setSignal(key: (typeof SHADOW_DEMO_SIGNAL_KEYS)[number], value: number): void {
     setCustom({ ...rawWeights, [key]: value })
+    setSubmissionError(null)
   }
 
   function setTopic(slug: string, value: number): void {
     setTopicIntent({ topicWeights: { ...topicIntent.topicWeights, [slug]: value } })
+    setSubmissionError(null)
   }
 
   function resetTopics(): void {
     setTopicIntent(mergeTopicPolicy(baselineTopicIntent, preset.topicIntent))
+    setSubmissionError(null)
+  }
+
+  function submitPolicy(): void {
+    setSubmissionError(null)
+    let submission: ReturnType<typeof createDemoVoteSubmission>
+    try {
+      submission = createDemoVoteSubmission(rawWeights, topicIntent, topicCatalog)
+    } catch (error) {
+      if (error instanceof RangeError) {
+        setSubmissionError("This policy has an incomplete or invalid value. Reset the preset and try again.")
+        return
+      }
+      throw error
+    }
+    onSubmit(submission.weights, submission.topicIntent)
   }
 
   return (
@@ -216,13 +236,16 @@ export function VotePanel({
 
               {fineTuneTab === "signals" ? (
                 <div className="mt-4 flex flex-col gap-1">
+                  <p className="mb-1 text-xs leading-relaxed text-foreground/55">
+                    Signal sliders are relative settings. Corgi normalizes them to 100% when you cast the ballot.
+                  </p>
                   {SHADOW_DEMO_SIGNAL_KEYS.map((key) => (
                     <PolicySlider
                       key={key}
                       label={SIGNAL_LABELS[key]}
                       ariaLabel={`${SIGNAL_LABELS[key]} weight`}
                       value={rawWeights[key]}
-                      displayValue={previewWeights[key]}
+                      displayValue={rawWeights[key]}
                       accentColor={SIGNAL_COLORS[key]}
                       detail={null}
                       changed={editedSignalKeys.includes(key)}
@@ -283,18 +306,18 @@ export function VotePanel({
       </div>
 
       <div className="mt-5 xl:mt-3 xl:shrink-0 xl:border-t xl:border-border/70 xl:bg-background xl:pt-3">
-        <button type="button" onClick={() => {
-          const submission = createDemoVoteSubmission(rawWeights, topicIntent, topicCatalog)
-          onSubmit(submission.weights, submission.topicIntent)
-        }} disabled={!canSubmit}
+        <button type="button" onClick={submitPolicy} disabled={!canSubmit}
           className={`inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-[0_2px_8px_rgba(200,97,44,0.25)] transition-colors hover:bg-primary-dark disabled:opacity-60 ${FOCUS}`}>
           {busy ? "Casting…" : STEP_PANELS.vote.cta}
         </button>
-        {topicMismatch ? (
+        {!ballotValidation.valid ? (
           <p className="mt-2 text-xs font-medium text-primary" role="alert">
-            This snapshot&apos;s complete topic policy is unavailable. Start a new demo session to continue.
+            This policy has an incomplete or invalid value. Reset the preset or start a new demo session to continue.
           </p>
         ) : null}
+        {submissionError === null ? null : (
+          <p className="mt-2 text-xs font-medium text-primary" role="alert">{submissionError}</p>
+        )}
       </div>
     </div>
   )

--- a/web-next/components/ui/slider.tsx
+++ b/web-next/components/ui/slider.tsx
@@ -5,22 +5,36 @@ import * as SliderPrimitive from '@radix-ui/react-slider'
 
 import { cn } from '@/lib/utils'
 
+type SliderProps = React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+  readonly accentColor?: string
+  readonly ariaLabel: string
+  readonly ariaValueText?: string
+}
+
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
+  SliderProps
+>(({ className, accentColor, ariaLabel, ariaValueText, style, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
-      'relative flex w-full touch-none select-none items-center',
+      'relative flex h-10 w-full touch-none select-none items-center',
       className,
     )}
+    style={{
+      ...style,
+      '--slider-accent': accentColor ?? 'hsl(var(--primary))',
+    } as React.CSSProperties}
     {...props}
   >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary/75">
+      <SliderPrimitive.Range className="absolute h-full bg-[var(--slider-accent)]" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb
+      aria-label={ariaLabel}
+      aria-valuetext={ariaValueText}
+      className="block h-5 w-5 rounded-full border-2 border-background bg-[var(--slider-accent)] shadow-sm ring-1 ring-[var(--slider-accent)] ring-offset-background transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--slider-accent)] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+    />
   </SliderPrimitive.Root>
 ))
 Slider.displayName = SliderPrimitive.Root.displayName

--- a/web-next/components/ui/slider.tsx
+++ b/web-next/components/ui/slider.tsx
@@ -7,36 +7,59 @@ import { cn } from '@/lib/utils'
 
 type SliderProps = React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
   readonly accentColor?: string
-  readonly ariaLabel: string
-  readonly ariaValueText?: string
+  readonly ariaLabel: string | readonly string[]
+  readonly ariaValueText?: string | readonly string[]
+}
+
+function thumbLabel(label: string | readonly string[], index: number, count: number): string {
+  if (typeof label !== 'string') {
+    return label[index] ?? `Slider thumb ${index + 1}`
+  }
+  return count === 1 ? label : `${label} ${index + 1}`
+}
+
+function thumbValueText(
+  valueText: string | readonly string[] | undefined,
+  index: number,
+  count: number,
+): string | undefined {
+  if (valueText === undefined) return undefined
+  if (typeof valueText !== 'string') return valueText[index]
+  return count === 1 ? valueText : undefined
 }
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   SliderProps
->(({ className, accentColor, ariaLabel, ariaValueText, style, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      'relative flex h-10 w-full touch-none select-none items-center',
-      className,
-    )}
-    style={{
-      ...style,
-      '--slider-accent': accentColor ?? 'hsl(var(--primary))',
-    } as React.CSSProperties}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary/75">
-      <SliderPrimitive.Range className="absolute h-full bg-[var(--slider-accent)]" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb
-      aria-label={ariaLabel}
-      aria-valuetext={ariaValueText}
-      className="block h-5 w-5 rounded-full border-2 border-background bg-[var(--slider-accent)] shadow-sm ring-1 ring-[var(--slider-accent)] ring-offset-background transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--slider-accent)] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-    />
-  </SliderPrimitive.Root>
-))
+>(({ className, accentColor, ariaLabel, ariaValueText, style, ...props }, ref) => {
+  const thumbValues = props.value ?? props.defaultValue ?? [props.min ?? 0]
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        'relative flex h-10 w-full touch-none select-none items-center',
+        className,
+      )}
+      style={{
+        ...style,
+        '--slider-accent': accentColor ?? 'hsl(var(--primary))',
+      } as React.CSSProperties}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary/75">
+        <SliderPrimitive.Range className="absolute h-full bg-[var(--slider-accent)]" />
+      </SliderPrimitive.Track>
+      {thumbValues.map((_, index) => (
+        <SliderPrimitive.Thumb
+          key={index}
+          aria-label={thumbLabel(ariaLabel, index, thumbValues.length)}
+          aria-valuetext={thumbValueText(ariaValueText, index, thumbValues.length)}
+          className="block h-5 w-5 rounded-full border-2 border-background bg-[var(--slider-accent)] shadow-sm ring-1 ring-[var(--slider-accent)] ring-offset-background transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--slider-accent)] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+})
 Slider.displayName = SliderPrimitive.Root.displayName
 
 export { Slider }


### PR DESCRIPTION
## Summary
- unify signal and topic controls on the shared accessible Radix slider system
- make topic edits visibly change the policy state, show preset deltas, and reset cleanly
- validate and submit the exact 26-topic ballot contract before calling the demo API
- keep the topic list readable inside the existing bounded vote-panel scroll behavior

## Product behavior
Topic weights now clearly shape the relevance signal. Keyboard and pointer edits update immediately, mark the policy as custom, and remain visible when the ballot advances to the 24 scripted-voter step. Signals and topics use the same interaction and spacing language without erasing the signals distinct colors.

## Verification
- focused frontend release blockers: 11 passed
- full `npm run verify`: 142 files, 1,522 tests passed; all builds passed
- `web-next` lint and TypeScript checks passed
- `npm run docs:verify` passed
- browser QA: 1440x1100, 756x762, 390x844
- edited 26-topic ballot accepted by the real demo API

Validation receipt: `ops/receipts/2026-07-12/PROJ-1798/validation.md`

Linear: https://linear.app/andrewnordstrom-eng/issue/PROJ-1798