### PR TITLE
[PROJ-1807] Mobile responsive polish — no clipped content or overflow at any width

### DIFF
--- a/web-next/app/history/page.tsx
+++ b/web-next/app/history/page.tsx
@@ -358,10 +358,10 @@ function DetailPanel({ epoch, epochAudit, auditWindowNote }: { epoch: EpochView;
     <div className="flex flex-col gap-8">
 
       {/* ── Header ────────────────────────────────────────── */}
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
         <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-3">
-            <h2 className="font-display text-2xl font-bold text-foreground tracking-normal">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+            <h2 className="whitespace-nowrap font-display text-2xl font-bold text-foreground tracking-normal">
               Round #{epoch.id}
             </h2>
             <StatusChip phase={epoch.policyActive ? "active" : "archived"} />
@@ -612,9 +612,12 @@ export default function HistoryPage() {
               <p className="text-[10px] font-mono text-foreground/50 uppercase tracking-widest px-1 mb-1">
                 Rounds · newest first
               </p>
-              <nav className="flex flex-row lg:flex-col gap-2 overflow-x-auto pb-2 lg:pb-0" aria-label="Select a round">
+              <nav
+                className="flex flex-row lg:flex-col gap-2 overflow-x-auto pb-2 lg:pb-0 snap-x snap-mandatory lg:snap-none [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                aria-label="Select a round"
+              >
                 {epochViews.map((epoch) => (
-                  <div key={epoch.id} className="flex-shrink-0 w-44 sm:w-48 lg:w-auto">
+                  <div key={epoch.id} className="flex-shrink-0 w-44 sm:w-48 lg:w-auto snap-start">
                     <EpochCard
                       epoch={epoch}
                       selected={epoch.id === selectedEpoch.id}

--- a/web-next/app/vote/page.tsx
+++ b/web-next/app/vote/page.tsx
@@ -584,6 +584,31 @@ function VoteWorkbench({ epoch, myVote, topics, contentRules, isAuthenticated, o
             </div>
           )}
 
+          {/* On phones the desktop right rail is hidden — keep its context in the flow. */}
+          <div className="lg:hidden rounded-xl border border-border bg-card p-5 flex flex-col gap-4">
+            <div className="flex flex-col gap-3">
+              <p className="text-[10px] text-foreground/50 font-mono uppercase tracking-widest">Community mix · Round #{epoch.id}</p>
+              <PolicyBar weights={communityWeights} height={10} />
+              <PolicyLegend weights={communityWeights} />
+            </div>
+            <div className="h-px bg-border/60" />
+            <div className="flex flex-col gap-2.5">
+              <p className="text-[10px] text-foreground/50 font-mono uppercase tracking-widest">Active filters</p>
+              {rules.include_keywords.length === 0 && rules.exclude_keywords.length === 0 ? (
+                <p className="text-xs text-foreground/50">None this round</p>
+              ) : (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {rules.include_keywords.map((w) => (
+                    <span key={w} className="text-[11px] font-mono px-2 py-0.5 rounded-full bg-success/10 border border-success/25 text-success">+{w}</span>
+                  ))}
+                  <ExcludeKeywordChips
+                    words={rules.exclude_keywords}
+                    chipClass="text-[11px] font-mono px-2 py-0.5 rounded-full bg-tongue/15 border border-tongue/30 text-tongue-foreground"
+                  />
+                </div>
+              )}
+            </div>
+          </div>
         </main>
 
         {/* ── RIGHT RAIL ────────────────────────────────── */}

--- a/web-next/components/app-shell.tsx
+++ b/web-next/components/app-shell.tsx
@@ -184,8 +184,11 @@ export function AppShell({ user = null, children }: AppShellProps) {
             )}
           </nav>
 
-          {/* Right side — auth state + hamburger */}
-          <div className="flex items-center gap-2 justify-self-end">
+          {/* Right side — auth state + hamburger.
+              col-start-3: when the desktop nav is display:none (mobile), this div
+              becomes the grid's second item and would otherwise land in the center
+              column — the hamburger belongs pinned to the right rail. */}
+          <div className="col-start-3 flex items-center gap-2 justify-self-end">
             {authedUser ? (
               /* Logged-in state */
               <div className="flex items-center gap-2">

--- a/web-next/components/feed/bluesky-feed.tsx
+++ b/web-next/components/feed/bluesky-feed.tsx
@@ -12,8 +12,9 @@ import { ExternalLink, Heart, MessageCircle, Play, Repeat2 } from "lucide-react"
  * uses design tokens. Keep Corgi annotations (the rank badge) OUTSIDE the card.
  */
 
-/** Width of the right-hand Corgi rank column — shared by the header and every row. */
-export const RANK_COL_CLASS = "grid grid-cols-[minmax(0,1fr)_104px]"
+/** Width of the right-hand Corgi rank column — shared by the header and every row.
+ *  Narrower on phones so the post text keeps a readable line length. */
+export const RANK_COL_CLASS = "grid grid-cols-[minmax(0,1fr)_72px] sm:grid-cols-[minmax(0,1fr)_104px]"
 
 export function formatCount(value: number | string | null | undefined): string {
   if (value === null || value === undefined) {
@@ -129,7 +130,7 @@ function BlueskyMedia({ media, bskyUrl }: {
       ) : null}
       {media.quote ? (
         <div className="rounded-xl border border-[#D9E3EE] px-3 py-2.5">
-          <p className="text-sm font-semibold text-[#0B0F14]">{media.quote.authorDisplayName} <span className="font-normal text-[#42576C]">@{media.quote.authorHandle}</span></p>
+          <p className="break-words text-sm font-semibold text-[#0B0F14]">{media.quote.authorDisplayName} <span className="break-all font-normal text-[#42576C]">@{media.quote.authorHandle}</span></p>
           <p className="mt-1 line-clamp-4 text-sm leading-5 text-[#0B0F14]">{media.quote.text}</p>
         </div>
       ) : null}
@@ -218,9 +219,10 @@ export function BlueskyPostCard({
 /** The "Corgi rank · Epoch N" header cell that labels the rank column once. */
 export function RankColumnHeader({ label = "Corgi rank", sublabel }: { readonly label?: string; readonly sublabel?: string }) {
   return (
-    <div className="flex flex-col items-center justify-center border-l border-border/60 bg-biscuit/25 px-2 text-center">
-      <span className="font-mono text-[9.5px] font-bold uppercase tracking-[0.14em] leading-none text-primary/80">{label}</span>
-      {sublabel ? <span className="mt-1 font-mono text-[9px] leading-none text-foreground/55">{sublabel}</span> : null}
+    <div className="flex flex-col items-center justify-center border-l border-border/60 bg-biscuit/25 px-1.5 text-center sm:px-2">
+      {/* leading allows a graceful two-line "CORGI / RANK" in the narrow phone rail */}
+      <span className="font-mono text-[9.5px] font-bold uppercase tracking-[0.14em] leading-[1.4] text-primary/80">{label}</span>
+      {sublabel ? <span className="mt-0.5 font-mono text-[9px] leading-none text-foreground/55">{sublabel}</span> : null}
     </div>
   )
 }
@@ -279,10 +281,23 @@ export function BlueskyFeedFrame({
           <div className="flex h-6 items-center justify-center">
             <Image src="/images/bluesky-butterfly-logo.svg" alt="Bluesky" width={22} height={19} className="h-[19px] w-[22px]" />
           </div>
-          <div className="mt-1 flex items-end gap-5 overflow-x-auto text-[13px] font-semibold text-[#42576C]">
+          <div className="mt-1 flex items-end gap-4 overflow-x-auto text-[13px] font-semibold text-[#42576C] [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:gap-5">
             {tabs.map((tab) => (
               <span
                 key={tab}
+                ref={
+                  tab === communityName
+                    ? (el) => {
+                        // The active (community) tab is third in Bluesky's order and starts
+                        // off-screen on phones — center it by scrolling only the tab strip
+                        // (scrollIntoView would also scroll the page itself).
+                        const strip = el?.parentElement
+                        if (el && strip && strip.scrollWidth > strip.clientWidth) {
+                          strip.scrollLeft = Math.max(0, el.offsetLeft - (strip.clientWidth - el.clientWidth) / 2)
+                        }
+                      }
+                    : undefined
+                }
                 className={`shrink-0 border-b-2 pb-2.5 ${tab === communityName ? "border-[#0085FF] text-[#0B0F14]" : "border-transparent"}`}
               >
                 {tab}

--- a/web-next/components/feed/corgi-rank-badge.tsx
+++ b/web-next/components/feed/corgi-rank-badge.tsx
@@ -127,7 +127,7 @@ export function CorgiRankBadge({
 
   return (
     <div ref={rootRef} className="relative flex flex-col items-center text-center">
-      <span className="font-display text-[42px] font-extrabold leading-[0.8] tracking-tight text-primary">{rank}</span>
+      <span className="font-display text-[32px] font-extrabold leading-[0.8] tracking-tight text-primary sm:text-[42px]">{rank}</span>
       {showMovement ? (
         <span className="mt-1">
           <MovementPill dir={movement.dir} delta={movement.delta} title={summary.text} />

--- a/web-next/components/footer-section.tsx
+++ b/web-next/components/footer-section.tsx
@@ -78,12 +78,13 @@ export function FooterSection() {
             {linkGroups.map((group) => (
               <div key={group.heading} className="flex flex-col gap-3">
                 <h3 className="text-foreground/55 text-xs font-semibold tracking-wide uppercase">{group.heading}</h3>
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
+                  {/* py-1 grows each link's touch target without changing the visual rhythm (gap absorbs it) */}
                   {group.links.map((link) => (
                     <Link
                       key={link.label}
                       href={link.href}
-                      className={`text-foreground/70 text-sm font-normal leading-5 hover:text-primary transition-colors ${FOCUS}`}
+                      className={`py-1 text-foreground/70 text-sm font-normal leading-5 hover:text-primary transition-colors ${FOCUS}`}
                     >
                       {link.label}
                     </Link>

--- a/web-next/components/header.tsx
+++ b/web-next/components/header.tsx
@@ -186,8 +186,11 @@ export function Header() {
             })}
           </nav>
 
-          {/* Right: desktop auth + mobile hamburger */}
-          <div className="justify-self-end flex items-center gap-2">
+          {/* Right: desktop auth + mobile hamburger.
+              col-start-3: when the desktop nav is display:none (mobile), this div
+              becomes the grid's second item and would otherwise land in the center
+              column — the hamburger belongs pinned to the right rail. */}
+          <div className="col-start-3 justify-self-end flex items-center gap-2">
             <div className="hidden md:flex items-center gap-3">
               <button
                 onClick={() => setSignInOpen(true)}

--- a/web-next/components/how-it-works-replay.tsx
+++ b/web-next/components/how-it-works-replay.tsx
@@ -216,16 +216,19 @@ function ScoringMath() {
       </div>
 
       <div className="rounded-2xl border border-border bg-card p-5 shadow-[0_2px_14px_rgba(46,38,32,0.06)] md:p-6">
+        {/* min-w-0 on both columns: without it the table's intrinsic width forces
+            the whole card past the phone viewport instead of scrolling inside it */}
         <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-          <div className="rounded-xl border border-border/70 bg-background">
+          <div className="min-w-0 rounded-xl border border-border/70 bg-background">
             <div className="border-b border-border/60 px-4 py-3">
               <p className="text-sm font-bold text-foreground">Raw signal scores</p>
               <p className="mt-1 text-xs leading-relaxed text-foreground/48">
                 These are the same post scores used by every policy in the walkthrough.
               </p>
+              <p className="mt-1 text-[11px] text-foreground/50 lg:hidden">Swipe sideways to see all five signals.</p>
             </div>
             <div className="overflow-x-auto px-4">
-              <table className="w-full min-w-[720px] text-left text-sm">
+              <table className="w-full min-w-[640px] text-left text-sm">
                 <thead>
                   <tr className="border-b border-border/70 text-xs uppercase tracking-[0.14em] text-foreground/50">
                     <th className="py-3 pr-4 font-semibold">Post</th>
@@ -250,7 +253,7 @@ function ScoringMath() {
             </div>
           </div>
 
-          <div className="flex flex-col gap-4">
+          <div className="flex min-w-0 flex-col gap-4">
             <div className="rounded-xl border border-border/70 bg-background p-5">
               <p className="text-[11px] font-mono uppercase tracking-[0.2em] text-foreground/55">Formula</p>
               <p className="mt-3 font-mono text-sm leading-relaxed text-foreground/75">

--- a/web-next/components/legal-layout.tsx
+++ b/web-next/components/legal-layout.tsx
@@ -125,7 +125,9 @@ export function LI({ children }: { children: React.ReactNode }) {
   return (
     <li className="flex items-start gap-2 text-sm text-foreground/65 leading-relaxed">
       <span className="mt-[0.4rem] w-1.5 h-1.5 rounded-full bg-primary/50 flex-shrink-0" aria-hidden="true" />
-      {children}
+      {/* Single flowing span: as direct flex items, mixed inline children (text,
+          links, <Strong>) would sit side-by-side and overflow narrow screens. */}
+      <span className="min-w-0">{children}</span>
     </li>
   )
 }

--- a/web-next/components/ui/status-chip.tsx
+++ b/web-next/components/ui/status-chip.tsx
@@ -30,7 +30,7 @@ export function StatusChip({ phase, className }: StatusChipProps) {
 
   return (
     <span
-      className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-semibold
+      className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap
         bg-biscuit text-primary border border-primary/20 ${className ?? ""}`}
     >
       {config.dot && (


### PR DESCRIPTION
## What this PR does

A systematic responsive audit of all 13 public pages at 320/375/390/768/1024 px (DOM overflow instrumentation + full-page visual review) found the defects that made phones feel like an afterthought. This fixes all of them in `web-next/`:

- **/how-it-works scoring-math section was unreadable on phones** — the raw-scores table's intrinsic 720px width forced the whole card past the viewport (missing `min-w-0` on grid children), clipping the table, formula, and epoch note with no way to reach them. Now the table scrolls inside its card, with a swipe hint on mobile.
- **LegalLayout `LI` couldn't wrap mixed inline content** (children were direct flex items) — a long link pushed /support 90px past the viewport. Children now render in one flowing `min-w-0` span; fixes all legal/docs/support pages.
- **The shared Corgi rank rail (`RANK_COL_CLASS`) was fixed at 104px**, squeezing post text to ~150px on phones across the landing teaser, how-it-works replay, and demo corpus feed. Now 72px below `sm` with a 32px numeral — one change, all three surfaces.
- **The active community tab started off-screen on phones** (third in Bluesky tab order). The strip now centers it on mount by scrolling only the strip (deliberately not `scrollIntoView`, which would also scroll the page), scrollbar hidden.
- Quote-embed handles `break-all` instead of overflowing; **StatusChip** is `whitespace-nowrap` (no more "Active / policy" internal wrap); history header rows wrap as units; the round-card scroller hides its desktop scrollbar and gains snap points.
- **Vote page no longer loses the community mix + active filters on phones** — the desktop-only right rail's content is mirrored in an in-flow `lg:hidden` block.
- Footer links padded from ~20px to ~28px tap targets with the visual rhythm preserved.

## Why

The site held up structurally on phones but read as desktop-first: one fully clipped section, one overflowing page, cramped feed columns, and lost context on the ballot. These are the gaps between "works on mobile" and "designed for mobile."

Linear: Fixes PROJ-1807

## Stacking

Based on `dev/PROJ-1803-site-seo-governance-status-polish` (PR #348, all checks green). When #348 merges and its branch is deleted, GitHub retargets this PR to `main` automatically. Merge #348 first.

## Testing performed

- Playwright sweep: **zero horizontal document overflow on all 13 public pages at 320/375/390/768/1024 px** (before: /support +90px, how-it-works calc section clipped).
- Visual verification at 375px of every fixed surface, including the demo corpus feed against the live API.
- `web-next-*` guard suites pass (82/82); static export builds 25/25 pages; `tsc --noEmit` clean via pre-commit hook.

## Reviewer focus

- `components/feed/bluesky-feed.tsx` — the responsive `RANK_COL_CLASS` and the tab-strip `scrollLeft` ref callback (runs per render; idempotent).
- `components/legal-layout.tsx` — the LI wrapper span changes flex behavior for every list on the legal pages; spot-check /tos and /privacy.
- Whether 72px feels too tight for the rank rail on small phones — compare /demo at 320px.

---

## CodeRabbit Audit

**Exemption authorized by @AndrewNordstrom in-session on 2026-07-13** (same authorization that cleared #348 for this stack landing).

- **Head SHA:** `9c2893ddcb5294cc7247ecbde1b4cad60db4a32a`
- **Why exempt:** CodeRabbit could not produce a review — the account reached its **usage spending cap**, so its check reports `FAILURE` and the freshness gate sees it as perpetually `pending`. Account-billing limit, not a code finding.
- **Review threads:** 0 total, **0 unresolved** (verified via GraphQL `reviewThreads.isResolved==false`).
- **Other required checks:** all green — aikido-thread-check, internal-tooling-hygiene, linear-policy, quality-gate, security-gate, coderabbit-thread-check. `coderabbit-freshness` is the only red.
- **Scope:** this branch was reset onto `main` after #348 squash-merged; net diff is exactly the 10 mobile-responsive files (no #348 residue).
- **Verification performed in lieu of CR:** web-next static export builds 25/25 pages; Playwright overflow sweep shows zero horizontal overflow on all 13 public pages at 320/375/390/768/1024 px, including the merged demo panel; `tsc --noEmit` clean via pre-commit hook.
