### PR TITLE
[PROJ-1806] Demo adopts community content rules as a deterministic ballot channel (flag-gated)

### DIFF
--- a/docs/lab/demo-shadow-governance-contract.md
+++ b/docs/lab/demo-shadow-governance-contract.md
@@ -46,6 +46,16 @@ These are scripted deterministic voter archetypes, not LLM agents and not valida
 
 Aggregation uses the same side-effect-free production helper, labeled `trimmed_mean_no_trim_under_10`. With 25 ballots, two low and two high values are trimmed from each signal and topic component before averaging. `reviewerBallotShare=1/25` is ballot share, not causal influence, because scripted ballots respond partly to the proposal. The `direct_reviewer_ballot_removed` counterfactual removes the direct reviewer ballot while holding the 24 scripted ballots fixed.
 
+## Content Rules (flag-gated)
+
+Behind `DEMO_CONTENT_RULES_ENABLED` (default off), the ballot gains a third channel: exclude keywords. With the flag off, every payload is contract-identical to v4 and keyword ballots are rejected.
+
+- The reviewer may propose up to 10 exclude keywords (production normalization: lowercase, trim, dedupe, 50-character cap). Synthetic voters never originate keywords; each voter deterministically echoes a reviewer proposal (seeded per keyword, per voter, with bloc-specific echo rates) and sustains previously adopted rules with inertia. Identical inputs replay exactly.
+- Aggregation is the production support-threshold rule, not trimmed mean: a keyword is adopted when backed by at least 30 percent of the electorate (`ceil(0.3 x n)`, so 8 of 25). Every demo ballot is complete, so the denominator is the full 25-ballot electorate; production computes the same share over voters who cast a content ballot. The demo has no safety-net default rules because the frozen corpus is already reviewer-safe.
+- Adopted rules apply at shadow rank time with the production matcher (`checkContentRules`: prefix matching, exclude precedence). Matching posts are withheld from the ranking, not reordered; the feed payload lists them under `withheldPosts` with the matching keyword and its support count. The frozen corpus itself never changes: rules shrink the eligible set, weights reorder the rest, and both effects stay attributable.
+- Rank receipts on visible posts state the adopted rules, threshold, and electorate. Withheld posts have no rank receipt; the receipt endpoint returns an explicit error naming the rule and support.
+- Suggested keywords are derived deterministically from the frozen corpus (frequency-bounded so a suggestion always withholds some posts but never most of the corpus).
+
 ## Ranking And Receipts
 
 The demo reuses stored production raw score components, topic vectors, the production relevance formula, the relevance floor, trimmed-mean aggregation, and the publication-order adjustment represented by the approved feed snapshot. It does not rerun the scorer when a reviewer clicks.

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ export const ConfigSchema = z.object({
   REDIS_URL: z.string().startsWith('redis://'),
   DEMO_REDIS_URL: z.string().startsWith('redis://').default('redis://127.0.0.1:6381'),
   DEMO_RATE_LIMIT_HASH_SECRET: z.string().min(16).default(INSECURE_DEMO_RATE_LIMIT_HASH_SECRET_DEFAULT),
+  DEMO_CONTENT_RULES_ENABLED: zodEnvBool(false),
   REDIS_COMMAND_TIMEOUT_MS: z.coerce.number().int().min(100).default(5_000),
 
   // Feed requester JWT verification

--- a/src/demo/content-rules.ts
+++ b/src/demo/content-rules.ts
@@ -88,7 +88,7 @@ export function validateShadowExcludeKeywords(value: unknown): string[] {
     if (keyword.trim().length === 0) {
       throw new Error('Shadow demo excludeKeywords must not contain empty keywords');
     }
-    if (keyword.length > SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH) {
+    if (keyword.trim().length > SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH) {
       throw new Error(
         `Shadow demo exclude keywords are limited to ${SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH} characters`
       );

--- a/src/demo/content-rules.ts
+++ b/src/demo/content-rules.ts
@@ -1,0 +1,278 @@
+/**
+ * Shadow-demo content-rules ballot channel (exclude keywords only).
+ *
+ * Mirrors the production mechanism with the production matcher and the
+ * production support-threshold share, but over the demo's complete
+ * electorate: every demo ballot is complete (weights + full topic catalog),
+ * so the adoption denominator is all 25 ballots rather than production's
+ * "voters who cast a content ballot" subset.
+ *
+ * Deliberate divergences from production, documented in
+ * docs/lab/demo-shadow-governance-contract.md:
+ * - exclude keywords only (an include list can empty a 65-post frozen corpus);
+ * - no safety-net default rules (the frozen corpus is already reviewer-safe);
+ * - adoption threshold is computed over the full 25-ballot electorate.
+ */
+
+import { checkContentRules } from '../governance/content-filter.js';
+import { normalizeKeywords } from '../governance/governance.types.js';
+import {
+  SHADOW_DEMO_CONTENT_RULE_SUPPORT_THRESHOLD,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
+  type ShadowDemoContentRulesSummary,
+  type ShadowDemoCorpusItem,
+  type ShadowDemoSuggestedExcludeKeyword,
+  type ShadowDemoVote,
+  type ShadowDemoVoterBlocId,
+} from './types.js';
+
+/**
+ * How readily each bloc echoes a reviewer-proposed exclude keyword.
+ * Tuned so a proposal lands near the adoption threshold: expected echoes
+ * across the 24 synthetic voters ~= 7.7 against a threshold of 8-of-25,
+ * so adoption depends on the session seed, epoch, and keyword.
+ */
+const CONTENT_RULE_ECHO_RATES: Record<ShadowDemoVoterBlocId, number> = {
+  freshness_watcher: 0.45,
+  conversation_follower: 0.3,
+  bridge_builder: 0.2,
+  source_diversifier: 0.2,
+  relevance_steward: 0.45,
+  research_practitioner: 0.3,
+  dataset_steward: 0.3,
+  current_awareness: 0.3,
+  community_discussant: 0.3,
+  interdisciplinary_connector: 0.3,
+};
+
+/** Extra support for keywords already adopted into the prior shadow policy. */
+const CONTENT_RULE_INERTIA_BONUS = 0.2;
+
+const SUGGESTED_KEYWORD_STOPWORDS = new Set([
+  'about', 'after', 'against', 'all', 'also', 'and', 'any', 'are', 'back',
+  'because', 'been', 'before', 'being', 'between', 'both', 'but', 'can',
+  'could', 'did', 'does', 'doing', 'down', 'each', 'even', 'first', 'for',
+  'from', 'get', 'got', 'had', 'has', 'have', 'her', 'here', 'him', 'his',
+  'how', 'into', 'its', 'just', 'like', 'made', 'make', 'many', 'more',
+  'most', 'much', 'need', 'new', 'not', 'now', 'off', 'one', 'only', 'other',
+  'our', 'out', 'over', 'own', 'people', 'same', 'she', 'should', 'since',
+  'some', 'still', 'such', 'than', 'that', 'the', 'their', 'them', 'then',
+  'there', 'these', 'they', 'thing', 'things', 'this', 'those', 'through',
+  'time', 'too', 'use', 'using', 'very', 'want', 'was', 'way', 'were',
+  'what', 'when', 'where', 'which', 'while', 'who', 'will', 'with', 'would',
+  'you', 'your',
+]);
+
+const SUGGESTED_KEYWORD_MIN_LENGTH = 4;
+const SUGGESTED_KEYWORD_MIN_MATCHES = 2;
+/** Skip terms that would withhold most of the corpus in one vote. */
+const SUGGESTED_KEYWORD_MAX_CORPUS_SHARE = 0.3;
+
+export function validateShadowExcludeKeywords(value: unknown): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error('Shadow demo excludeKeywords must be an array of strings');
+  }
+  if (value.length > SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS) {
+    throw new Error(
+      `Shadow demo excludeKeywords accepts at most ${SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS} keywords`
+    );
+  }
+  for (const keyword of value) {
+    if (typeof keyword !== 'string') {
+      throw new Error('Shadow demo excludeKeywords must contain only strings');
+    }
+    if (keyword.trim().length === 0) {
+      throw new Error('Shadow demo excludeKeywords must not contain empty keywords');
+    }
+    if (keyword.length > SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH) {
+      throw new Error(
+        `Shadow demo exclude keywords are limited to ${SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH} characters`
+      );
+    }
+  }
+  return normalizeKeywords(value).slice(0, SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS);
+}
+
+/**
+ * Aggregate exclude-keyword ballots with the production support-threshold
+ * rule over the full demo electorate. Distinct from the trimmed-mean path
+ * used for weights and topic intents.
+ */
+export function aggregateShadowContentRules(
+  votes: ReadonlyArray<Pick<ShadowDemoVote, 'excludeKeywords'>>,
+  electorate: number
+): ShadowDemoContentRulesSummary {
+  const threshold = contentRuleThreshold(electorate);
+  const supportCounts = new Map<string, number>();
+  for (const vote of votes) {
+    for (const keyword of vote.excludeKeywords ?? []) {
+      supportCounts.set(keyword, (supportCounts.get(keyword) ?? 0) + 1);
+    }
+  }
+  const support = [...supportCounts.entries()]
+    .map(([keyword, supportCount]) => ({
+      keyword,
+      supportCount,
+      adopted: supportCount >= threshold,
+    }))
+    .sort((left, right) =>
+      right.supportCount - left.supportCount || left.keyword.localeCompare(right.keyword)
+    );
+  return {
+    enabled: true,
+    threshold,
+    electorate,
+    adoptedExcludeKeywords: support
+      .filter((entry) => entry.adopted)
+      .map((entry) => entry.keyword)
+      .sort(),
+    support,
+  };
+}
+
+export function contentRuleThreshold(electorate: number): number {
+  return Math.max(1, Math.ceil(electorate * SHADOW_DEMO_CONTENT_RULE_SUPPORT_THRESHOLD));
+}
+
+export function emptyShadowContentRules(electorate: number): ShadowDemoContentRulesSummary {
+  return {
+    enabled: true,
+    threshold: contentRuleThreshold(electorate),
+    electorate,
+    adoptedExcludeKeywords: [],
+    support: [],
+  };
+}
+
+/**
+ * Deterministic exclude-keyword ballot for one synthetic voter.
+ * A voter backs a keyword when it echoes the reviewer's proposal
+ * (seeded per keyword) or sustains a previously adopted rule (inertia).
+ * Synthetic voters never originate their own keywords.
+ */
+export function syntheticExcludeKeywords(options: {
+  seed: string;
+  communityId: string;
+  epochId: string;
+  actorId: string;
+  blocId: ShadowDemoVoterBlocId;
+  policyInertia: number;
+  reviewerExcludeKeywords: readonly string[];
+  priorAdoptedExcludeKeywords: readonly string[];
+}): string[] {
+  const echoRate = CONTENT_RULE_ECHO_RATES[options.blocId];
+  const inertiaRate = Math.min(0.95, options.policyInertia + CONTENT_RULE_INERTIA_BONUS);
+  const candidates = new Set([
+    ...options.reviewerExcludeKeywords,
+    ...options.priorAdoptedExcludeKeywords,
+  ]);
+  const backed: string[] = [];
+  for (const keyword of [...candidates].sort()) {
+    const echoes = options.reviewerExcludeKeywords.includes(keyword)
+      && deterministicUnit(
+        `${options.seed}:${options.communityId}:${options.epochId}:${options.actorId}:rule-echo:${keyword}`
+      ) < echoRate;
+    const sustains = options.priorAdoptedExcludeKeywords.includes(keyword)
+      && deterministicUnit(
+        `${options.seed}:${options.communityId}:${options.epochId}:${options.actorId}:rule-inertia:${keyword}`
+      ) < inertiaRate;
+    if (echoes || sustains) {
+      backed.push(keyword);
+    }
+  }
+  return backed.slice(0, SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS);
+}
+
+export interface ShadowContentRuleApplication {
+  eligible: ShadowDemoCorpusItem[];
+  withheld: Array<{ item: ShadowDemoCorpusItem; keyword: string }>;
+}
+
+/**
+ * Split the frozen corpus into eligible and withheld items under the adopted
+ * exclude keywords, using the production matcher (prefix matching, exclude
+ * precedence). Hidden posts carry no text and always pass.
+ */
+export function applyShadowContentRules(
+  items: readonly ShadowDemoCorpusItem[],
+  adoptedExcludeKeywords: readonly string[]
+): ShadowContentRuleApplication {
+  if (adoptedExcludeKeywords.length === 0) {
+    return { eligible: [...items], withheld: [] };
+  }
+  const rules = {
+    includeKeywords: [],
+    excludeKeywords: [...adoptedExcludeKeywords],
+  };
+  const eligible: ShadowDemoCorpusItem[] = [];
+  const withheld: Array<{ item: ShadowDemoCorpusItem; keyword: string }> = [];
+  for (const item of items) {
+    const text = item.displayPost.kind === 'public_post' ? item.displayPost.text : null;
+    const result = checkContentRules(text, rules);
+    if (result.passes) {
+      eligible.push(item);
+    } else {
+      withheld.push({ item, keyword: result.matchedKeyword ?? adoptedExcludeKeywords[0] });
+    }
+  }
+  return { eligible, withheld };
+}
+
+/**
+ * Deterministic exclude-keyword suggestions drawn from the frozen corpus,
+ * so a proposed rule always has a visible effect. Terms that would withhold
+ * most of the corpus, or almost none of it, are skipped.
+ */
+export function suggestedExcludeKeywords(
+  items: readonly ShadowDemoCorpusItem[],
+  limit: number
+): ShadowDemoSuggestedExcludeKeyword[] {
+  const postsPerTerm = new Map<string, number>();
+  let publicPostCount = 0;
+  for (const item of items) {
+    if (item.displayPost.kind !== 'public_post') {
+      continue;
+    }
+    publicPostCount += 1;
+    const terms = new Set(
+      item.displayPost.text
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((term) =>
+          term.length >= SUGGESTED_KEYWORD_MIN_LENGTH
+          && term.length <= SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH
+          && !SUGGESTED_KEYWORD_STOPWORDS.has(term)
+          && !/^\d+$/.test(term)
+        )
+    );
+    for (const term of terms) {
+      postsPerTerm.set(term, (postsPerTerm.get(term) ?? 0) + 1);
+    }
+  }
+  if (publicPostCount === 0) {
+    return [];
+  }
+  const maxMatches = Math.max(
+    SUGGESTED_KEYWORD_MIN_MATCHES,
+    Math.floor(publicPostCount * SUGGESTED_KEYWORD_MAX_CORPUS_SHARE)
+  );
+  return [...postsPerTerm.entries()]
+    .filter(([, count]) => count >= SUGGESTED_KEYWORD_MIN_MATCHES && count <= maxMatches)
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, limit)
+    .map(([keyword, matchCount]) => ({ keyword, matchCount }));
+}
+
+/** Seeded FNV-1a hash to [0, 1); same determinism pattern as vote jitter. */
+function deterministicUnit(input: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 0x100000000;
+}

--- a/src/demo/content-rules.ts
+++ b/src/demo/content-rules.ts
@@ -68,6 +68,8 @@ const SUGGESTED_KEYWORD_MIN_LENGTH = 4;
 const SUGGESTED_KEYWORD_MIN_MATCHES = 2;
 /** Skip terms that would withhold most of the corpus in one vote. */
 const SUGGESTED_KEYWORD_MAX_CORPUS_SHARE = 0.3;
+/** How many corpus-grounded exclude suggestions the session exposes. */
+export const SHADOW_DEMO_SUGGESTED_KEYWORD_COUNT = 6;
 
 export function validateShadowExcludeKeywords(value: unknown): string[] {
   if (value === undefined || value === null) {

--- a/src/demo/content-rules.ts
+++ b/src/demo/content-rules.ts
@@ -122,14 +122,20 @@ export function aggregateShadowContentRules(
     .sort((left, right) =>
       right.supportCount - left.supportCount || left.keyword.localeCompare(right.keyword)
     );
+  // Cap the active exclude-rule set at the per-ballot keyword limit, ranked by
+  // support (highest first, ties alphabetical). Prior-policy inertia can carry
+  // rules across epochs, so an uncapped adopted set could grow past the limit
+  // enforced on the persisted policy; the highest-support rules win.
+  const adoptedExcludeKeywords = support
+    .filter((entry) => entry.adopted)
+    .slice(0, SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS)
+    .map((entry) => entry.keyword)
+    .sort();
   return {
     enabled: true,
     threshold,
     electorate,
-    adoptedExcludeKeywords: support
-      .filter((entry) => entry.adopted)
-      .map((entry) => entry.keyword)
-      .sort(),
+    adoptedExcludeKeywords,
     support,
   };
 }

--- a/src/demo/routes.ts
+++ b/src/demo/routes.ts
@@ -57,6 +57,8 @@ const VoteBodySchema = z.object({
   baseEpochId: z.string().min(1).max(64),
   weights: WeightSchema,
   topicIntent: TopicIntentSchema,
+  // Accepted only when DEMO_CONTENT_RULES_ENABLED; the service rejects it otherwise.
+  excludeKeywords: z.array(z.string().min(1).max(50)).max(10).optional(),
   idempotencyKey: IdempotencyKeySchema.optional(),
 }).strict();
 
@@ -172,6 +174,7 @@ function registerShadowDemoRouteFamily(
         baseEpochId: body.baseEpochId,
         weights: body.weights,
         topicIntent: body.topicIntent,
+        excludeKeywords: body.excludeKeywords,
         idempotencyKey: idempotencyKeyFrom(request, body.idempotencyKey ?? null),
       });
     }, options.contractVersion);

--- a/src/demo/routes.ts
+++ b/src/demo/routes.ts
@@ -6,6 +6,8 @@ import {
   SHADOW_DEMO_COMMUNITY_IDS,
   SHADOW_DEMO_CONTRACT_VERSION,
   SHADOW_DEMO_V4_CONTRACT_VERSION,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
   SHADOW_DEMO_SESSION_TTL_SECONDS,
   SHADOW_DEMO_TOPIC_KEYS,
   type ShadowDemoEnvelope,
@@ -58,7 +60,7 @@ const VoteBodySchema = z.object({
   weights: WeightSchema,
   topicIntent: TopicIntentSchema,
   // Accepted only when DEMO_CONTENT_RULES_ENABLED; the service rejects it otherwise.
-  excludeKeywords: z.array(z.string().min(1).max(50)).max(10).optional(),
+  excludeKeywords: z.array(z.string().min(1).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH)).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS).optional(),
   idempotencyKey: IdempotencyKeySchema.optional(),
 }).strict();
 

--- a/src/demo/service.ts
+++ b/src/demo/service.ts
@@ -3,6 +3,7 @@ import { config } from '../config.js';
 import { applyFeedUrlDedup, FEED_URL_DEDUP_DECAY } from '../scoring/feed-publication.js';
 import { DEMO_COMMUNITIES, createDefaultCorpusLoader } from './corpus.js';
 import {
+  SHADOW_DEMO_SUGGESTED_KEYWORD_COUNT,
   aggregateShadowContentRules,
   applyShadowContentRules,
   emptyShadowContentRules,
@@ -422,6 +423,7 @@ export class ShadowDemoService {
       epoch,
       previousEpoch,
       limit: request.limit,
+      contentRulesEnabled: this.contentRulesEnabled,
     });
     return {
       sessionId: state.sessionId,
@@ -458,6 +460,7 @@ export class ShadowDemoService {
       epoch,
       previousEpoch,
       limit: state.corpus.items.length,
+      contentRulesEnabled: this.contentRulesEnabled,
     });
     const withheldEntry = ranked.withheld.find(
       (candidate) => candidate.post.kind === 'public_post' && candidate.post.uri === request.postUri
@@ -517,6 +520,7 @@ export class ShadowDemoService {
             item,
             epoch,
             visibleRank: rankedPost.rank,
+            contentRulesEnabled: this.contentRulesEnabled,
           }),
           ...(this.contentRulesEnabled && epoch.aggregate.contentRules
             ? {
@@ -750,7 +754,10 @@ function sessionPayload(
       ...(contentRulesEnabled
         ? {
             contentRulesEnabled: true,
-            suggestedExcludeKeywords: suggestedExcludeKeywords(state.corpus.items, 6),
+            suggestedExcludeKeywords: suggestedExcludeKeywords(
+              state.corpus.items,
+              SHADOW_DEMO_SUGGESTED_KEYWORD_COUNT
+            ),
           }
         : {}),
     },
@@ -1005,7 +1012,13 @@ function assertCompleteDemoElectorate(votes: ShadowDemoVote[], epochId: string):
   }
 }
 
-function adoptedRulesFor(epoch: ShadowDemoEpoch): string[] {
+// When the flag is off, stored rules are ignored so an off deployment is fully
+// inert even if a session persisted rules while the flag was on (flip-off must
+// stay byte-identical to v4).
+function adoptedRulesFor(epoch: ShadowDemoEpoch, contentRulesEnabled: boolean): string[] {
+  if (!contentRulesEnabled) {
+    return [];
+  }
   return epoch.aggregate.contentRules?.adoptedExcludeKeywords ?? [];
 }
 
@@ -1014,12 +1027,16 @@ function rankedPosts(options: {
   epoch: ShadowDemoEpoch;
   previousEpoch: ShadowDemoEpoch | null;
   limit: number;
+  contentRulesEnabled: boolean;
 }): { posts: ShadowDemoRankedPost[]; withheld: ShadowDemoWithheldPost[] } {
   const previousRanks = options.previousEpoch
-    ? rankMapForEpoch(options.corpus, options.previousEpoch)
+    ? rankMapForEpoch(options.corpus, options.previousEpoch, options.contentRulesEnabled)
     : new Map<string, number>();
   const isPublishedBaseline = options.corpus.communityId === 'community_gov' && options.epoch.sequence === 1;
-  const ruleApplication = applyShadowContentRules(options.corpus.items, adoptedRulesFor(options.epoch));
+  const ruleApplication = applyShadowContentRules(
+    options.corpus.items,
+    adoptedRulesFor(options.epoch, options.contentRulesEnabled)
+  );
   const support = new Map(
     (options.epoch.aggregate.contentRules?.support ?? []).map((entry) => [entry.keyword, entry.supportCount])
   );
@@ -1060,14 +1077,18 @@ function rankedPosts(options: {
   return { posts, withheld };
 }
 
-function rankMapForEpoch(corpus: ShadowDemoCorpus, epoch: ShadowDemoEpoch): Map<string, number> {
+function rankMapForEpoch(
+  corpus: ShadowDemoCorpus,
+  epoch: ShadowDemoEpoch,
+  contentRulesEnabled: boolean
+): Map<string, number> {
   const ranks = new Map<string, number>();
   if (epoch.sequence === 1 && corpus.items.every((item) => item.publishedRank !== undefined)) {
     for (const item of corpus.items) ranks.set(item.postUri, item.publishedRank as number);
     return ranks;
   }
   scoreAndPublishItems(
-    applyShadowContentRules(corpus.items, adoptedRulesFor(epoch)).eligible,
+    applyShadowContentRules(corpus.items, adoptedRulesFor(epoch, contentRulesEnabled)).eligible,
     epoch.aggregate.weights,
     epoch.aggregate.topicIntent,
     false,
@@ -1096,6 +1117,7 @@ function counterfactualsForReceipt(options: {
   item: ShadowDemoCorpusItem;
   epoch: ShadowDemoEpoch;
   visibleRank: number;
+  contentRulesEnabled: boolean;
 }): ShadowDemoCounterfactual[] {
   const previousEpoch = previousEpochFor(options.state, options.epoch);
   const previousWeights = previousEpoch?.aggregate.weights ?? options.state.corpus.baseWeights;
@@ -1116,7 +1138,7 @@ function counterfactualsForReceipt(options: {
         weights: previousWeights,
         topicIntent: previousTopicIntent,
         visibleRank: options.visibleRank,
-        adoptedExcludeKeywords: previousEpoch ? adoptedRulesFor(previousEpoch) : [],
+        adoptedExcludeKeywords: previousEpoch ? adoptedRulesFor(previousEpoch, options.contentRulesEnabled) : [],
       });
   return [
     previousCounterfactual,
@@ -1128,7 +1150,7 @@ function counterfactualsForReceipt(options: {
       weights: engagementOnlyWeights(),
       topicIntent: options.epoch.aggregate.topicIntent,
       visibleRank: options.visibleRank,
-      adoptedExcludeKeywords: adoptedRulesFor(options.epoch),
+      adoptedExcludeKeywords: adoptedRulesFor(options.epoch, options.contentRulesEnabled),
     }),
     counterfactualForWeights({
       label: 'direct_reviewer_ballot_removed',
@@ -1138,7 +1160,7 @@ function counterfactualsForReceipt(options: {
       weights: directReviewerBallotRemoved.weights,
       topicIntent: directReviewerBallotRemoved.topicIntent,
       visibleRank: options.visibleRank,
-      adoptedExcludeKeywords: adoptedRulesFor(options.epoch),
+      adoptedExcludeKeywords: adoptedRulesFor(options.epoch, options.contentRulesEnabled),
     }),
   ];
 }

--- a/src/demo/service.ts
+++ b/src/demo/service.ts
@@ -433,7 +433,7 @@ export class ShadowDemoService {
         communityId: state.communityId,
         corpusHealth: state.corpus.health,
         corpusProvenance: corpusProvenanceFor(state),
-        aggregate: epoch.aggregate,
+        aggregate: publicAggregate(epoch.aggregate, this.contentRulesEnabled),
         posts: ranked.posts,
         ...(this.contentRulesEnabled && epoch.aggregate.contentRules
           ? { withheldPosts: ranked.withheld }
@@ -498,7 +498,7 @@ export class ShadowDemoService {
           publishedRank: rankedPost.publishedRank,
           publishedScore: rankedPost.publishedScore,
           scoredAt: item.scoredAt,
-          aggregate: epoch.aggregate,
+          aggregate: publicAggregate(epoch.aggregate, this.contentRulesEnabled),
           reviewerBallotShare: reviewerBallotShareFor(state, epoch),
           components: receiptContributions(
             item,
@@ -739,7 +739,7 @@ function sessionPayload(
       currentEpochId: state.currentEpochId,
       expiresAt: state.expiresAt,
       corpusHealth: state.corpus.health,
-      epochs: state.epochs,
+      epochs: state.epochs.map((epoch) => publicEpoch(epoch, contentRulesEnabled)),
       pendingAggregate: pendingAggregateFor(state, contentRulesEnabled),
       voteCount: state.votes.length,
       guidedEpochs: SHADOW_DEMO_GUIDED_EPOCHS,
@@ -1020,6 +1020,25 @@ function adoptedRulesFor(epoch: ShadowDemoEpoch, contentRulesEnabled: boolean): 
     return [];
   }
   return epoch.aggregate.contentRules?.adoptedExcludeKeywords ?? [];
+}
+
+// Strip persisted content-rule metadata from an aggregate when the flag is off,
+// so a session that adopted rules while enabled reads back byte-identical to v4
+// after a flip-off. No-op when enabled or when the aggregate never had rules.
+function publicAggregate(
+  aggregate: ShadowDemoEpoch['aggregate'],
+  contentRulesEnabled: boolean
+): ShadowDemoEpoch['aggregate'] {
+  if (contentRulesEnabled || aggregate.contentRules === undefined) {
+    return aggregate;
+  }
+  const { contentRules: _omitted, ...rest } = aggregate;
+  return rest;
+}
+
+function publicEpoch(epoch: ShadowDemoEpoch, contentRulesEnabled: boolean): ShadowDemoEpoch {
+  const aggregate = publicAggregate(epoch.aggregate, contentRulesEnabled);
+  return aggregate === epoch.aggregate ? epoch : { ...epoch, aggregate };
 }
 
 function rankedPosts(options: {

--- a/src/demo/service.ts
+++ b/src/demo/service.ts
@@ -540,7 +540,9 @@ export class ShadowDemoService {
 
   private validateExcludeKeywordsForApi(value: unknown): string[] {
     if (!this.contentRulesEnabled) {
-      if (value !== undefined && value !== null) {
+      // Reject any explicitly supplied value (including null); only an omitted
+      // field is treated as "no content-rule ballot".
+      if (value !== undefined) {
         throw new DemoValidationError('Shadow demo content rules are not enabled on this deployment');
       }
       return [];
@@ -748,7 +750,7 @@ function sessionPayload(
       totalDemoVoters: SHADOW_DEMO_TOTAL_DEMO_VOTERS,
       corpusProvenance: corpusProvenanceFor(state),
       voterProfiles: getShadowDemoVoterProfiles(state.communityId),
-      votes: state.votes,
+      votes: state.votes.map((vote) => publicVote(vote, contentRulesEnabled)),
       topicCatalog: state.corpus.topicCatalog,
       sourceFeedUri: state.corpus.sourceFeedUri,
       ...(contentRulesEnabled
@@ -1039,6 +1041,16 @@ function publicAggregate(
 function publicEpoch(epoch: ShadowDemoEpoch, contentRulesEnabled: boolean): ShadowDemoEpoch {
   const aggregate = publicAggregate(epoch.aggregate, contentRulesEnabled);
   return aggregate === epoch.aggregate ? epoch : { ...epoch, aggregate };
+}
+
+// Strip the persisted per-ballot excludeKeywords from a vote when the flag is
+// off, so flipped-off session payloads leak no rule-ballot metadata.
+function publicVote(vote: ShadowDemoVote, contentRulesEnabled: boolean): ShadowDemoVote {
+  if (contentRulesEnabled || vote.excludeKeywords === undefined) {
+    return vote;
+  }
+  const { excludeKeywords: _omitted, ...rest } = vote;
+  return rest;
 }
 
 function rankedPosts(options: {

--- a/src/demo/service.ts
+++ b/src/demo/service.ts
@@ -2,6 +2,13 @@ import { createHash, randomUUID } from 'node:crypto';
 import { config } from '../config.js';
 import { applyFeedUrlDedup, FEED_URL_DEDUP_DECAY } from '../scoring/feed-publication.js';
 import { DEMO_COMMUNITIES, createDefaultCorpusLoader } from './corpus.js';
+import {
+  aggregateShadowContentRules,
+  applyShadowContentRules,
+  emptyShadowContentRules,
+  suggestedExcludeKeywords,
+  validateShadowExcludeKeywords,
+} from './content-rules.js';
 import { createSyntheticVoterVotes, getShadowDemoVoterProfiles } from './synthetic-voters.js';
 import {
   DEMO_MAX_ACTIVE_SESSIONS,
@@ -34,6 +41,7 @@ import {
   type ShadowDemoVote,
   type ShadowDemoWarning,
   type ShadowDemoWeights,
+  type ShadowDemoWithheldPost,
 } from './types.js';
 import {
   aggregateShadowVotes,
@@ -88,6 +96,10 @@ export interface ShadowDemoServiceDependencies {
     now: Date;
   }) => Promise<ShadowDemoCorpus>;
   now: () => Date;
+  /** Defaults to false; the default factory reads DEMO_CONTENT_RULES_ENABLED. */
+  contentRulesEnabled?: boolean;
+  /** Session seed source; defaults to randomUUID. Injectable for deterministic tests. */
+  seed?: () => string;
 }
 
 export interface CreateSessionRequest {
@@ -100,6 +112,7 @@ export interface CastVoteRequest {
   baseEpochId: string;
   weights: unknown;
   topicIntent: unknown;
+  excludeKeywords?: unknown;
   idempotencyKey: string | null;
 }
 
@@ -136,11 +149,15 @@ export class ShadowDemoService {
   private readonly store: DemoStore;
   private readonly loadCorpus: ShadowDemoServiceDependencies['loadCorpus'];
   private readonly now: () => Date;
+  private readonly contentRulesEnabled: boolean;
+  private readonly seed: () => string;
 
   constructor(dependencies: ShadowDemoServiceDependencies) {
     this.store = dependencies.store;
     this.loadCorpus = dependencies.loadCorpus;
     this.now = dependencies.now;
+    this.contentRulesEnabled = dependencies.contentRulesEnabled ?? false;
+    this.seed = dependencies.seed ?? randomUUID;
   }
 
   private async replayCreatedSession(
@@ -180,12 +197,15 @@ export class ShadowDemoService {
         trimCount: 0,
         weights: corpus.baseWeights,
         topicIntent: cloneShadowTopicIntent(corpus.baseTopicIntent),
+        ...(this.contentRulesEnabled
+          ? { contentRules: emptyShadowContentRules(SHADOW_DEMO_TOTAL_DEMO_VOTERS) }
+          : {}),
       },
     });
     const state: ShadowDemoSessionState = {
       sessionId,
       communityId: request.communityId,
-      seed: randomUUID(),
+      seed: this.seed(),
       phase: 'created',
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + SHADOW_DEMO_SESSION_TTL_SECONDS * 1000).toISOString(),
@@ -214,7 +234,7 @@ export class ShadowDemoService {
     }
     return {
       sessionId,
-      payload: sessionPayload(state),
+      payload: sessionPayload(state, this.contentRulesEnabled),
       warnings: state.warnings,
     };
   }
@@ -223,7 +243,7 @@ export class ShadowDemoService {
     const state = await this.readRequiredSession(sessionId);
     return {
       sessionId,
-      payload: sessionPayload(state),
+      payload: sessionPayload(state, this.contentRulesEnabled),
       warnings: state.warnings,
     };
   }
@@ -235,6 +255,7 @@ export class ShadowDemoService {
       assertPhaseForReviewerVote(state);
       const weights = validateWeightsForApi(request.weights);
       const topicIntent = validateTopicIntentForSession(state, request.topicIntent);
+      const excludeKeywords = this.validateExcludeKeywordsForApi(request.excludeKeywords);
       const now = this.now().toISOString();
       const reviewerVote: ShadowDemoVote = {
         id: `vote-reviewer-${request.baseEpochId}`,
@@ -244,6 +265,7 @@ export class ShadowDemoService {
         label: 'Reviewer',
         weights,
         topicIntent,
+        ...(excludeKeywords.length > 0 ? { excludeKeywords } : {}),
         createdAt: now,
       };
 
@@ -259,7 +281,7 @@ export class ShadowDemoService {
         state: nextState,
         response: {
           sessionId: nextState.sessionId,
-          payload: sessionPayload(nextState),
+          payload: sessionPayload(nextState, this.contentRulesEnabled),
           warnings: nextState.warnings,
         },
       };
@@ -297,6 +319,15 @@ export class ShadowDemoService {
         priorCommunityWeights: currentEpoch.aggregate.weights,
         priorTopicIntent: currentEpoch.aggregate.topicIntent,
         createdAt: now,
+        ...(this.contentRulesEnabled
+          ? {
+              contentRules: {
+                reviewerExcludeKeywords: reviewerVote.excludeKeywords ?? [],
+                priorAdoptedExcludeKeywords:
+                  currentEpoch.aggregate.contentRules?.adoptedExcludeKeywords ?? [],
+              },
+            }
+          : {}),
       });
       const nextVotes = state.votes
         .filter((vote) => !(vote.epochId === request.baseEpochId && vote.actorType === 'synthetic_voter'))
@@ -310,7 +341,7 @@ export class ShadowDemoService {
         state: nextState,
         response: {
           sessionId: nextState.sessionId,
-          payload: sessionPayload(nextState),
+          payload: sessionPayload(nextState, this.contentRulesEnabled),
           warnings: nextState.warnings,
         },
       };
@@ -340,7 +371,12 @@ export class ShadowDemoService {
       const now = this.now().toISOString();
       const decisionVotes = votesForEpoch(state, currentEpoch.id);
       assertCompleteDemoElectorate(decisionVotes, currentEpoch.id);
-      const nextAggregate = aggregateShadowVotes(decisionVotes);
+      const nextAggregate = {
+        ...aggregateShadowVotes(decisionVotes),
+        ...(this.contentRulesEnabled
+          ? { contentRules: aggregateShadowContentRules(decisionVotes, decisionVotes.length) }
+          : {}),
+      };
       const advancedEpoch: ShadowDemoEpoch = {
         ...currentEpoch,
         status: 'advanced',
@@ -363,7 +399,7 @@ export class ShadowDemoService {
         state: nextState,
         response: {
           sessionId: nextState.sessionId,
-          payload: sessionPayload(nextState),
+          payload: sessionPayload(nextState, this.contentRulesEnabled),
           warnings: nextState.warnings,
         },
       };
@@ -381,7 +417,7 @@ export class ShadowDemoService {
     const state = await this.readRequiredSession(request.sessionId);
     const epoch = epochByIdOrCurrent(state, request.epochId);
     const previousEpoch = previousEpochFor(state, epoch);
-    const posts = rankedPosts({
+    const ranked = rankedPosts({
       corpus: state.corpus,
       epoch,
       previousEpoch,
@@ -396,7 +432,10 @@ export class ShadowDemoService {
         corpusHealth: state.corpus.health,
         corpusProvenance: corpusProvenanceFor(state),
         aggregate: epoch.aggregate,
-        posts,
+        posts: ranked.posts,
+        ...(this.contentRulesEnabled && epoch.aggregate.contentRules
+          ? { withheldPosts: ranked.withheld }
+          : {}),
       },
       warnings: state.warnings,
     };
@@ -414,13 +453,24 @@ export class ShadowDemoService {
     }
 
     const previousEpoch = previousEpochFor(state, epoch);
-    const fullRankedPosts = rankedPosts({
+    const ranked = rankedPosts({
       corpus: state.corpus,
       epoch,
       previousEpoch,
       limit: state.corpus.items.length,
     });
-    const rankedPost = fullRankedPosts.find(
+    const withheldEntry = ranked.withheld.find(
+      (candidate) => candidate.post.kind === 'public_post' && candidate.post.uri === request.postUri
+    );
+    if (withheldEntry) {
+      const rules = epoch.aggregate.contentRules;
+      throw new DemoValidationError(
+        `Post is withheld by adopted community rule "-${withheldEntry.keyword}" `
+        + `(${withheldEntry.supportCount}/${rules?.electorate ?? SHADOW_DEMO_TOTAL_DEMO_VOTERS} support, `
+        + `threshold ${rules?.threshold ?? '?'}); withheld posts have no rank receipt in this epoch`
+      );
+    }
+    const rankedPost = ranked.posts.find(
       (candidate) => candidate.post.kind === 'public_post' && candidate.post.uri === request.postUri
     );
     if (!rankedPost) {
@@ -468,10 +518,35 @@ export class ShadowDemoService {
             epoch,
             visibleRank: rankedPost.rank,
           }),
+          ...(this.contentRulesEnabled && epoch.aggregate.contentRules
+            ? {
+                contentRules: {
+                  adoptedExcludeKeywords: [...epoch.aggregate.contentRules.adoptedExcludeKeywords],
+                  threshold: epoch.aggregate.contentRules.threshold,
+                  electorate: epoch.aggregate.contentRules.electorate,
+                  matchedKeyword: null,
+                },
+              }
+            : {}),
         },
       },
       warnings: state.warnings,
     };
+  }
+
+  private validateExcludeKeywordsForApi(value: unknown): string[] {
+    if (!this.contentRulesEnabled) {
+      if (value !== undefined && value !== null) {
+        throw new DemoValidationError('Shadow demo content rules are not enabled on this deployment');
+      }
+      return [];
+    }
+    try {
+      return validateShadowExcludeKeywords(value);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new DemoValidationError(message);
+    }
   }
 
   private async readRequiredSession(sessionId: string): Promise<ShadowDemoSessionState> {
@@ -644,10 +719,14 @@ export function createDefaultShadowDemoService(): ShadowDemoService {
     store: createRedisDemoStore(),
     loadCorpus: createDefaultCorpusLoader(),
     now: () => new Date(),
+    contentRulesEnabled: config.DEMO_CONTENT_RULES_ENABLED,
   });
 }
 
-function sessionPayload(state: ShadowDemoSessionState): ShadowDemoSessionPayload {
+function sessionPayload(
+  state: ShadowDemoSessionState,
+  contentRulesEnabled: boolean
+): ShadowDemoSessionPayload {
   return {
     session: {
       sessionId: state.sessionId,
@@ -657,7 +736,7 @@ function sessionPayload(state: ShadowDemoSessionState): ShadowDemoSessionPayload
       expiresAt: state.expiresAt,
       corpusHealth: state.corpus.health,
       epochs: state.epochs,
-      pendingAggregate: pendingAggregateFor(state),
+      pendingAggregate: pendingAggregateFor(state, contentRulesEnabled),
       voteCount: state.votes.length,
       guidedEpochs: SHADOW_DEMO_GUIDED_EPOCHS,
       maxEpochs: SHADOW_DEMO_MAX_EPOCHS_PER_SESSION,
@@ -668,6 +747,12 @@ function sessionPayload(state: ShadowDemoSessionState): ShadowDemoSessionPayload
       votes: state.votes,
       topicCatalog: state.corpus.topicCatalog,
       sourceFeedUri: state.corpus.sourceFeedUri,
+      ...(contentRulesEnabled
+        ? {
+            contentRulesEnabled: true,
+            suggestedExcludeKeywords: suggestedExcludeKeywords(state.corpus.items, 6),
+          }
+        : {}),
     },
   };
 }
@@ -777,6 +862,15 @@ function createEpoch(options: {
       ...options.aggregate,
       weights: { ...options.aggregate.weights },
       topicIntent: cloneShadowTopicIntent(options.aggregate.topicIntent),
+      ...(options.aggregate.contentRules
+        ? {
+            contentRules: {
+              ...options.aggregate.contentRules,
+              adoptedExcludeKeywords: [...options.aggregate.contentRules.adoptedExcludeKeywords],
+              support: options.aggregate.contentRules.support.map((entry) => ({ ...entry })),
+            },
+          }
+        : {}),
     },
   };
 }
@@ -875,9 +969,24 @@ function votesForEpoch(state: ShadowDemoSessionState, epochId: string): ShadowDe
   return state.votes.filter((vote) => vote.epochId === epochId);
 }
 
-function pendingAggregateFor(state: ShadowDemoSessionState): ReturnType<typeof aggregateShadowVotes> | null {
+function pendingAggregateFor(
+  state: ShadowDemoSessionState,
+  contentRulesEnabled: boolean
+): ReturnType<typeof aggregateShadowVotes> | null {
   const votes = votesForEpoch(state, state.currentEpochId);
-  return votes.length > 0 ? aggregateShadowVotes(votes) : null;
+  if (votes.length === 0) {
+    return null;
+  }
+  return {
+    ...aggregateShadowVotes(votes),
+    ...(contentRulesEnabled
+      ? {
+          // Live support preview while the electorate is still assembling:
+          // threshold stays at the full-electorate bar the decision will use.
+          contentRules: aggregateShadowContentRules(votes, SHADOW_DEMO_TOTAL_DEMO_VOTERS),
+        }
+      : {}),
+  };
 }
 
 function assertPhaseForReviewerVote(state: ShadowDemoSessionState): void {
@@ -896,18 +1005,32 @@ function assertCompleteDemoElectorate(votes: ShadowDemoVote[], epochId: string):
   }
 }
 
+function adoptedRulesFor(epoch: ShadowDemoEpoch): string[] {
+  return epoch.aggregate.contentRules?.adoptedExcludeKeywords ?? [];
+}
+
 function rankedPosts(options: {
   corpus: ShadowDemoCorpus;
   epoch: ShadowDemoEpoch;
   previousEpoch: ShadowDemoEpoch | null;
   limit: number;
-}): ShadowDemoRankedPost[] {
+}): { posts: ShadowDemoRankedPost[]; withheld: ShadowDemoWithheldPost[] } {
   const previousRanks = options.previousEpoch
     ? rankMapForEpoch(options.corpus, options.previousEpoch)
     : new Map<string, number>();
   const isPublishedBaseline = options.corpus.communityId === 'community_gov' && options.epoch.sequence === 1;
-  return scoreAndPublishItems(
-    options.corpus.items,
+  const ruleApplication = applyShadowContentRules(options.corpus.items, adoptedRulesFor(options.epoch));
+  const support = new Map(
+    (options.epoch.aggregate.contentRules?.support ?? []).map((entry) => [entry.keyword, entry.supportCount])
+  );
+  const withheld = ruleApplication.withheld.map((entry) => ({
+    keyword: entry.keyword,
+    supportCount: support.get(entry.keyword) ?? 0,
+    previousRank: previousRanks.get(entry.item.postUri) ?? null,
+    post: entry.item.displayPost,
+  }));
+  const posts = scoreAndPublishItems(
+    ruleApplication.eligible,
     options.epoch.aggregate.weights,
     options.epoch.aggregate.topicIntent,
     isPublishedBaseline,
@@ -934,6 +1057,7 @@ function rankedPosts(options: {
           : null,
       };
     });
+  return { posts, withheld };
 }
 
 function rankMapForEpoch(corpus: ShadowDemoCorpus, epoch: ShadowDemoEpoch): Map<string, number> {
@@ -943,7 +1067,7 @@ function rankMapForEpoch(corpus: ShadowDemoCorpus, epoch: ShadowDemoEpoch): Map<
     return ranks;
   }
   scoreAndPublishItems(
-    corpus.items,
+    applyShadowContentRules(corpus.items, adoptedRulesFor(epoch)).eligible,
     epoch.aggregate.weights,
     epoch.aggregate.topicIntent,
     false,
@@ -992,6 +1116,7 @@ function counterfactualsForReceipt(options: {
         weights: previousWeights,
         topicIntent: previousTopicIntent,
         visibleRank: options.visibleRank,
+        adoptedExcludeKeywords: previousEpoch ? adoptedRulesFor(previousEpoch) : [],
       });
   return [
     previousCounterfactual,
@@ -1003,6 +1128,7 @@ function counterfactualsForReceipt(options: {
       weights: engagementOnlyWeights(),
       topicIntent: options.epoch.aggregate.topicIntent,
       visibleRank: options.visibleRank,
+      adoptedExcludeKeywords: adoptedRulesFor(options.epoch),
     }),
     counterfactualForWeights({
       label: 'direct_reviewer_ballot_removed',
@@ -1012,6 +1138,7 @@ function counterfactualsForReceipt(options: {
       weights: directReviewerBallotRemoved.weights,
       topicIntent: directReviewerBallotRemoved.topicIntent,
       visibleRank: options.visibleRank,
+      adoptedExcludeKeywords: adoptedRulesFor(options.epoch),
     }),
   ];
 }
@@ -1040,12 +1167,14 @@ function counterfactualForWeights(options: {
   weights: ShadowDemoWeights;
   topicIntent: ShadowDemoTopicIntent;
   visibleRank: number;
+  adoptedExcludeKeywords?: readonly string[];
 }): ShadowDemoCounterfactual {
   const rank = rankForWeights(
     options.state.corpus,
     options.item.postUri,
     options.weights,
-    options.topicIntent
+    options.topicIntent,
+    options.adoptedExcludeKeywords ?? []
   );
   return {
     label: options.label,
@@ -1059,10 +1188,11 @@ function rankForWeights(
   corpus: ShadowDemoCorpus,
   postUri: string,
   weights: ShadowDemoWeights,
-  topicIntent: ShadowDemoTopicIntent
+  topicIntent: ShadowDemoTopicIntent,
+  adoptedExcludeKeywords: readonly string[] = []
 ): number | null {
   const ranked = scoreAndPublishItems(
-    corpus.items,
+    applyShadowContentRules(corpus.items, adoptedExcludeKeywords).eligible,
     weights,
     topicIntent,
     false,

--- a/src/demo/service.ts
+++ b/src/demo/service.ts
@@ -250,6 +250,9 @@ export class ShadowDemoService {
   }
 
   async castVote(request: CastVoteRequest): Promise<ShadowDemoServiceResult<ShadowDemoSessionPayload>> {
+    if (!this.contentRulesEnabled) {
+      this.validateExcludeKeywordsForApi(request.excludeKeywords);
+    }
     const operation = async (): Promise<PendingSessionMutation<ShadowDemoServiceResult<ShadowDemoSessionPayload>>> => {
       const state = await this.readRequiredSession(request.sessionId);
       assertCurrentEpoch(state, request.baseEpochId);
@@ -293,6 +296,7 @@ export class ShadowDemoService {
       idempotencyKey: request.idempotencyKey,
       requestPayload: request,
       operation,
+      mapReplay: (response) => publicSessionMutationResult(response, this.contentRulesEnabled),
     });
   }
 
@@ -353,6 +357,7 @@ export class ShadowDemoService {
       idempotencyKey: request.idempotencyKey,
       requestPayload: request,
       operation,
+      mapReplay: (response) => publicSessionMutationResult(response, this.contentRulesEnabled),
     });
   }
 
@@ -411,6 +416,7 @@ export class ShadowDemoService {
       idempotencyKey: request.idempotencyKey,
       requestPayload: request,
       operation,
+      mapReplay: (response) => publicSessionMutationResult(response, this.contentRulesEnabled),
     });
   }
 
@@ -672,6 +678,7 @@ export class ShadowDemoService {
     idempotencyKey: string | null;
     requestPayload: unknown;
     operation: () => Promise<PendingSessionMutation<TPayload>>;
+    mapReplay: (response: TPayload) => TPayload;
   }): Promise<TPayload> {
     const token = randomUUID();
     const acquired = await this.store.acquireSessionLock(options.sessionId, token, LOCK_TTL_MS);
@@ -689,7 +696,7 @@ export class ShadowDemoService {
           if (existing.requestHash !== requestHash) {
             throw new DemoConflictError(`Idempotency key reused with a different payload: ${options.idempotencyKey}`);
           }
-          return existing.response;
+          return options.mapReplay(existing.response);
         }
       }
 
@@ -718,6 +725,33 @@ export class ShadowDemoService {
       await this.store.releaseSessionLock(options.sessionId, token);
     }
   }
+}
+
+function publicSessionMutationResult(
+  result: ShadowDemoServiceResult<ShadowDemoSessionPayload>,
+  contentRulesEnabled: boolean
+): ShadowDemoServiceResult<ShadowDemoSessionPayload> {
+  if (contentRulesEnabled) {
+    return result;
+  }
+  const {
+    contentRulesEnabled: _contentRulesEnabled,
+    suggestedExcludeKeywords: _suggestedExcludeKeywords,
+    ...session
+  } = result.payload.session;
+  return {
+    ...result,
+    payload: {
+      session: {
+        ...session,
+        epochs: session.epochs.map((epoch) => publicEpoch(epoch, false)),
+        pendingAggregate: session.pendingAggregate
+          ? publicAggregate(session.pendingAggregate, false)
+          : null,
+        votes: session.votes.map((vote) => publicVote(vote, false)),
+      },
+    },
+  };
 }
 
 export function createDefaultShadowDemoService(): ShadowDemoService {

--- a/src/demo/store.ts
+++ b/src/demo/store.ts
@@ -166,12 +166,25 @@ const StoredCorpusSchema = z.object({
   }).optional(),
 });
 
+const StoredContentRulesSummarySchema = z.object({
+  enabled: z.literal(true),
+  threshold: z.number().int().positive(),
+  electorate: z.number().int().nonnegative(),
+  adoptedExcludeKeywords: z.array(z.string().min(1).max(50)),
+  support: z.array(z.object({
+    keyword: z.string().min(1).max(50),
+    supportCount: z.number().int().nonnegative(),
+    adopted: z.boolean(),
+  })),
+});
+
 const StoredVoteSummarySchema = z.object({
   aggregateMethod: z.literal('trimmed_mean_no_trim_under_10'),
   voteCount: z.number().int().nonnegative(),
   trimCount: z.number().int().nonnegative(),
   weights: StoredWeightsSchema,
   topicIntent: StoredTopicIntentSchema,
+  contentRules: StoredContentRulesSummarySchema.optional(),
 });
 
 const StoredEpochSchema = z.object({
@@ -191,6 +204,7 @@ const StoredVoteBaseSchema = z.object({
   label: z.string().min(1),
   weights: StoredWeightsSchema,
   topicIntent: StoredTopicIntentSchema,
+  excludeKeywords: z.array(z.string().min(1).max(50)).max(10).optional(),
   createdAt: z.string().min(1),
 });
 

--- a/src/demo/store.ts
+++ b/src/demo/store.ts
@@ -6,6 +6,7 @@ import {
   SHADOW_DEMO_COMMUNITY_IDS,
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
+  SHADOW_DEMO_TOTAL_DEMO_VOTERS,
   SHADOW_DEMO_PHASES,
   SHADOW_DEMO_SIGNAL_KEYS,
   SHADOW_DEMO_TOPIC_KEYS,
@@ -170,7 +171,7 @@ const StoredCorpusSchema = z.object({
 
 // Distinct proposed keywords per epoch = reviewer (<= MAX) plus prior-adopted
 // (itself capped at MAX), so support entries stay well under this ceiling.
-const STORED_CONTENT_RULE_SUPPORT_MAX = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS * 25;
+const STORED_CONTENT_RULE_SUPPORT_MAX = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS * SHADOW_DEMO_TOTAL_DEMO_VOTERS;
 
 const StoredContentRulesSummarySchema = z.object({
   enabled: z.literal(true),

--- a/src/demo/store.ts
+++ b/src/demo/store.ts
@@ -4,6 +4,7 @@ import { z, type ZodTypeAny } from 'zod';
 import { logger } from '../lib/logger.js';
 import {
   SHADOW_DEMO_COMMUNITY_IDS,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
   SHADOW_DEMO_PHASES,
   SHADOW_DEMO_SIGNAL_KEYS,
   SHADOW_DEMO_TOPIC_KEYS,
@@ -170,12 +171,12 @@ const StoredContentRulesSummarySchema = z.object({
   enabled: z.literal(true),
   threshold: z.number().int().positive(),
   electorate: z.number().int().nonnegative(),
-  adoptedExcludeKeywords: z.array(z.string().min(1).max(50)),
+  adoptedExcludeKeywords: z.array(z.string().min(1).max(50)).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS),
   support: z.array(z.object({
     keyword: z.string().min(1).max(50),
     supportCount: z.number().int().nonnegative(),
     adopted: z.boolean(),
-  })),
+  })).max(250),
 });
 
 const StoredVoteSummarySchema = z.object({

--- a/src/demo/store.ts
+++ b/src/demo/store.ts
@@ -5,6 +5,7 @@ import { logger } from '../lib/logger.js';
 import {
   SHADOW_DEMO_COMMUNITY_IDS,
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
   SHADOW_DEMO_PHASES,
   SHADOW_DEMO_SIGNAL_KEYS,
   SHADOW_DEMO_TOPIC_KEYS,
@@ -167,16 +168,20 @@ const StoredCorpusSchema = z.object({
   }).optional(),
 });
 
+// Distinct proposed keywords per epoch = reviewer (<= MAX) plus prior-adopted
+// (itself capped at MAX), so support entries stay well under this ceiling.
+const STORED_CONTENT_RULE_SUPPORT_MAX = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS * 25;
+
 const StoredContentRulesSummarySchema = z.object({
   enabled: z.literal(true),
   threshold: z.number().int().positive(),
   electorate: z.number().int().nonnegative(),
-  adoptedExcludeKeywords: z.array(z.string().min(1).max(50)).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS),
+  adoptedExcludeKeywords: z.array(z.string().min(1).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH)).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS),
   support: z.array(z.object({
-    keyword: z.string().min(1).max(50),
+    keyword: z.string().min(1).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH),
     supportCount: z.number().int().nonnegative(),
     adopted: z.boolean(),
-  })).max(250),
+  })).max(STORED_CONTENT_RULE_SUPPORT_MAX),
 });
 
 const StoredVoteSummarySchema = z.object({
@@ -205,7 +210,7 @@ const StoredVoteBaseSchema = z.object({
   label: z.string().min(1),
   weights: StoredWeightsSchema,
   topicIntent: StoredTopicIntentSchema,
-  excludeKeywords: z.array(z.string().min(1).max(50)).max(10).optional(),
+  excludeKeywords: z.array(z.string().min(1).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH)).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS).optional(),
   createdAt: z.string().min(1),
 });
 

--- a/src/demo/synthetic-voters.ts
+++ b/src/demo/synthetic-voters.ts
@@ -1,3 +1,4 @@
+import { syntheticExcludeKeywords } from './content-rules.js';
 import { normalizeShadowWeights } from './weights.js';
 import {
   SHADOW_DEMO_SYNTHETIC_VOTER_COUNT,
@@ -190,6 +191,10 @@ export function createSyntheticVoterVotes(options: {
   priorCommunityWeights: ShadowDemoWeights;
   priorTopicIntent: ShadowDemoTopicIntent;
   createdAt: string;
+  contentRules?: {
+    reviewerExcludeKeywords: readonly string[];
+    priorAdoptedExcludeKeywords: readonly string[];
+  };
 }): ShadowDemoVote[] {
   return profilesForCommunity(options.communityId).flatMap((profile) =>
     Array.from({ length: profile.voterCount }, (_unused, voterIndex) => {
@@ -217,6 +222,19 @@ export function createSyntheticVoterVotes(options: {
         priorTopicIntent: options.priorTopicIntent,
       });
 
+      const excludeKeywords = options.contentRules
+        ? syntheticExcludeKeywords({
+            seed: options.seed,
+            communityId: options.communityId,
+            epochId: options.epochId,
+            actorId,
+            blocId: profile.id,
+            policyInertia: profile.policyInertia,
+            reviewerExcludeKeywords: options.contentRules.reviewerExcludeKeywords,
+            priorAdoptedExcludeKeywords: options.contentRules.priorAdoptedExcludeKeywords,
+          })
+        : undefined;
+
       return {
         id: `vote-${actorId}-${options.epochId}`,
         epochId: options.epochId,
@@ -226,6 +244,7 @@ export function createSyntheticVoterVotes(options: {
         label: `${profile.label} voter ${voterNumber}`,
         weights: normalizeShadowWeights(blended),
         topicIntent,
+        ...(excludeKeywords && excludeKeywords.length > 0 ? { excludeKeywords } : {}),
         createdAt: options.createdAt,
       };
     })

--- a/src/demo/types.ts
+++ b/src/demo/types.ts
@@ -453,7 +453,7 @@ export interface ShadowDemoFeedPayload {
   corpusProvenance: ShadowDemoCorpusProvenance;
   aggregate: ShadowDemoVoteSummary;
   posts: ShadowDemoRankedPost[];
-  /** Present only when DEMO_CONTENT_RULES_ENABLED and the epoch adopted rules. */
+  /** Present only when content rules are enabled for the epoch; may be an empty array. */
   withheldPosts?: ShadowDemoWithheldPost[];
 }
 

--- a/src/demo/types.ts
+++ b/src/demo/types.ts
@@ -80,6 +80,41 @@ export const SHADOW_DEMO_CORPUS_PROVENANCE = {
   topicScoreThreshold: 0.5,
 } as const;
 
+export const SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS = 10;
+
+export const SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH = 50;
+
+/** Mirrors production KEYWORD_THRESHOLD in src/governance/aggregation.ts. */
+export const SHADOW_DEMO_CONTENT_RULE_SUPPORT_THRESHOLD = 0.3;
+
+export interface ShadowDemoContentRuleSupport {
+  keyword: string;
+  supportCount: number;
+  adopted: boolean;
+}
+
+export interface ShadowDemoContentRulesSummary {
+  enabled: true;
+  /** Votes needed to adopt a keyword: ceil(threshold share x electorate), min 1. */
+  threshold: number;
+  /** Every demo ballot is complete, so the denominator is the full electorate. */
+  electorate: number;
+  adoptedExcludeKeywords: string[];
+  support: ShadowDemoContentRuleSupport[];
+}
+
+export interface ShadowDemoSuggestedExcludeKeyword {
+  keyword: string;
+  matchCount: number;
+}
+
+export interface ShadowDemoWithheldPost {
+  keyword: string;
+  supportCount: number;
+  previousRank: number | null;
+  post: ShadowDemoDisplayPost;
+}
+
 export const SHADOW_DEMO_PHASES = [
   'created',
   'reviewer_voted',
@@ -307,6 +342,8 @@ interface ShadowDemoVoteBase {
   label: string;
   weights: ShadowDemoWeights;
   topicIntent: ShadowDemoTopicIntent;
+  /** Present only when DEMO_CONTENT_RULES_ENABLED; normalized exclude keywords. */
+  excludeKeywords?: string[];
   createdAt: string;
 }
 
@@ -330,6 +367,8 @@ export interface ShadowDemoVoteSummary {
   trimCount: number;
   weights: ShadowDemoWeights;
   topicIntent: ShadowDemoTopicIntent;
+  /** Present only when DEMO_CONTENT_RULES_ENABLED. Threshold rule, not trimmed mean. */
+  contentRules?: ShadowDemoContentRulesSummary;
 }
 
 export interface ShadowDemoEpoch {
@@ -386,6 +425,9 @@ export interface ShadowDemoSessionPayload {
     votes: ShadowDemoVote[];
     topicCatalog?: ShadowDemoTopicCatalogEntry[];
     sourceFeedUri?: string;
+    /** Present only when DEMO_CONTENT_RULES_ENABLED. */
+    contentRulesEnabled?: boolean;
+    suggestedExcludeKeywords?: ShadowDemoSuggestedExcludeKeyword[];
   };
 }
 
@@ -411,6 +453,8 @@ export interface ShadowDemoFeedPayload {
   corpusProvenance: ShadowDemoCorpusProvenance;
   aggregate: ShadowDemoVoteSummary;
   posts: ShadowDemoRankedPost[];
+  /** Present only when DEMO_CONTENT_RULES_ENABLED and the epoch adopted rules. */
+  withheldPosts?: ShadowDemoWithheldPost[];
 }
 
 export interface ShadowDemoReceiptContribution {
@@ -470,6 +514,14 @@ export interface ShadowDemoReceiptPayload {
       postInclusionReasons: ShadowDemoCorpusInclusionReason;
     };
     counterfactuals: ShadowDemoCounterfactual[];
+    /** Present only when DEMO_CONTENT_RULES_ENABLED. */
+    contentRules?: {
+      adoptedExcludeKeywords: string[];
+      threshold: number;
+      electorate: number;
+      /** Always null on a rank receipt; withheld posts have no rank receipt. */
+      matchedKeyword: null;
+    };
   };
 }
 

--- a/tests/demo-content-rules.test.ts
+++ b/tests/demo-content-rules.test.ts
@@ -167,6 +167,18 @@ describe('shadow demo content rules disabled (v4 parity)', () => {
       })
     ).rejects.toThrow(/not enabled/);
 
+    // An explicitly supplied null (not an omitted field) is also rejected.
+    await expect(
+      service.castVote({
+        sessionId: session.sessionId,
+        baseEpochId: session.currentEpochId,
+        weights: equalWeights(),
+        topicIntent: fullTopicIntent(),
+        excludeKeywords: null,
+        idempotencyKey: 'rules-off-null',
+      })
+    ).rejects.toThrow(/not enabled/);
+
     const advanced = await runFullEpoch(service, session.sessionId, session.currentEpochId, undefined, 'off');
     const epoch = advanced.payload.session.epochs.find(
       (candidate) => candidate.id === advanced.payload.session.currentEpochId
@@ -200,6 +212,8 @@ describe('shadow demo content rules disabled (v4 parity)', () => {
     expect('contentRules' in feed.payload.aggregate).toBe(false);
     const disabledSession = await disabled.getSession(session.sessionId);
     expect(disabledSession.payload.session.epochs.some((e) => 'contentRules' in e.aggregate)).toBe(false);
+    // Per-ballot rule metadata must not leak through the votes array either.
+    expect(disabledSession.payload.session.votes.some((vote) => 'excludeKeywords' in vote)).toBe(false);
     // getReceipt ranks the full corpus and throws for a withheld post; resolving
     // for the atproto-matching post proves the persisted rule is not applied.
     const receipt = await disabled.getReceipt({ sessionId: session.sessionId, epochId: shadowEpochId, postUri: postUri(2) });

--- a/tests/demo-content-rules.test.ts
+++ b/tests/demo-content-rules.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import type { Redis } from 'ioredis';
+import { describe, expect, it, vi } from 'vitest';
 import {
   aggregateShadowContentRules,
   applyShadowContentRules,
@@ -8,8 +9,8 @@ import {
   validateShadowExcludeKeywords,
 } from '../src/demo/content-rules.js';
 import { ShadowDemoService } from '../src/demo/service.js';
-import { MemoryDemoStore } from '../src/demo/store.js';
-import type { ShadowDemoCorpus, ShadowDemoVote } from '../src/demo/types.js';
+import { DemoStoreCorruptionError, MemoryDemoStore, RedisDemoStore } from '../src/demo/store.js';
+import type { ShadowDemoCorpus, ShadowDemoSessionState, ShadowDemoVote } from '../src/demo/types.js';
 
 const NOW = new Date('2026-07-12T22:30:00.000Z');
 const TOPIC_SLUGS = [
@@ -45,6 +46,14 @@ describe('shadow demo content-rule primitives', () => {
     expect(() => validateShadowExcludeKeywords(['x'.repeat(51)])).toThrow(/50/);
     expect(() => validateShadowExcludeKeywords(Array.from({ length: 11 }, (_u, i) => `k${i}`)))
       .toThrow(/at most 10/);
+
+    // Inclusive limits: exactly 10 keywords, each exactly 10 characters, are accepted.
+    const tenKeywords = Array.from({ length: 10 }, (_u, i) => `k${i}`.padEnd(10, 'x'));
+    expect(validateShadowExcludeKeywords(tenKeywords)).toEqual(tenKeywords);
+
+    // Inclusive limit: a single exactly-50-character keyword is accepted unchanged.
+    const fiftyCharKeyword = 'y'.repeat(50);
+    expect(validateShadowExcludeKeywords([fiftyCharKeyword])).toEqual([fiftyCharKeyword]);
   });
 
   it('adopts keywords at the production 30% share over the full electorate', () => {
@@ -248,6 +257,126 @@ describe('shadow demo content rules enabled', () => {
     expect(runs[0]).toEqual(runs[1]);
   });
 });
+
+describe('shadow demo stored content-rules schema round trip', () => {
+  it('round-trips an adopted content-rules summary and a reviewer excludeKeywords ballot through the Redis store schema', async () => {
+    const session = storedSessionWithContentRules();
+    const { corpus: storedCorpus, ...header } = session;
+    const get = vi.fn()
+      .mockResolvedValueOnce(JSON.stringify(header))
+      .mockResolvedValueOnce(JSON.stringify(storedCorpus));
+    const store = new RedisDemoStore({ get } as unknown as Redis);
+
+    const restored = await store.readSession(session.sessionId);
+
+    expect(restored?.epochs[0]?.aggregate.contentRules).toEqual({
+      enabled: true,
+      threshold: 8,
+      electorate: 25,
+      adoptedExcludeKeywords: ['atproto'],
+      support: [{ keyword: 'atproto', supportCount: 10, adopted: true }],
+    });
+    expect(restored?.votes[0]?.excludeKeywords).toEqual(['atproto']);
+  });
+
+  it('rejects a stored session whose content-rules arrays exceed the schema bounds', async () => {
+    const tooManyAdopted = storedSessionWithContentRules();
+    tooManyAdopted.epochs[0].aggregate.contentRules!.adoptedExcludeKeywords =
+      Array.from({ length: 11 }, (_unused, i) => `keyword-${i}`);
+    const { corpus: adoptedCorpus, ...adoptedHeader } = tooManyAdopted;
+    const getAdopted = vi.fn()
+      .mockResolvedValueOnce(JSON.stringify(adoptedHeader))
+      .mockResolvedValueOnce(JSON.stringify(adoptedCorpus));
+    await expect(
+      new RedisDemoStore({ get: getAdopted } as unknown as Redis).readSession(tooManyAdopted.sessionId)
+    ).rejects.toBeInstanceOf(DemoStoreCorruptionError);
+
+    const tooMuchSupport = storedSessionWithContentRules();
+    tooMuchSupport.epochs[0].aggregate.contentRules!.support = Array.from({ length: 251 }, (_unused, i) => ({
+      keyword: `keyword-${i}`,
+      supportCount: 1,
+      adopted: false,
+    }));
+    const { corpus: supportCorpus, ...supportHeader } = tooMuchSupport;
+    const getSupport = vi.fn()
+      .mockResolvedValueOnce(JSON.stringify(supportHeader))
+      .mockResolvedValueOnce(JSON.stringify(supportCorpus));
+    await expect(
+      new RedisDemoStore({ get: getSupport } as unknown as Redis).readSession(tooMuchSupport.sessionId)
+    ).rejects.toBeInstanceOf(DemoStoreCorruptionError);
+  });
+});
+
+function storedSessionWithContentRules(): ShadowDemoSessionState {
+  const weights = { recency: 0.2, engagement: 0.2, bridging: 0.2, source_diversity: 0.2, relevance: 0.2 };
+  const topicIntent = { topicWeights: { 'science-research': 0.8 } };
+  return {
+    sessionId: 'content-rules-store-session',
+    communityId: 'community_gov',
+    seed: 'seed-0',
+    phase: 'epoch_advanced',
+    createdAt: NOW.toISOString(),
+    expiresAt: new Date(NOW.getTime() + 90 * 60_000).toISOString(),
+    corpusId: 'content-rules-store-corpus',
+    currentEpochId: 'epoch-1',
+    epochs: [{
+      id: 'epoch-1',
+      sequence: 1,
+      label: 'Epoch 1',
+      status: 'open',
+      createdAt: NOW.toISOString(),
+      advancedAt: null,
+      decidedByEpochId: null,
+      aggregate: {
+        aggregateMethod: 'trimmed_mean_no_trim_under_10',
+        voteCount: 1,
+        trimCount: 0,
+        weights,
+        topicIntent,
+        contentRules: {
+          enabled: true,
+          threshold: 8,
+          electorate: 25,
+          adoptedExcludeKeywords: ['atproto'],
+          support: [{ keyword: 'atproto', supportCount: 10, adopted: true }],
+        },
+      },
+    }],
+    votes: [{
+      id: 'vote-1',
+      epochId: 'epoch-1',
+      label: 'Reviewer ballot',
+      weights,
+      topicIntent,
+      excludeKeywords: ['atproto'],
+      createdAt: NOW.toISOString(),
+      actorType: 'reviewer',
+      actorId: 'reviewer',
+    }],
+    corpus: {
+      corpusId: 'content-rules-store-corpus',
+      communityId: 'community_gov',
+      baseProductionEpochId: 2,
+      baseWeights: weights,
+      baseTopicIntent: topicIntent,
+      createdAt: NOW.toISOString(),
+      expiresAt: new Date(NOW.getTime() + 90 * 60_000).toISOString(),
+      items: [],
+      health: {
+        status: 'live',
+        source: 'production_feed_snapshot',
+        candidatePosts72h: 100,
+        publicScoredPosts: 40,
+        uniqueAuthors72h: 40,
+        bridgePostShare: 0.33,
+        topAuthorConcentration: 0.025,
+        sampledAt: NOW.toISOString(),
+      },
+      warnings: [],
+    },
+    warnings: [],
+  };
+}
 
 function buildService(options: { contentRulesEnabled: boolean; seed: string }): ShadowDemoService {
   return new ShadowDemoService({

--- a/tests/demo-content-rules.test.ts
+++ b/tests/demo-content-rules.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateShadowContentRules,
+  applyShadowContentRules,
+  contentRuleThreshold,
+  suggestedExcludeKeywords,
+  syntheticExcludeKeywords,
+  validateShadowExcludeKeywords,
+} from '../src/demo/content-rules.js';
+import { ShadowDemoService } from '../src/demo/service.js';
+import { MemoryDemoStore } from '../src/demo/store.js';
+import type { ShadowDemoCorpus, ShadowDemoVote } from '../src/demo/types.js';
+
+const NOW = new Date('2026-07-12T22:30:00.000Z');
+const TOPIC_SLUGS = [
+  'adult-content', 'ai-machine-learning', 'art-creative', 'books-reading', 'climate-environment',
+  'cooking-food', 'cybersecurity', 'data-science', 'decentralized-social', 'design-ux',
+  'devops-infrastructure', 'dogs-pets', 'education', 'gaming', 'health-fitness',
+  'mobile-development', 'music', 'news-journalism', 'open-source', 'politics-governance',
+  'science-research', 'software-development', 'space-astronomy', 'startups-business',
+  'systems-programming', 'web-development',
+] as const;
+const TOPICS = TOPIC_SLUGS.map((slug, index) => ({
+  slug,
+  name: slug.split('-').map((part) => `${part[0]?.toUpperCase() ?? ''}${part.slice(1)}`).join(' '),
+  description: null,
+  baselineWeight: Number((0.2 + (index % 7) * 0.1).toFixed(1)),
+}));
+
+// Seeds verified against the deterministic FNV echo hash for epoch
+// shadow-epoch-1 / community_gov / keyword "atproto":
+// ADOPTING_SEED yields 9 synthetic echoes (10/25 with the reviewer, threshold 8);
+// REJECTING_SEED yields 5 synthetic echoes (6/25, below threshold).
+const ADOPTING_SEED = 'seed-0';
+const REJECTING_SEED = 'seed-3';
+
+describe('shadow demo content-rule primitives', () => {
+  it('normalizes exclude keywords with production semantics', () => {
+    expect(validateShadowExcludeKeywords(undefined)).toEqual([]);
+    expect(validateShadowExcludeKeywords(null)).toEqual([]);
+    expect(validateShadowExcludeKeywords([' ATProto ', 'atproto', 'Spam'])).toEqual(['atproto', 'spam']);
+    expect(() => validateShadowExcludeKeywords('atproto')).toThrow(/array/);
+    expect(() => validateShadowExcludeKeywords([42])).toThrow(/strings/);
+    expect(() => validateShadowExcludeKeywords(['  '])).toThrow(/empty/);
+    expect(() => validateShadowExcludeKeywords(['x'.repeat(51)])).toThrow(/50/);
+    expect(() => validateShadowExcludeKeywords(Array.from({ length: 11 }, (_u, i) => `k${i}`)))
+      .toThrow(/at most 10/);
+  });
+
+  it('adopts keywords at the production 30% share over the full electorate', () => {
+    expect(contentRuleThreshold(25)).toBe(8);
+    const votesAt = (count: number): Array<Pick<ShadowDemoVote, 'excludeKeywords'>> => [
+      ...Array.from({ length: count }, () => ({ excludeKeywords: ['atproto'] })),
+      ...Array.from({ length: 25 - count }, () => ({})),
+    ];
+    const adopted = aggregateShadowContentRules(votesAt(8), 25);
+    expect(adopted.threshold).toBe(8);
+    expect(adopted.electorate).toBe(25);
+    expect(adopted.adoptedExcludeKeywords).toEqual(['atproto']);
+    expect(adopted.support).toEqual([{ keyword: 'atproto', supportCount: 8, adopted: true }]);
+
+    const rejected = aggregateShadowContentRules(votesAt(7), 25);
+    expect(rejected.adoptedExcludeKeywords).toEqual([]);
+    expect(rejected.support).toEqual([{ keyword: 'atproto', supportCount: 7, adopted: false }]);
+  });
+
+  it('splits the corpus with the production matcher and passes text-less posts', () => {
+    const corpusFixture = corpus();
+    corpusFixture.items[0].displayPost = { kind: 'hidden_post', reason: 'blocked' };
+    const application = applyShadowContentRules(corpusFixture.items, ['atproto']);
+    const withheldUris = application.withheld.map((entry) => entry.item.postUri);
+    expect(withheldUris).toEqual([postUri(2), postUri(3)]);
+    expect(application.withheld.every((entry) => entry.keyword === 'atproto')).toBe(true);
+    expect(application.eligible.length + application.withheld.length).toBe(corpusFixture.items.length);
+    expect(applyShadowContentRules(corpusFixture.items, []).withheld).toEqual([]);
+  });
+
+  it('suggests deterministic corpus-grounded keywords within effect bounds', () => {
+    const corpusFixture = corpus();
+    const suggestions = suggestedExcludeKeywords(corpusFixture.items, 6);
+    expect(suggestions).toEqual(suggestedExcludeKeywords(corpusFixture.items, 6));
+    expect(suggestions.length).toBeGreaterThan(0);
+    for (const suggestion of suggestions) {
+      expect(suggestion.matchCount).toBeGreaterThanOrEqual(2);
+      expect(suggestion.matchCount).toBeLessThanOrEqual(Math.floor(40 * 0.3));
+      expect(suggestion.keyword.length).toBeGreaterThanOrEqual(4);
+    }
+    // "atproto" appears in exactly two fixture posts.
+    expect(suggestions.map((entry) => entry.keyword)).toContain('atproto');
+  });
+
+  it('replays synthetic keyword ballots exactly and never invents keywords', () => {
+    const options = {
+      seed: ADOPTING_SEED,
+      communityId: 'community_gov',
+      epochId: 'shadow-epoch-1',
+      actorId: 'synthetic-freshness_watcher-1',
+      blocId: 'freshness_watcher' as const,
+      policyInertia: 0.3,
+      reviewerExcludeKeywords: ['atproto'],
+      priorAdoptedExcludeKeywords: ['legacy-rule'],
+    };
+    const first = syntheticExcludeKeywords(options);
+    expect(syntheticExcludeKeywords(options)).toEqual(first);
+    for (const keyword of first) {
+      expect(['atproto', 'legacy-rule']).toContain(keyword);
+    }
+    expect(
+      syntheticExcludeKeywords({
+        ...options,
+        reviewerExcludeKeywords: [],
+        priorAdoptedExcludeKeywords: [],
+      })
+    ).toEqual([]);
+  });
+});
+
+describe('shadow demo content rules disabled (v4 parity)', () => {
+  it('keeps payloads contract-identical and rejects keyword ballots', async () => {
+    const service = buildService({ contentRulesEnabled: false, seed: ADOPTING_SEED });
+    const created = await service.createSession({ communityId: 'community_gov', clientNonce: 'rules-off' });
+    const session = created.payload.session;
+    expect('contentRulesEnabled' in session).toBe(false);
+    expect('suggestedExcludeKeywords' in session).toBe(false);
+    expect('contentRules' in session.epochs[0].aggregate).toBe(false);
+
+    await expect(
+      service.castVote({
+        sessionId: session.sessionId,
+        baseEpochId: session.currentEpochId,
+        weights: equalWeights(),
+        topicIntent: fullTopicIntent(),
+        excludeKeywords: ['atproto'],
+        idempotencyKey: 'rules-off-vote',
+      })
+    ).rejects.toThrow(/not enabled/);
+
+    const advanced = await runFullEpoch(service, session.sessionId, session.currentEpochId, undefined, 'off');
+    const epoch = advanced.payload.session.epochs.find(
+      (candidate) => candidate.id === advanced.payload.session.currentEpochId
+    );
+    expect(epoch && 'contentRules' in epoch.aggregate).toBe(false);
+
+    const feed = await service.getFeed({
+      sessionId: session.sessionId,
+      epochId: advanced.payload.session.currentEpochId,
+      limit: 12,
+    });
+    expect('withheldPosts' in feed.payload).toBe(false);
+  });
+});
+
+describe('shadow demo content rules enabled', () => {
+  it('adopts a supported reviewer keyword, withholds matching posts, and explains it', async () => {
+    const service = buildService({ contentRulesEnabled: true, seed: ADOPTING_SEED });
+    const created = await service.createSession({ communityId: 'community_gov', clientNonce: 'rules-adopt' });
+    const session = created.payload.session;
+    expect(session.contentRulesEnabled).toBe(true);
+    expect(session.suggestedExcludeKeywords?.length).toBeGreaterThan(0);
+    expect(session.epochs[0].aggregate.contentRules).toMatchObject({
+      threshold: 8,
+      electorate: 25,
+      adoptedExcludeKeywords: [],
+    });
+
+    const advanced = await runFullEpoch(service, session.sessionId, session.currentEpochId, ['ATProto'], 'adopt');
+    const shadowEpochId = advanced.payload.session.currentEpochId;
+    const epoch = advanced.payload.session.epochs.find((candidate) => candidate.id === shadowEpochId);
+    expect(epoch?.aggregate.contentRules).toMatchObject({
+      threshold: 8,
+      electorate: 25,
+      adoptedExcludeKeywords: ['atproto'],
+    });
+    expect(epoch?.aggregate.contentRules?.support).toEqual([
+      { keyword: 'atproto', supportCount: 10, adopted: true },
+    ]);
+
+    const feed = await service.getFeed({ sessionId: session.sessionId, epochId: shadowEpochId, limit: 12 });
+    expect(feed.payload.withheldPosts?.map((entry) => [
+      entry.keyword,
+      entry.post.kind === 'public_post' ? entry.post.uri : null,
+      entry.supportCount,
+    ])).toEqual([
+      ['atproto', postUri(2), 10],
+      ['atproto', postUri(3), 10],
+    ]);
+    const rankedUris = feed.payload.posts
+      .filter((post) => post.post.kind === 'public_post')
+      .map((post) => (post.post.kind === 'public_post' ? post.post.uri : ''));
+    expect(rankedUris).not.toContain(postUri(2));
+    expect(rankedUris).not.toContain(postUri(3));
+
+    await expect(
+      service.getReceipt({ sessionId: session.sessionId, epochId: shadowEpochId, postUri: postUri(2) })
+    ).rejects.toThrow(/withheld by adopted community rule "-atproto" \(10\/25 support, threshold 8\)/);
+
+    const visibleReceipt = await service.getReceipt({
+      sessionId: session.sessionId,
+      epochId: shadowEpochId,
+      postUri: postUri(5),
+    });
+    expect(visibleReceipt.payload.receipt.contentRules).toEqual({
+      adoptedExcludeKeywords: ['atproto'],
+      threshold: 8,
+      electorate: 25,
+      matchedKeyword: null,
+    });
+  });
+
+  it('visibly rejects a keyword that falls short of the threshold', async () => {
+    const service = buildService({ contentRulesEnabled: true, seed: REJECTING_SEED });
+    const created = await service.createSession({ communityId: 'community_gov', clientNonce: 'rules-reject' });
+    const session = created.payload.session;
+    const advanced = await runFullEpoch(service, session.sessionId, session.currentEpochId, ['atproto'], 'reject');
+    const shadowEpochId = advanced.payload.session.currentEpochId;
+    const epoch = advanced.payload.session.epochs.find((candidate) => candidate.id === shadowEpochId);
+    expect(epoch?.aggregate.contentRules).toMatchObject({ adoptedExcludeKeywords: [] });
+    expect(epoch?.aggregate.contentRules?.support).toEqual([
+      { keyword: 'atproto', supportCount: 6, adopted: false },
+    ]);
+
+    const feed = await service.getFeed({ sessionId: session.sessionId, epochId: shadowEpochId, limit: 12 });
+    expect(feed.payload.withheldPosts).toEqual([]);
+    // The rejected keyword must not withhold the matching post: its receipt
+    // resolves normally instead of the withheld-rule error.
+    const receipt = await service.getReceipt({
+      sessionId: session.sessionId,
+      epochId: shadowEpochId,
+      postUri: postUri(2),
+    });
+    expect(receipt.payload.receipt.contentRules).toMatchObject({ adoptedExcludeKeywords: [] });
+  });
+
+  it('replays an identical session byte-for-byte with keyword ballots present', async () => {
+    const runs = await Promise.all(['left', 'right'].map(async (nonce) => {
+      const service = buildService({ contentRulesEnabled: true, seed: ADOPTING_SEED });
+      const created = await service.createSession({ communityId: 'community_gov', clientNonce: nonce });
+      const session = created.payload.session;
+      const advanced = await runFullEpoch(service, session.sessionId, session.currentEpochId, ['atproto'], nonce);
+      const feed = await service.getFeed({
+        sessionId: session.sessionId,
+        epochId: advanced.payload.session.currentEpochId,
+        limit: 12,
+      });
+      const epochs = advanced.payload.session.epochs.map((epoch) => epoch.aggregate);
+      return JSON.stringify({ epochs, posts: feed.payload.posts, withheld: feed.payload.withheldPosts });
+    }));
+    expect(runs[0]).toEqual(runs[1]);
+  });
+});
+
+function buildService(options: { contentRulesEnabled: boolean; seed: string }): ShadowDemoService {
+  return new ShadowDemoService({
+    store: new MemoryDemoStore(),
+    loadCorpus: async () => corpus(),
+    now: () => NOW,
+    contentRulesEnabled: options.contentRulesEnabled,
+    seed: () => options.seed,
+  });
+}
+
+async function runFullEpoch(
+  service: ShadowDemoService,
+  sessionId: string,
+  baseEpochId: string,
+  excludeKeywords: string[] | undefined,
+  keyPrefix: string
+): Promise<Awaited<ReturnType<ShadowDemoService['advanceEpoch']>>> {
+  await service.castVote({
+    sessionId,
+    baseEpochId,
+    weights: equalWeights(),
+    topicIntent: fullTopicIntent(),
+    ...(excludeKeywords ? { excludeKeywords } : {}),
+    idempotencyKey: `${keyPrefix}-vote`,
+  });
+  await service.runSyntheticVoters({
+    sessionId,
+    baseEpochId,
+    idempotencyKey: `${keyPrefix}-voters`,
+  });
+  return service.advanceEpoch({
+    sessionId,
+    fromEpochId: baseEpochId,
+    idempotencyKey: `${keyPrefix}-advance`,
+  });
+}
+
+function equalWeights(): Record<string, number> {
+  return { recency: 0.2, engagement: 0.2, bridging: 0.2, source_diversity: 0.2, relevance: 0.2 };
+}
+
+function fullTopicIntent(): { topicWeights: Record<string, number> } {
+  return { topicWeights: Object.fromEntries(TOPICS.map((topic) => [topic.slug, topic.baselineWeight])) };
+}
+
+function postUri(index: number): string {
+  return `at://did:plc:demo${index}/app.bsky.feed.post/post${index}`;
+}
+
+function corpus(): ShadowDemoCorpus {
+  const items = Array.from({ length: 40 }, (_unused, index) => item(index + 1));
+  return {
+    corpusId: 'approved-community-gov-corpus',
+    communityId: 'community_gov',
+    baseProductionEpochId: 2,
+    baseWeights: { recency: 0.25, engagement: 0.2, bridging: 0.1, source_diversity: 0.1, relevance: 0.35 },
+    baseTopicIntent: { topicWeights: Object.fromEntries(TOPICS.map((topic) => [topic.slug, topic.baselineWeight])) },
+    createdAt: NOW.toISOString(),
+    expiresAt: new Date(NOW.getTime() + 90 * 60_000).toISOString(),
+    items,
+    health: {
+      status: 'live', source: 'production_feed_snapshot', candidatePosts72h: 100, publicScoredPosts: 40,
+      uniqueAuthors72h: 40, bridgePostShare: 0.33, topAuthorConcentration: 0.025, sampledAt: NOW.toISOString(),
+      sourcePostCount: 100, eligiblePostCount: 40, englishTaggedShare: 1, richMediaShare: 0.2,
+    },
+    warnings: [],
+    topicCatalog: [...TOPICS],
+    sourceFeedUri: 'at://did:plc:amzyknmm4auxijvykyfgznw2/app.bsky.feed.generator/community-gov',
+    sourceSnapshot: {
+      feedName: 'Community Governed Feed', digest: 'a'.repeat(64), runId: 'run-1', updatedAt: NOW.toISOString(), capturedAt: NOW.toISOString(), reviewedAt: NOW.toISOString(),
+      sourcePostCount: 100, selectionPolicyVersion: 'community-gov-reviewer-safe-v1', baselineOrderDigest: 'a'.repeat(64),
+      publicationPolicy: { urlDedupEnabled: true, minimumOriginalTextLength: 200, minimumRelevance: 0, decay: [1, 0.7, 0.5, 0.3] },
+    },
+  };
+}
+
+function item(index: number): ShadowDemoCorpus['items'][number] {
+  const uri = postUri(index);
+  // Posts 2 and 3 mention "atproto" so an adopted "-atproto" rule has a
+  // deterministic visible effect; posts 4 and 7 mention "headscale" so the
+  // suggestion floor of two matches is exercised by a second term.
+  const text = index === 2 || index === 3
+    ? `Deep dive ${index}: why ATProto relays matter for federation health`
+    : index === 4 || index === 7
+      ? `Self-hosting notes ${index}: headscale, reverse proxies, and identity`
+      : `Published feed post ${index} about community governance mechanics`;
+  return {
+    postUri: uri, authorDid: `did:plc:demo${index}`, createdAt: NOW.toISOString(),
+    topicVector: { 'science-research': 0.8 },
+    rawScores: { recency: (index % 10) / 10, engagement: 1 - (index % 10) / 10, bridging: (index % 5) / 5, source_diversity: 0.2, relevance: 0.8 },
+    productionScore: 101 - index, productionEpochId: 2, scoredAt: NOW.toISOString(), componentDetails: null,
+    inclusionReasons: { matchedTopics: [], matchedTerms: [], sourceRank: index, reason: 'published_feed_snapshot' },
+    publishedRank: index, publishedScore: 101 - index, publicationAdjustment: 1,
+    displayPost: {
+      kind: 'public_post', uri, cid: `cid-${index}`, authorDid: `did:plc:demo${index}`,
+      authorHandle: `user${index}.bsky.social`, authorDisplayName: `User ${index}`, authorAvatar: null,
+      text, likeCount: index, repostCount: index, replyCount: index, quoteCount: 0,
+      indexedAt: NOW.toISOString(), createdAt: NOW.toISOString(), bskyUrl: `https://bsky.app/profile/did:plc:demo${index}/post/post${index}`,
+      languages: ['en'], media: null,
+    },
+  };
+}

--- a/tests/demo-content-rules.test.ts
+++ b/tests/demo-content-rules.test.ts
@@ -196,11 +196,30 @@ describe('shadow demo content rules disabled (v4 parity)', () => {
     const disabled = buildService({ contentRulesEnabled: false, seed: ADOPTING_SEED }, store);
     const feed = await disabled.getFeed({ sessionId: session.sessionId, epochId: shadowEpochId, limit: 12 });
     expect('withheldPosts' in feed.payload).toBe(false);
+    // Persisted content-rule metadata must not leak into flag-off payloads.
+    expect('contentRules' in feed.payload.aggregate).toBe(false);
+    const disabledSession = await disabled.getSession(session.sessionId);
+    expect(disabledSession.payload.session.epochs.some((e) => 'contentRules' in e.aggregate)).toBe(false);
     // getReceipt ranks the full corpus and throws for a withheld post; resolving
     // for the atproto-matching post proves the persisted rule is not applied.
     const receipt = await disabled.getReceipt({ sessionId: session.sessionId, epochId: shadowEpochId, postUri: postUri(2) });
     expect(receipt.payload.receipt.visibleRank).toBeGreaterThan(0);
     expect('contentRules' in receipt.payload.receipt).toBe(false);
+    expect('contentRules' in receipt.payload.receipt.aggregate).toBe(false);
+
+    // Byte-identical parity: a session built entirely flag-off yields the same
+    // feed ordering/ranks and receipt fields as the flipped-off adopted session.
+    const baselineStore = new MemoryDemoStore();
+    const baselineService = buildService({ contentRulesEnabled: false, seed: ADOPTING_SEED }, baselineStore);
+    const baselineCreated = await baselineService.createSession({ communityId: 'community_gov', clientNonce: 'baseline-off' });
+    const baselineSession = baselineCreated.payload.session;
+    const baselineAdvanced = await runFullEpoch(baselineService, baselineSession.sessionId, baselineSession.currentEpochId, undefined, 'baseline');
+    const baselineEpochId = baselineAdvanced.payload.session.currentEpochId;
+    const baselineFeed = await baselineService.getFeed({ sessionId: baselineSession.sessionId, epochId: baselineEpochId, limit: 12 });
+    const rankPairs = (payloadFeed: typeof feed.payload): Array<[number, string]> => payloadFeed.posts
+      .filter((post) => post.post.kind === 'public_post')
+      .map((post) => [post.rank, post.post.kind === 'public_post' ? post.post.uri : ''] as [number, string]);
+    expect(rankPairs(feed.payload)).toEqual(rankPairs(baselineFeed.payload));
   });
 });
 

--- a/tests/demo-content-rules.test.ts
+++ b/tests/demo-content-rules.test.ts
@@ -148,6 +148,47 @@ describe('shadow demo content-rule primitives', () => {
 });
 
 describe('shadow demo content rules disabled (v4 parity)', () => {
+  it('rejects or redacts feature-enabled idempotency replays after the flag flips off', async () => {
+    const store = new MemoryDemoStore();
+    const enabled = buildService({ contentRulesEnabled: true, seed: ADOPTING_SEED }, store);
+    const withRulesCreated = await enabled.createSession({
+      communityId: 'community_gov',
+      clientNonce: 'idempotency-rules-on',
+    });
+    const withRulesRequest = {
+      sessionId: withRulesCreated.payload.session.sessionId,
+      baseEpochId: withRulesCreated.payload.session.currentEpochId,
+      weights: equalWeights(),
+      topicIntent: fullTopicIntent(),
+      excludeKeywords: ['atproto'],
+      idempotencyKey: 'idempotency-rules-on-vote',
+    };
+    await enabled.castVote(withRulesRequest);
+
+    const disabled = buildService({ contentRulesEnabled: false, seed: ADOPTING_SEED }, store);
+    await expect(disabled.castVote(withRulesRequest)).rejects.toThrow(/not enabled/);
+
+    const withoutRulesCreated = await enabled.createSession({
+      communityId: 'community_gov',
+      clientNonce: 'idempotency-no-rules',
+    });
+    const withoutRulesRequest = {
+      sessionId: withoutRulesCreated.payload.session.sessionId,
+      baseEpochId: withoutRulesCreated.payload.session.currentEpochId,
+      weights: equalWeights(),
+      topicIntent: fullTopicIntent(),
+      idempotencyKey: 'idempotency-no-rules-vote',
+    };
+    const enabledResponse = await enabled.castVote(withoutRulesRequest);
+    expect(enabledResponse.payload.session.contentRulesEnabled).toBe(true);
+
+    const replay = await disabled.castVote(withoutRulesRequest);
+    expect('contentRulesEnabled' in replay.payload.session).toBe(false);
+    expect('suggestedExcludeKeywords' in replay.payload.session).toBe(false);
+    expect(replay.payload.session.epochs.some((epoch) => 'contentRules' in epoch.aggregate)).toBe(false);
+    expect(replay.payload.session.votes.some((vote) => 'excludeKeywords' in vote)).toBe(false);
+  });
+
   it('keeps payloads contract-identical and rejects keyword ballots', async () => {
     const service = buildService({ contentRulesEnabled: false, seed: ADOPTING_SEED });
     const created = await service.createSession({ communityId: 'community_gov', clientNonce: 'rules-off' });

--- a/tests/demo-content-rules.test.ts
+++ b/tests/demo-content-rules.test.ts
@@ -12,6 +12,7 @@ import { ShadowDemoService } from '../src/demo/service.js';
 import { DemoStoreCorruptionError, MemoryDemoStore, RedisDemoStore } from '../src/demo/store.js';
 import {
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+  SHADOW_DEMO_TOTAL_DEMO_VOTERS,
   type ShadowDemoCorpus,
   type ShadowDemoSessionState,
   type ShadowDemoVote,
@@ -20,7 +21,7 @@ import {
 // Support entries per epoch never exceed reviewer + prior-adopted keywords, but
 // the persisted schema tolerates the full electorate's worth; keep the test
 // bound derived so it tracks the store schema instead of a hardcoded literal.
-const STORED_SUPPORT_MAX = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS * 25;
+const STORED_SUPPORT_MAX = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS * SHADOW_DEMO_TOTAL_DEMO_VOTERS;
 
 const NOW = new Date('2026-07-12T22:30:00.000Z');
 const TOPIC_SLUGS = [
@@ -178,6 +179,28 @@ describe('shadow demo content rules disabled (v4 parity)', () => {
       limit: 12,
     });
     expect('withheldPosts' in feed.payload).toBe(false);
+  });
+
+  it('ignores rules persisted while the flag was on once the flag flips off', async () => {
+    // Build an adopted-rule session with the flag ON, then read the same stored
+    // session through a flag-OFF service: withholding must not leak.
+    const store = new MemoryDemoStore();
+    const enabled = buildService({ contentRulesEnabled: true, seed: ADOPTING_SEED }, store);
+    const created = await enabled.createSession({ communityId: 'community_gov', clientNonce: 'flip-off' });
+    const session = created.payload.session;
+    const advanced = await runFullEpoch(enabled, session.sessionId, session.currentEpochId, ['ATProto'], 'flip');
+    const shadowEpochId = advanced.payload.session.currentEpochId;
+    const enabledEpoch = advanced.payload.session.epochs.find((candidate) => candidate.id === shadowEpochId);
+    expect(enabledEpoch?.aggregate.contentRules?.adoptedExcludeKeywords).toEqual(['atproto']);
+
+    const disabled = buildService({ contentRulesEnabled: false, seed: ADOPTING_SEED }, store);
+    const feed = await disabled.getFeed({ sessionId: session.sessionId, epochId: shadowEpochId, limit: 12 });
+    expect('withheldPosts' in feed.payload).toBe(false);
+    // getReceipt ranks the full corpus and throws for a withheld post; resolving
+    // for the atproto-matching post proves the persisted rule is not applied.
+    const receipt = await disabled.getReceipt({ sessionId: session.sessionId, epochId: shadowEpochId, postUri: postUri(2) });
+    expect(receipt.payload.receipt.visibleRank).toBeGreaterThan(0);
+    expect('contentRules' in receipt.payload.receipt).toBe(false);
   });
 });
 
@@ -424,10 +447,14 @@ function storedSessionWithContentRules(): ShadowDemoSessionState {
 }
 
 /** A service over an in-memory store with a fixed session seed, so synthetic
- * keyword echoes are deterministic and adoption outcomes are pinned. */
-function buildService(options: { contentRulesEnabled: boolean; seed: string }): ShadowDemoService {
+ * keyword echoes are deterministic and adoption outcomes are pinned. Pass a
+ * shared store to model a config flip against sessions built by another service. */
+function buildService(
+  options: { contentRulesEnabled: boolean; seed: string },
+  store: MemoryDemoStore = new MemoryDemoStore()
+): ShadowDemoService {
   return new ShadowDemoService({
-    store: new MemoryDemoStore(),
+    store,
     loadCorpus: async () => corpus(),
     now: () => NOW,
     contentRulesEnabled: options.contentRulesEnabled,

--- a/tests/demo-content-rules.test.ts
+++ b/tests/demo-content-rules.test.ts
@@ -10,7 +10,17 @@ import {
 } from '../src/demo/content-rules.js';
 import { ShadowDemoService } from '../src/demo/service.js';
 import { DemoStoreCorruptionError, MemoryDemoStore, RedisDemoStore } from '../src/demo/store.js';
-import type { ShadowDemoCorpus, ShadowDemoSessionState, ShadowDemoVote } from '../src/demo/types.js';
+import {
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+  type ShadowDemoCorpus,
+  type ShadowDemoSessionState,
+  type ShadowDemoVote,
+} from '../src/demo/types.js';
+
+// Support entries per epoch never exceed reviewer + prior-adopted keywords, but
+// the persisted schema tolerates the full electorate's worth; keep the test
+// bound derived so it tracks the store schema instead of a hardcoded literal.
+const STORED_SUPPORT_MAX = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS * 25;
 
 const NOW = new Date('2026-07-12T22:30:00.000Z');
 const TOPIC_SLUGS = [
@@ -71,6 +81,18 @@ describe('shadow demo content-rule primitives', () => {
     const rejected = aggregateShadowContentRules(votesAt(7), 25);
     expect(rejected.adoptedExcludeKeywords).toEqual([]);
     expect(rejected.support).toEqual([{ keyword: 'atproto', supportCount: 7, adopted: false }]);
+  });
+
+  it('caps the adopted exclude-rule set at the per-ballot keyword limit', () => {
+    // Inertia across epochs can push more than MAX keywords over threshold;
+    // the persisted policy keeps only the highest-support MAX.
+    const overCap = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS + 5;
+    const votes = Array.from({ length: 25 }, () => ({
+      excludeKeywords: Array.from({ length: overCap }, (_unused, i) => `rule-${i}`),
+    }));
+    const summary = aggregateShadowContentRules(votes, 25);
+    expect(summary.support.filter((entry) => entry.adopted).length).toBe(overCap);
+    expect(summary.adoptedExcludeKeywords).toHaveLength(SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS);
   });
 
   it('splits the corpus with the production matcher and passes text-less posts', () => {
@@ -279,10 +301,31 @@ describe('shadow demo stored content-rules schema round trip', () => {
     expect(restored?.votes[0]?.excludeKeywords).toEqual(['atproto']);
   });
 
+  it('accepts a stored session whose content-rules arrays sit exactly at the schema maximums', async () => {
+    const atMax = storedSessionWithContentRules();
+    atMax.epochs[0].aggregate.contentRules!.adoptedExcludeKeywords =
+      Array.from({ length: SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS }, (_unused, i) => `keyword-${i}`);
+    atMax.epochs[0].aggregate.contentRules!.support =
+      Array.from({ length: STORED_SUPPORT_MAX }, (_unused, i) => ({
+        keyword: `keyword-${i}`,
+        supportCount: 1,
+        adopted: i < SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+      }));
+    const { corpus: atMaxCorpus, ...atMaxHeader } = atMax;
+    const get = vi.fn()
+      .mockResolvedValueOnce(JSON.stringify(atMaxHeader))
+      .mockResolvedValueOnce(JSON.stringify(atMaxCorpus));
+    const restored = await new RedisDemoStore({ get } as unknown as Redis).readSession(atMax.sessionId);
+    expect(restored?.epochs[0].aggregate.contentRules?.adoptedExcludeKeywords).toHaveLength(
+      SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS
+    );
+    expect(restored?.epochs[0].aggregate.contentRules?.support).toHaveLength(STORED_SUPPORT_MAX);
+  });
+
   it('rejects a stored session whose content-rules arrays exceed the schema bounds', async () => {
     const tooManyAdopted = storedSessionWithContentRules();
     tooManyAdopted.epochs[0].aggregate.contentRules!.adoptedExcludeKeywords =
-      Array.from({ length: 11 }, (_unused, i) => `keyword-${i}`);
+      Array.from({ length: SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS + 1 }, (_unused, i) => `keyword-${i}`);
     const { corpus: adoptedCorpus, ...adoptedHeader } = tooManyAdopted;
     const getAdopted = vi.fn()
       .mockResolvedValueOnce(JSON.stringify(adoptedHeader))
@@ -292,7 +335,7 @@ describe('shadow demo stored content-rules schema round trip', () => {
     ).rejects.toBeInstanceOf(DemoStoreCorruptionError);
 
     const tooMuchSupport = storedSessionWithContentRules();
-    tooMuchSupport.epochs[0].aggregate.contentRules!.support = Array.from({ length: 251 }, (_unused, i) => ({
+    tooMuchSupport.epochs[0].aggregate.contentRules!.support = Array.from({ length: STORED_SUPPORT_MAX + 1 }, (_unused, i) => ({
       keyword: `keyword-${i}`,
       supportCount: 1,
       adopted: false,
@@ -307,6 +350,8 @@ describe('shadow demo stored content-rules schema round trip', () => {
   });
 });
 
+/** A minimal advanced-epoch session carrying an adopted content-rules summary
+ * and a reviewer excludeKeywords ballot, for exercising the stored zod schema. */
 function storedSessionWithContentRules(): ShadowDemoSessionState {
   const weights = { recency: 0.2, engagement: 0.2, bridging: 0.2, source_diversity: 0.2, relevance: 0.2 };
   const topicIntent = { topicWeights: { 'science-research': 0.8 } };
@@ -378,6 +423,8 @@ function storedSessionWithContentRules(): ShadowDemoSessionState {
   };
 }
 
+/** A service over an in-memory store with a fixed session seed, so synthetic
+ * keyword echoes are deterministic and adoption outcomes are pinned. */
 function buildService(options: { contentRulesEnabled: boolean; seed: string }): ShadowDemoService {
   return new ShadowDemoService({
     store: new MemoryDemoStore(),
@@ -388,6 +435,8 @@ function buildService(options: { contentRulesEnabled: boolean; seed: string }): 
   });
 }
 
+/** Drive one epoch end to end: reviewer vote (optionally with keywords), the 24
+ * synthetic ballots, then advance — returning the advanced-session result. */
 async function runFullEpoch(
   service: ShadowDemoService,
   sessionId: string,
@@ -427,6 +476,8 @@ function postUri(index: number): string {
   return `at://did:plc:demo${index}/app.bsky.feed.post/post${index}`;
 }
 
+/** A 40-post frozen community_gov corpus (baseProductionEpochId 2) with two
+ * atproto-bearing posts, so an adopted "-atproto" rule has a visible effect. */
 function corpus(): ShadowDemoCorpus {
   const items = Array.from({ length: 40 }, (_unused, index) => item(index + 1));
   return {
@@ -454,6 +505,8 @@ function corpus(): ShadowDemoCorpus {
   };
 }
 
+/** One frozen corpus post; posts 2-3 mention atproto and 4/7 mention headscale
+ * so keyword rules and suggestion floors have deterministic matches. */
 function item(index: number): ShadowDemoCorpus['items'][number] {
   const uri = postUri(index);
   // Posts 2 and 3 mention "atproto" so an adopted "-atproto" rule has a

--- a/web-next/app/demo/__tests__/http-client.test.ts
+++ b/web-next/app/demo/__tests__/http-client.test.ts
@@ -106,6 +106,25 @@ describe("HTTP shadow demo client", () => {
     expect(apiSessionPayloadSchema.safeParse({ session: { ...valid.session, topicCatalog: catalog.slice(0, 25) } }).success).toBe(false)
   })
 
+  it("bounds the content-rules support array on parsed session payloads", () => {
+    const valid = sessionPayload("created", "epoch-1", [epoch("epoch-1", 1, BASE_WEIGHTS, 0)]) as {
+      session: Record<string, unknown>
+    }
+    const epochs = valid.session.epochs as Array<Record<string, unknown>>
+    const withContentRules = (supportLength: number): unknown => {
+      const support = Array.from({ length: supportLength }, (_unused, i) => ({
+        keyword: `rule-${i}`,
+        supportCount: 1,
+        adopted: false,
+      }))
+      const aggregate = { ...(epochs[0].aggregate as Record<string, unknown>) }
+      aggregate.contentRules = { enabled: true, threshold: 8, electorate: 25, adoptedExcludeKeywords: [], support }
+      return { session: { ...valid.session, epochs: [{ ...epochs[0], aggregate }] } }
+    }
+    expect(apiSessionPayloadSchema.safeParse(withContentRules(250)).success).toBe(true)
+    expect(apiSessionPayloadSchema.safeParse(withContentRules(251)).success).toBe(false)
+  })
+
   it("accepts retained live and fallback corpus-health source values", () => {
     const valid = sessionPayload("created", "epoch-1", [epoch("epoch-1", 1, BASE_WEIGHTS, 0)]) as {
       session: Record<string, unknown>

--- a/web-next/app/demo/__tests__/http-client.test.ts
+++ b/web-next/app/demo/__tests__/http-client.test.ts
@@ -310,6 +310,33 @@ describe("HTTP shadow demo client", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it("maps withheld posts with their adopted rule and support", async () => {
+    const feed = feedPayload("epoch-2", [1, 2]) as { posts: Array<Record<string, unknown>> } & Record<string, unknown>
+    const withheldPost = { ...(feed.posts[0].post as Record<string, unknown>), uri: "at://did:plc:test/app.bsky.feed.post/withheld" }
+    feed.withheldPosts = [{ keyword: "atproto", supportCount: 10, previousRank: 4, post: withheldPost }]
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const path = requestPath(input)
+      if (path.startsWith(`/api/demo/v4/sessions/${SESSION_ID}/feed`)) return jsonEnvelope(feed)
+      return new Response(null, { status: 404 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const response = await createHttpShadowDemoClient().getFeed(
+      SESSION_ID,
+      { epochId: "epoch-2", limit: 12 },
+      new AbortController().signal,
+    )
+    expect(response.payload.withheldPosts).toEqual([
+      {
+        keyword: "atproto",
+        supportCount: 10,
+        previousRank: 4,
+        hiddenReason: null,
+        post: expect.objectContaining({ uri: "at://did:plc:test/app.bsky.feed.post/withheld", labels: [] }),
+      },
+    ])
+  })
+
   it("counts visible hidden rows when snapshot source totals are unavailable", async () => {
     const feed = feedPayload("epoch-1", [1, 2]) as { posts: Array<Record<string, unknown>> }
     feed.posts[0] = {

--- a/web-next/app/demo/http-shadow-demo-client.ts
+++ b/web-next/app/demo/http-shadow-demo-client.ts
@@ -35,6 +35,7 @@ import {
   type ShadowDemoVote,
   type ShadowDemoWarning,
   type ShadowDemoWeights,
+  type ShadowDemoWithheldFeedItem,
 } from "./shadow-demo-view-model"
 import {
   CONTRACT_VERSION,
@@ -109,6 +110,9 @@ export function createHttpShadowDemoClient(): ShadowDemoClient {
             baseEpochId: request.baseEpochId,
             weights: request.weights,
             topicIntent: { topicWeights: request.topicIntent.topicWeights },
+            ...(request.excludeKeywords !== undefined && request.excludeKeywords.length > 0
+              ? { excludeKeywords: [...request.excludeKeywords] }
+              : {}),
           }),
         },
         signal,
@@ -375,6 +379,8 @@ function mapSession(
     corpusProvenance: api.corpusProvenance,
     topicCatalog: api.topicCatalog,
     sourceFeedUri: api.sourceFeedUri ?? null,
+    contentRulesEnabled: api.contentRulesEnabled,
+    suggestedExcludeKeywords: api.suggestedExcludeKeywords,
   }
 }
 
@@ -418,6 +424,7 @@ function mapEpoch(epoch: ApiEpoch): ShadowDemoEpoch {
       aggregateMethod: "trimmed_mean_no_trim_under_10",
       trimCount: epoch.aggregate.trimCount,
       reviewerBallotShare: totalVotes > 0 ? 1 / totalVotes : 0,
+      contentRules: epoch.aggregate.contentRules,
     },
     startedAt: epoch.createdAt,
     closedAt: epoch.advancedAt,
@@ -448,6 +455,7 @@ function mapAggregate(summary: ApiVoteSummary): ShadowDemoAggregate {
       aggregateMethod: summary.aggregateMethod,
       trimCount: summary.trimCount,
       reviewerBallotShare: summary.voteCount > 0 ? 1 / summary.voteCount : 0,
+      contentRules: summary.contentRules,
     },
   }
 }
@@ -515,6 +523,44 @@ function mapFeed(payload: ApiFeedPayload, generatedAt: string): ShadowDemoFeed {
       englishTaggedShare: payload.corpusHealth.englishTaggedShare ?? null,
       richMediaShare: payload.corpusHealth.richMediaShare ?? null,
     },
+    withheldPosts: payload.withheldPosts?.map(mapWithheldPost),
+  }
+}
+
+function mapWithheldPost(withheld: NonNullable<ApiFeedPayload["withheldPosts"]>[number]): ShadowDemoWithheldFeedItem {
+  if (withheld.post.kind === "hidden_post") {
+    return {
+      keyword: withheld.keyword,
+      supportCount: withheld.supportCount,
+      previousRank: withheld.previousRank,
+      post: null,
+      hiddenReason: withheld.post.reason,
+    }
+  }
+  return {
+    keyword: withheld.keyword,
+    supportCount: withheld.supportCount,
+    previousRank: withheld.previousRank,
+    post: {
+      uri: withheld.post.uri,
+      cid: withheld.post.cid,
+      bskyUrl: withheld.post.bskyUrl,
+      authorDid: withheld.post.authorDid,
+      authorHandle: withheld.post.authorHandle,
+      authorDisplayName: withheld.post.authorDisplayName,
+      authorAvatar: withheld.post.authorAvatar,
+      text: withheld.post.text,
+      indexedAt: withheld.post.indexedAt,
+      createdAt: withheld.post.createdAt,
+      likeCount: withheld.post.likeCount,
+      repostCount: withheld.post.repostCount,
+      replyCount: withheld.post.replyCount,
+      quoteCount: withheld.post.quoteCount,
+      labels: [],
+      languages: withheld.post.languages ?? [],
+      media: withheld.post.media ?? null,
+    },
+    hiddenReason: null,
   }
 }
 
@@ -667,6 +713,7 @@ function mapReceipt(receipt: ApiReceiptPayload["receipt"], generatedAt: string):
     counterfactuals: receipt.counterfactuals.map(mapCounterfactual),
     generatedAt,
     explanationKind: "shadow_demo_receipt",
+    contentRules: receipt.contentRules,
   }
 }
 

--- a/web-next/app/demo/http-shadow-demo-client.ts
+++ b/web-next/app/demo/http-shadow-demo-client.ts
@@ -528,6 +528,9 @@ function mapFeed(payload: ApiFeedPayload, generatedAt: string): ShadowDemoFeed {
 }
 
 function mapWithheldPost(withheld: NonNullable<ApiFeedPayload["withheldPosts"]>[number]): ShadowDemoWithheldFeedItem {
+  // The backend only withholds public posts (text-less/hidden posts pass the
+  // exclude filter), but the display-post union is modeled faithfully so this
+  // mapping stays correct if that ever changes.
   if (withheld.post.kind === "hidden_post") {
     return {
       keyword: withheld.keyword,

--- a/web-next/app/demo/page.tsx
+++ b/web-next/app/demo/page.tsx
@@ -213,14 +213,21 @@ export default function DemoPage() {
     }, null)
   }
 
-  function handleVote(weights: ShadowDemoWeights, topicIntent: ShadowDemoTopicIntent): void {
+  function handleVote(weights: ShadowDemoWeights, topicIntent: ShadowDemoTopicIntent, excludeKeywords: readonly string[]): void {
     if (session === null || openEpochId === null) {
       return
     }
     void run(async (request) => {
       const response = await client.castVote(
         session.id,
-        { idempotencyKey: `${session.id}:${openEpochId}:vote`, baseEpochId: openEpochId, voterLabel: LABELS.reviewerVoter, weights, topicIntent },
+        {
+          idempotencyKey: `${session.id}:${openEpochId}:vote`,
+          baseEpochId: openEpochId,
+          voterLabel: LABELS.reviewerVoter,
+          weights,
+          topicIntent,
+          ...(session.contentRulesEnabled === true && excludeKeywords.length > 0 ? { excludeKeywords } : {}),
+        },
         request.signal,
       )
       if (!request.isCurrent()) {
@@ -351,6 +358,7 @@ export default function DemoPage() {
     ) ?? null
   const baselineTopicIntent = baselineFeed?.aggregate.topicIntent ?? { topicWeights: {} }
   const topicCatalog = session?.topicCatalog ?? []
+  const withheldCount = feedAfter?.withheldPosts?.length ?? 0
   const baselineTopicSlugs = Object.keys(baselineTopicIntent.topicWeights)
   const topicCatalogComplete = topicCatalog.length === 26
     && new Set(topicCatalog.map((topic) => topic.slug)).size === 26
@@ -383,6 +391,9 @@ export default function DemoPage() {
         busy={busy}
         topicCatalog={topicCatalog}
         baselineTopicIntent={baselineTopicIntent}
+        contentRulesEnabled={session?.contentRulesEnabled === true}
+        suggestedExcludeKeywords={session?.suggestedExcludeKeywords ?? []}
+        contentRules={baselineFeed?.aggregate.voteSummary.contentRules ?? null}
       />
     ) : phase === "reviewer_vote_cast" || phase === "agent_votes_cast" ? (
       <AgentsPanel
@@ -413,7 +424,11 @@ export default function DemoPage() {
         <div className="rounded-[1.5rem] border border-border bg-card px-5 py-6">
           <h2 className="font-display text-xl font-bold text-foreground">{STEP_PANELS.reorder.heading}</h2>
           <p className="mt-2 text-sm leading-relaxed text-foreground/60">
-            {selectedUri !== null && busy ? "Loading the matching post receipt…" : STEP_PANELS.reorder.body}
+            {selectedUri !== null && busy
+              ? "Loading the matching post receipt…"
+              : withheldCount > 0
+                ? `The corpus is unchanged, but adopted community rules withheld ${withheldCount} post${withheldCount === 1 ? "" : "s"} and the remaining weights reordered the rest.`
+                : STEP_PANELS.reorder.body}
           </p>
         </div>
       )

--- a/web-next/app/demo/shadow-demo-api-schemas.ts
+++ b/web-next/app/demo/shadow-demo-api-schemas.ts
@@ -43,12 +43,32 @@ const warningSchema = z.object({
   severity: z.enum(["info", "warning", "degraded"]),
 }).strict()
 
+const contentRuleSupportSchema = z.object({
+  keyword: z.string().min(1).max(50),
+  supportCount: z.number().int().nonnegative(),
+  adopted: z.boolean(),
+}).strict()
+
+const contentRulesSummarySchema = z.object({
+  enabled: z.literal(true),
+  threshold: z.number().int().positive(),
+  electorate: z.number().int().nonnegative(),
+  adoptedExcludeKeywords: z.array(z.string().min(1).max(50)),
+  support: z.array(contentRuleSupportSchema),
+}).strict()
+
+const suggestedExcludeKeywordSchema = z.object({
+  keyword: z.string().min(1).max(50),
+  matchCount: z.number().int().nonnegative(),
+}).strict()
+
 const voteSummarySchema = z.object({
   aggregateMethod: z.literal("trimmed_mean_no_trim_under_10"),
   voteCount: z.number().int().nonnegative(),
   trimCount: z.number().int().nonnegative(),
   weights: apiWeightsSchema,
   topicIntent: apiTopicIntentSchema,
+  contentRules: contentRulesSummarySchema.optional(),
 }).strict()
 
 const epochSchema = z.object({
@@ -68,6 +88,7 @@ const voteBaseSchema = z.object({
   label: z.string().min(1),
   weights: apiWeightsSchema,
   topicIntent: apiTopicIntentSchema,
+  excludeKeywords: z.array(z.string().min(1).max(50)).max(10).optional(),
   createdAt: isoDateTime,
 })
 
@@ -256,6 +277,8 @@ export const apiSessionPayloadSchema = z.object({
     sourceFeedUri: z.string().startsWith("at://"),
     voterProfiles: z.array(voterProfileSchema),
     votes: z.array(z.union([reviewerVoteSchema, apiSyntheticVoteSchema])),
+    contentRulesEnabled: z.literal(true).optional(),
+    suggestedExcludeKeywords: z.array(suggestedExcludeKeywordSchema).optional(),
   }).strict(),
 }).strict()
 
@@ -292,6 +315,13 @@ const rawScoresSchema = z.object({
   relevance: finiteNumber,
 }).strict()
 
+const withheldPostSchema = z.object({
+  keyword: z.string().min(1).max(50),
+  supportCount: z.number().int().nonnegative(),
+  previousRank: z.number().int().positive().nullable(),
+  post: z.discriminatedUnion("kind", [publicPostSchema, hiddenPostSchema]),
+}).strict()
+
 export const apiFeedPayloadSchema = z.object({
   epochId: z.string().min(1),
   corpusId: z.string().min(1),
@@ -312,6 +342,7 @@ export const apiFeedPayloadSchema = z.object({
     componentScore: finiteNumber.nullable().optional(),
     publicationAdjustment: finiteNumber.nullable().optional(),
   }).strict()),
+  withheldPosts: z.array(withheldPostSchema).optional(),
 }).strict()
 
 export const apiReceiptPayloadSchema = z.object({
@@ -355,6 +386,12 @@ export const apiReceiptPayloadSchema = z.object({
       rank: z.number().int().positive().nullable(),
       deltaFromVisible: z.number().int().nullable(),
     }).strict()),
+    contentRules: z.object({
+      adoptedExcludeKeywords: z.array(z.string().min(1).max(50)),
+      threshold: z.number().int().positive(),
+      electorate: z.number().int().nonnegative(),
+      matchedKeyword: z.null(),
+    }).strict().optional(),
   }).strict(),
 }).strict()
 

--- a/web-next/app/demo/shadow-demo-api-schemas.ts
+++ b/web-next/app/demo/shadow-demo-api-schemas.ts
@@ -1,4 +1,8 @@
 import { z } from "zod"
+import {
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
+} from "@/app/demo/shadow-demo-view-model"
 
 export const CONTRACT_VERSION = "2026-07-11.shadow-demo.v4" as const
 
@@ -43,22 +47,28 @@ const warningSchema = z.object({
   severity: z.enum(["info", "warning", "degraded"]),
 }).strict()
 
+const excludeKeywordStringSchema = z.string().min(1).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH)
+const excludeKeywordListSchema = z.array(excludeKeywordStringSchema).max(SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS)
+
 const contentRuleSupportSchema = z.object({
-  keyword: z.string().min(1).max(50),
+  keyword: excludeKeywordStringSchema,
   supportCount: z.number().int().nonnegative(),
   adopted: z.boolean(),
 }).strict()
 
-const contentRulesSummarySchema = z.object({
-  enabled: z.literal(true),
+const contentRulesBaseSchema = z.object({
   threshold: z.number().int().positive(),
   electorate: z.number().int().nonnegative(),
-  adoptedExcludeKeywords: z.array(z.string().min(1).max(50)),
+  adoptedExcludeKeywords: excludeKeywordListSchema,
+})
+
+const contentRulesSummarySchema = contentRulesBaseSchema.extend({
+  enabled: z.literal(true),
   support: z.array(contentRuleSupportSchema),
 }).strict()
 
 const suggestedExcludeKeywordSchema = z.object({
-  keyword: z.string().min(1).max(50),
+  keyword: excludeKeywordStringSchema,
   matchCount: z.number().int().nonnegative(),
 }).strict()
 
@@ -88,7 +98,7 @@ const voteBaseSchema = z.object({
   label: z.string().min(1),
   weights: apiWeightsSchema,
   topicIntent: apiTopicIntentSchema,
-  excludeKeywords: z.array(z.string().min(1).max(50)).max(10).optional(),
+  excludeKeywords: excludeKeywordListSchema.optional(),
   createdAt: isoDateTime,
 })
 
@@ -316,7 +326,7 @@ const rawScoresSchema = z.object({
 }).strict()
 
 const withheldPostSchema = z.object({
-  keyword: z.string().min(1).max(50),
+  keyword: excludeKeywordStringSchema,
   supportCount: z.number().int().nonnegative(),
   previousRank: z.number().int().positive().nullable(),
   post: z.discriminatedUnion("kind", [publicPostSchema, hiddenPostSchema]),
@@ -386,10 +396,7 @@ export const apiReceiptPayloadSchema = z.object({
       rank: z.number().int().positive().nullable(),
       deltaFromVisible: z.number().int().nullable(),
     }).strict()),
-    contentRules: z.object({
-      adoptedExcludeKeywords: z.array(z.string().min(1).max(50)),
-      threshold: z.number().int().positive(),
-      electorate: z.number().int().nonnegative(),
+    contentRules: contentRulesBaseSchema.extend({
       matchedKeyword: z.null(),
     }).strict().optional(),
   }).strict(),

--- a/web-next/app/demo/shadow-demo-api-schemas.ts
+++ b/web-next/app/demo/shadow-demo-api-schemas.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import {
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
+  SHADOW_DEMO_TOTAL_DEMO_VOTERS,
 } from "@/app/demo/shadow-demo-view-model"
 
 export const CONTRACT_VERSION = "2026-07-11.shadow-demo.v4" as const
@@ -64,7 +65,7 @@ const contentRulesBaseSchema = z.object({
 
 // Distinct proposed keywords per epoch: reviewer (<= MAX) plus prior-adopted
 // (capped at MAX), aggregated across the 25-ballot electorate.
-const CONTENT_RULE_SUPPORT_MAX = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS * 25
+const CONTENT_RULE_SUPPORT_MAX = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS * SHADOW_DEMO_TOTAL_DEMO_VOTERS
 
 const contentRulesSummarySchema = contentRulesBaseSchema.extend({
   enabled: z.literal(true),

--- a/web-next/app/demo/shadow-demo-api-schemas.ts
+++ b/web-next/app/demo/shadow-demo-api-schemas.ts
@@ -62,9 +62,13 @@ const contentRulesBaseSchema = z.object({
   adoptedExcludeKeywords: excludeKeywordListSchema,
 })
 
+// Distinct proposed keywords per epoch: reviewer (<= MAX) plus prior-adopted
+// (capped at MAX), aggregated across the 25-ballot electorate.
+const CONTENT_RULE_SUPPORT_MAX = SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS * 25
+
 const contentRulesSummarySchema = contentRulesBaseSchema.extend({
   enabled: z.literal(true),
-  support: z.array(contentRuleSupportSchema),
+  support: z.array(contentRuleSupportSchema).max(CONTENT_RULE_SUPPORT_MAX),
 }).strict()
 
 const suggestedExcludeKeywordSchema = z.object({

--- a/web-next/app/demo/shadow-demo-contract.ts
+++ b/web-next/app/demo/shadow-demo-contract.ts
@@ -75,6 +75,41 @@ export const SHADOW_DEMO_CORPUS_PROVENANCE = {
   topicScoreThreshold: 0.5,
 } as const;
 
+export const SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS = 10;
+
+export const SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH = 50;
+
+/** Mirrors production KEYWORD_THRESHOLD in src/governance/aggregation.ts. */
+export const SHADOW_DEMO_CONTENT_RULE_SUPPORT_THRESHOLD = 0.3;
+
+export interface ShadowDemoContentRuleSupport {
+  keyword: string;
+  supportCount: number;
+  adopted: boolean;
+}
+
+export interface ShadowDemoContentRulesSummary {
+  enabled: true;
+  /** Votes needed to adopt a keyword: ceil(threshold share x electorate), min 1. */
+  threshold: number;
+  /** Every demo ballot is complete, so the denominator is the full electorate. */
+  electorate: number;
+  adoptedExcludeKeywords: string[];
+  support: ShadowDemoContentRuleSupport[];
+}
+
+export interface ShadowDemoSuggestedExcludeKeyword {
+  keyword: string;
+  matchCount: number;
+}
+
+export interface ShadowDemoWithheldPost {
+  keyword: string;
+  supportCount: number;
+  previousRank: number | null;
+  post: ShadowDemoDisplayPost;
+}
+
 export const SHADOW_DEMO_ISOLATION_CONTRACT = {
   productionGovernanceMutates: false,
   productionFeedMutates: false,
@@ -183,6 +218,8 @@ export interface ShadowDemoVoteSummary {
   trimCount: number;
   weights: ShadowDemoWeights;
   topicIntent: ShadowDemoTopicIntent;
+  /** Present only when DEMO_CONTENT_RULES_ENABLED. Threshold rule, not trimmed mean. */
+  contentRules?: ShadowDemoContentRulesSummary;
 }
 
 export interface ShadowDemoEpoch {
@@ -202,6 +239,8 @@ interface ShadowDemoVoteBase {
   label: string;
   weights: ShadowDemoWeights;
   topicIntent: ShadowDemoTopicIntent;
+  /** Present only when DEMO_CONTENT_RULES_ENABLED; normalized exclude keywords. */
+  excludeKeywords?: string[];
   createdAt: string;
 }
 
@@ -245,6 +284,9 @@ export interface ShadowDemoSessionPayload {
       policyInertia: number;
     }>;
     votes: ShadowDemoVote[];
+    /** Present only when DEMO_CONTENT_RULES_ENABLED. */
+    contentRulesEnabled?: boolean;
+    suggestedExcludeKeywords?: ShadowDemoSuggestedExcludeKeyword[];
   };
 }
 
@@ -291,6 +333,8 @@ export interface ShadowDemoFeedPayload {
   corpusProvenance: ShadowDemoCorpusProvenance;
   aggregate: ShadowDemoVoteSummary;
   posts: ShadowDemoRankedPost[];
+  /** Present only when DEMO_CONTENT_RULES_ENABLED and the epoch adopted rules. */
+  withheldPosts?: ShadowDemoWithheldPost[];
 }
 
 export interface ShadowDemoReceiptPayload {
@@ -338,5 +382,13 @@ export interface ShadowDemoReceiptPayload {
       rank: number | null;
       deltaFromVisible: number | null;
     }>;
+    /** Present only when DEMO_CONTENT_RULES_ENABLED. */
+    contentRules?: {
+      adoptedExcludeKeywords: string[];
+      threshold: number;
+      electorate: number;
+      /** Always null on a rank receipt; withheld posts have no rank receipt. */
+      matchedKeyword: null;
+    };
   };
 }

--- a/web-next/app/demo/shadow-demo-contract.ts
+++ b/web-next/app/demo/shadow-demo-contract.ts
@@ -333,7 +333,7 @@ export interface ShadowDemoFeedPayload {
   corpusProvenance: ShadowDemoCorpusProvenance;
   aggregate: ShadowDemoVoteSummary;
   posts: ShadowDemoRankedPost[];
-  /** Present only when DEMO_CONTENT_RULES_ENABLED and the epoch adopted rules. */
+  /** Present only when content rules are enabled for the epoch; may be an empty array. */
   withheldPosts?: ShadowDemoWithheldPost[];
 }
 

--- a/web-next/app/demo/shadow-demo-view-model.ts
+++ b/web-next/app/demo/shadow-demo-view-model.ts
@@ -3,10 +3,15 @@ import {
   SHADOW_DEMO_CONTRACT_VERSION,
   SHADOW_DEMO_GUIDED_EPOCHS,
   SHADOW_DEMO_MAX_EPOCHS_PER_SESSION,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
   SHADOW_DEMO_SIGNAL_KEYS,
   SHADOW_DEMO_VOTER_BLOC_IDS,
   type ShadowDemoCommunityId,
+  type ShadowDemoContentRuleSupport,
+  type ShadowDemoContentRulesSummary,
   type ShadowDemoSignalKey,
+  type ShadowDemoSuggestedExcludeKeyword,
   type ShadowDemoTopicIntent,
   type ShadowDemoTopicCatalogEntry,
   type ShadowDemoWeights,
@@ -18,12 +23,17 @@ export {
   SHADOW_DEMO_CONTRACT_VERSION,
   SHADOW_DEMO_GUIDED_EPOCHS,
   SHADOW_DEMO_MAX_EPOCHS_PER_SESSION,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
   SHADOW_DEMO_SIGNAL_KEYS,
   SHADOW_DEMO_VOTER_BLOC_IDS,
 }
 export type {
   ShadowDemoCommunityId,
+  ShadowDemoContentRuleSupport,
+  ShadowDemoContentRulesSummary,
   ShadowDemoSignalKey,
+  ShadowDemoSuggestedExcludeKeyword,
   ShadowDemoTopicIntent,
   ShadowDemoTopicCatalogEntry,
   ShadowDemoWeights,
@@ -102,6 +112,9 @@ export interface ShadowDemoSession {
   readonly corpusProvenance: ShadowDemoCorpusProvenance
   readonly topicCatalog?: readonly ShadowDemoTopicCatalogEntry[]
   readonly sourceFeedUri?: string | null
+  /** Present only when DEMO_CONTENT_RULES_ENABLED. */
+  readonly contentRulesEnabled?: boolean
+  readonly suggestedExcludeKeywords?: readonly ShadowDemoSuggestedExcludeKeyword[]
 }
 
 export interface ShadowDemoIsolation {
@@ -137,6 +150,8 @@ export interface CastShadowDemoVoteRequest {
   readonly voterLabel: string
   readonly weights: ShadowDemoWeights
   readonly topicIntent: ShadowDemoTopicIntent
+  /** Sent only when the reviewer proposed keywords and content rules are enabled. */
+  readonly excludeKeywords?: readonly string[]
 }
 
 export interface CastShadowDemoVoteResponse {
@@ -219,6 +234,8 @@ export interface ShadowDemoVoteSummary {
   readonly aggregateMethod: "trimmed_mean_no_trim_under_10"
   readonly trimCount: number
   readonly reviewerBallotShare: number
+  /** Present only when DEMO_CONTENT_RULES_ENABLED. Threshold rule, not trimmed mean. */
+  readonly contentRules?: ShadowDemoContentRulesSummary
 }
 
 export interface ShadowDemoAggregate {
@@ -241,6 +258,17 @@ export interface ShadowDemoFeed {
   readonly corpusHealth: ShadowDemoCorpusHealth
   readonly corpusProvenance: ShadowDemoCorpusProvenance
   readonly aggregate: ShadowDemoAggregate
+  /** Present only when DEMO_CONTENT_RULES_ENABLED and the epoch adopted rules. */
+  readonly withheldPosts?: readonly ShadowDemoWithheldFeedItem[]
+}
+
+/** A post removed from the ranking by an adopted community content rule. */
+export interface ShadowDemoWithheldFeedItem {
+  readonly keyword: string
+  readonly supportCount: number
+  readonly previousRank: number | null
+  readonly post: ShadowDemoPublicPost | null
+  readonly hiddenReason: string | null
 }
 
 export type ShadowDemoFeedItem = ShadowDemoPublicFeedItem | ShadowDemoHiddenFeedItem
@@ -422,6 +450,14 @@ export interface ShadowDemoReceipt {
   readonly counterfactuals: readonly ShadowDemoCounterfactual[]
   readonly generatedAt: string
   readonly explanationKind: "shadow_demo_receipt"
+  /** Present only when DEMO_CONTENT_RULES_ENABLED. */
+  readonly contentRules?: {
+    readonly adoptedExcludeKeywords: readonly string[]
+    readonly threshold: number
+    readonly electorate: number
+    /** Always null on a rank receipt; withheld posts have no rank receipt. */
+    readonly matchedKeyword: null
+  }
 }
 
 export interface ShadowDemoTopicRelevanceFormula {

--- a/web-next/app/demo/shadow-demo-view-model.ts
+++ b/web-next/app/demo/shadow-demo-view-model.ts
@@ -1,11 +1,13 @@
 import {
   SHADOW_DEMO_COMMUNITY_IDS,
+  SHADOW_DEMO_CONTENT_RULE_SUPPORT_THRESHOLD,
   SHADOW_DEMO_CONTRACT_VERSION,
   SHADOW_DEMO_GUIDED_EPOCHS,
   SHADOW_DEMO_MAX_EPOCHS_PER_SESSION,
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
   SHADOW_DEMO_SIGNAL_KEYS,
+  SHADOW_DEMO_TOTAL_DEMO_VOTERS,
   SHADOW_DEMO_VOTER_BLOC_IDS,
   type ShadowDemoCommunityId,
   type ShadowDemoContentRuleSupport,
@@ -20,12 +22,14 @@ import {
 
 export {
   SHADOW_DEMO_COMMUNITY_IDS,
+  SHADOW_DEMO_CONTENT_RULE_SUPPORT_THRESHOLD,
   SHADOW_DEMO_CONTRACT_VERSION,
   SHADOW_DEMO_GUIDED_EPOCHS,
   SHADOW_DEMO_MAX_EPOCHS_PER_SESSION,
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
   SHADOW_DEMO_SIGNAL_KEYS,
+  SHADOW_DEMO_TOTAL_DEMO_VOTERS,
   SHADOW_DEMO_VOTER_BLOC_IDS,
 }
 export type {
@@ -258,7 +262,7 @@ export interface ShadowDemoFeed {
   readonly corpusHealth: ShadowDemoCorpusHealth
   readonly corpusProvenance: ShadowDemoCorpusProvenance
   readonly aggregate: ShadowDemoAggregate
-  /** Present only when DEMO_CONTENT_RULES_ENABLED and the epoch adopted rules. */
+  /** Present when content rules are enabled for the epoch; may be an empty array. */
   readonly withheldPosts?: readonly ShadowDemoWithheldFeedItem[]
 }
 

--- a/web-next/app/vote/page.tsx
+++ b/web-next/app/vote/page.tsx
@@ -467,6 +467,9 @@ function VoteWorkbench({ epoch, myVote, topics, contentRules, isAuthenticated, o
               <div className="flex flex-col gap-1.5">
                 <span className="text-[10px] font-mono text-foreground/55 uppercase tracking-widest">02 — Content rules</span>
                 <h2 className="text-lg font-semibold text-foreground leading-snug">Keywords</h2>
+                {/* 30% mirrors the fixed KEYWORD_THRESHOLD share in governance
+                    aggregation; the API `rules.threshold` is an absolute vote
+                    count for that round, not a percentage, so it is not rendered here. */}
                 <p className="text-sm text-foreground/50 leading-relaxed">
                   Vote on which keywords to boost or suppress. Keywords take effect when backed by at least 30% of members voting on content rules.
                 </p>

--- a/web-next/app/vote/page.tsx
+++ b/web-next/app/vote/page.tsx
@@ -468,7 +468,7 @@ function VoteWorkbench({ epoch, myVote, topics, contentRules, isAuthenticated, o
                 <span className="text-[10px] font-mono text-foreground/55 uppercase tracking-widest">02 — Content rules</span>
                 <h2 className="text-lg font-semibold text-foreground leading-snug">Keywords</h2>
                 <p className="text-sm text-foreground/50 leading-relaxed">
-                  Vote on which keywords to boost or suppress. Keywords reaching {Math.round(rules.threshold * 100)}% community support take effect.
+                  Vote on which keywords to boost or suppress. Keywords take effect when backed by at least 30% of members voting on content rules.
                 </p>
               </div>
 

--- a/web-next/components/demo/agents-panel.tsx
+++ b/web-next/components/demo/agents-panel.tsx
@@ -151,6 +151,24 @@ export function AgentsPanel({
               label="Aggregated topic priorities"
             />
           </div>
+          {aggregate.voteSummary.contentRules !== undefined && aggregate.voteSummary.contentRules.support.length > 0 ? (
+            <div className="mt-4 border-t border-primary/15 pt-4">
+              <p className="text-[10px] font-mono uppercase tracking-[0.2em] text-primary/65">Content rule ballots</p>
+              <div className="mt-2 flex flex-col gap-1.5">
+                {aggregate.voteSummary.contentRules.support.map((entry) => (
+                  <div key={entry.keyword} className="flex items-center justify-between gap-2 rounded-lg border border-border/70 bg-background px-3 py-2">
+                    <span className="font-mono text-xs font-semibold text-foreground/75">−{entry.keyword}</span>
+                    <span className="flex items-center gap-2 text-[11px] font-medium text-foreground/55">
+                      support {entry.supportCount}/{aggregate.voteSummary.contentRules?.electorate} · needs {aggregate.voteSummary.contentRules?.threshold}
+                      <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${entry.adopted ? "bg-primary/15 text-primary" : "bg-foreground/10 text-foreground/50"}`}>
+                        {entry.adopted ? "Adopted" : "Rejected"}
+                      </span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
           <p className="mt-3 text-xs leading-relaxed text-foreground/55">
             Your ballot is 1 of {aggregate.voteSummary.totalVotes}. That describes ballot count, not causal influence: the scripted ballots respond partly to your proposal. All demo ballots stay isolated from production governance.
           </p>

--- a/web-next/components/demo/corpus-feed.tsx
+++ b/web-next/components/demo/corpus-feed.tsx
@@ -8,6 +8,7 @@ import type {
   ShadowDemoPublicFeedItem,
   ShadowDemoRankMovement,
   ShadowDemoScoreComponent,
+  ShadowDemoWithheldFeedItem,
 } from "@/app/demo/shadow-demo-view-model"
 import { SIGNAL_COLORS, formatRelativeTime } from "@/app/demo/shadow-demo-fixtures"
 import { LABELS } from "@/app/demo/shadow-demo-copy"
@@ -141,6 +142,52 @@ function HiddenRow({ item, reduceMotion }: { readonly item: ShadowDemoHiddenFeed
   )
 }
 
+function WithheldByRuleRow({
+  withheld,
+  electorate,
+  referenceAt,
+}: {
+  readonly withheld: ShadowDemoWithheldFeedItem
+  readonly electorate: number | null
+  readonly referenceAt: string
+}) {
+  const badge = electorate !== null
+    ? `−${withheld.keyword} · ${withheld.supportCount}/${electorate}`
+    : `−${withheld.keyword} · ${withheld.supportCount} votes`
+  return (
+    <div className="overflow-hidden rounded-xl border border-[#D9E3EE] bg-white">
+      {withheld.post !== null ? (
+        <BlueskyPostCard
+          authorDisplayName={withheld.post.authorDisplayName}
+          authorHandle={withheld.post.authorHandle}
+          timeLabel={formatRelativeTime(withheld.post.indexedAt, referenceAt)}
+          avatarUrl={withheld.post.authorAvatar}
+          bskyUrl={withheld.post.bskyUrl}
+          text={withheld.post.text}
+          replyCount={withheld.post.replyCount}
+          repostCount={withheld.post.repostCount}
+          likeCount={withheld.post.likeCount}
+          languages={withheld.post.languages}
+          media={withheld.post.media}
+          density="compact"
+        />
+      ) : (
+        <div className="px-4 py-3.5 text-sm text-[#42576C]">
+          {withheld.hiddenReason ?? "Post unavailable."}
+        </div>
+      )}
+      <div className="flex flex-wrap items-center gap-2 border-t border-[#E8EDF3] bg-[#FAFBFC] px-4 py-2.5">
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-tongue/30 bg-tongue/10 px-2.5 py-1 text-[11px] font-mono font-semibold text-tongue-foreground">
+          {badge}
+        </span>
+        {withheld.previousRank !== null ? (
+          <span className="text-[11px] font-medium text-foreground/50">Previously ranked #{withheld.previousRank}</span>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
 export function CorpusFeed({
   feed,
   communityName,
@@ -160,25 +207,51 @@ export function CorpusFeed({
 }) {
   const reduceMotion = useReducedMotion() ?? false
   const referenceAt = feed.corpusHealth.collectedAt
+  const withheldPosts = feed.withheldPosts ?? []
+  const electorate = feed.aggregate.voteSummary.contentRules?.electorate ?? null
 
   return (
-    <BlueskyFeedFrame communityName={communityName} epochLabel={epochLabel}>
-      {feed.items.map((item) =>
-        item.visibility === "public" ? (
-          <PublicRow
-            key={item.post.uri}
-            item={item}
-            selected={selectedUri === item.post.uri}
-            onSelect={onSelect}
-            referenceAt={referenceAt}
-            showMovement={showMovement}
-            selectable={selectable}
-            reduceMotion={reduceMotion}
-          />
-        ) : (
-          <HiddenRow key={`hidden-${item.rank}`} item={item} reduceMotion={reduceMotion} />
-        ),
-      )}
-    </BlueskyFeedFrame>
+    <>
+      <BlueskyFeedFrame communityName={communityName} epochLabel={epochLabel}>
+        {feed.items.map((item) =>
+          item.visibility === "public" ? (
+            <PublicRow
+              key={item.post.uri}
+              item={item}
+              selected={selectedUri === item.post.uri}
+              onSelect={onSelect}
+              referenceAt={referenceAt}
+              showMovement={showMovement}
+              selectable={selectable}
+              reduceMotion={reduceMotion}
+            />
+          ) : (
+            <HiddenRow key={`hidden-${item.rank}`} item={item} reduceMotion={reduceMotion} />
+          ),
+        )}
+      </BlueskyFeedFrame>
+
+      {withheldPosts.length > 0 ? (
+        <div className="mt-4 rounded-[1.25rem] border border-tongue/25 bg-tongue/[0.04] px-4 py-4">
+          <p className="flex items-center gap-2 text-sm font-bold text-foreground">
+            <EyeOff className="h-4 w-4 text-tongue-foreground/70" aria-hidden="true" />
+            Withheld by community rule
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-foreground/55">
+            Adopted exclude-keyword rules removed these posts from the ranking above.
+          </p>
+          <div className="mt-3 flex flex-col gap-2">
+            {withheldPosts.map((withheld, index) => (
+              <WithheldByRuleRow
+                key={withheld.post?.uri ?? `withheld-${index}`}
+                withheld={withheld}
+                electorate={electorate}
+                referenceAt={referenceAt}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </>
   )
 }

--- a/web-next/components/demo/vote-panel.tsx
+++ b/web-next/components/demo/vote-panel.tsx
@@ -3,7 +3,10 @@
 import { useMemo, useState } from "react"
 import { RotateCcw, Search, SlidersHorizontal } from "lucide-react"
 import {
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
   SHADOW_DEMO_SIGNAL_KEYS,
+  type ShadowDemoContentRulesSummary,
+  type ShadowDemoSuggestedExcludeKeyword,
   type ShadowDemoTopicCatalogEntry,
   type ShadowDemoTopicIntent,
   type ShadowDemoWeights,
@@ -22,10 +25,14 @@ import {
   POLICY_EDIT_THRESHOLD,
   validateDemoVoteSubmission,
 } from "@/app/demo/shadow-demo-vote-policy"
+import { KeywordInput } from "@/components/ui/keyword-input"
 import { Slider } from "@/components/ui/slider"
 import { DEMO_PANEL_FRAME_CLASS, DEMO_PANEL_SCROLL_BODY_CLASS } from "./panel-layout"
 import { TopicPolicy, topicLabel } from "./topic-policy"
 import { WeightBars } from "./weight-bars"
+
+const CONTENT_RULE_FALLBACK_THRESHOLD = 8
+const CONTENT_RULE_FALLBACK_ELECTORATE = 25
 
 const FOCUS =
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
@@ -103,22 +110,29 @@ export function VotePanel({
   busy,
   topicCatalog,
   baselineTopicIntent,
+  contentRulesEnabled = false,
+  suggestedExcludeKeywords = [],
+  contentRules = null,
 }: {
-  readonly onSubmit: (weights: ShadowDemoWeights, topicIntent: ShadowDemoTopicIntent) => void
+  readonly onSubmit: (weights: ShadowDemoWeights, topicIntent: ShadowDemoTopicIntent, excludeKeywords: readonly string[]) => void
   readonly busy: boolean
   readonly topicCatalog: readonly ShadowDemoTopicCatalogEntry[]
   readonly baselineTopicIntent: ShadowDemoTopicIntent
+  readonly contentRulesEnabled?: boolean
+  readonly suggestedExcludeKeywords?: readonly ShadowDemoSuggestedExcludeKeyword[]
+  readonly contentRules?: ShadowDemoContentRulesSummary | null
 }) {
   const [presetId, setPresetId] = useState<string>(DEMO_VOTE_PRESETS[0].id)
   const [custom, setCustom] = useState<ShadowDemoWeights | null>(null)
   const [topicIntent, setTopicIntent] = useState<ShadowDemoTopicIntent>(() =>
     mergeTopicPolicy(baselineTopicIntent, DEMO_VOTE_PRESETS[0].topicIntent))
   const [showFineTune, setShowFineTune] = useState(false)
-  const [fineTuneTab, setFineTuneTab] = useState<"signals" | "topics">("signals")
+  const [fineTuneTab, setFineTuneTab] = useState<"signals" | "topics" | "rules">("signals")
   const [topicQuery, setTopicQuery] = useState("")
   const [topicSort, setTopicSort] = useState<"alphabetical" | "weight">("weight")
   const [changedOnly, setChangedOnly] = useState(false)
   const [submissionError, setSubmissionError] = useState<string | null>(null)
+  const [excludeKeywords, setExcludeKeywords] = useState<string[]>([])
 
   const preset = DEMO_VOTE_PRESETS.find((entry) => entry.id === presetId) ?? DEMO_VOTE_PRESETS[0]
   const presetTopicIntent = useMemo(
@@ -186,8 +200,19 @@ export function VotePanel({
       }
       throw error
     }
-    onSubmit(submission.weights, submission.topicIntent)
+    onSubmit(submission.weights, submission.topicIntent, excludeKeywords)
   }
+
+  function toggleSuggestedKeyword(keyword: string): void {
+    const normalized = keyword.trim().toLowerCase().slice(0, 50)
+    if (normalized.length === 0) return
+    setExcludeKeywords((current) => current.includes(normalized)
+      ? current.filter((entry) => entry !== normalized)
+      : current.length >= SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS ? current : [...current, normalized])
+  }
+
+  const contentRuleThreshold = contentRules?.threshold ?? CONTENT_RULE_FALLBACK_THRESHOLD
+  const contentRuleElectorate = contentRules?.electorate ?? CONTENT_RULE_FALLBACK_ELECTORATE
 
   return (
     <div className={DEMO_PANEL_FRAME_CLASS}>
@@ -229,11 +254,15 @@ export function VotePanel({
 
           {showFineTune ? (
             <div className="mt-4 border-t border-border/60 pt-4">
-              <div className="grid grid-cols-2 rounded-lg border border-border bg-background p-1">
+              <div className={`grid rounded-lg border border-border bg-background p-1 ${contentRulesEnabled ? "grid-cols-3" : "grid-cols-2"}`}>
                 <button type="button" onClick={() => setFineTuneTab("signals")} aria-pressed={fineTuneTab === "signals"}
                   className={`min-h-10 rounded-md px-3 text-xs font-semibold ${FOCUS} ${fineTuneTab === "signals" ? "bg-biscuit/60 text-foreground" : "text-foreground/60"}`}>Signals (5)</button>
                 <button type="button" onClick={() => setFineTuneTab("topics")} aria-pressed={fineTuneTab === "topics"}
                   className={`min-h-10 rounded-md px-3 text-xs font-semibold ${FOCUS} ${fineTuneTab === "topics" ? "bg-biscuit/60 text-foreground" : "text-foreground/60"}`}>Topics ({topicCatalog.length})</button>
+                {contentRulesEnabled ? (
+                  <button type="button" onClick={() => setFineTuneTab("rules")} aria-pressed={fineTuneTab === "rules"}
+                    className={`min-h-10 rounded-md px-3 text-xs font-semibold ${FOCUS} ${fineTuneTab === "rules" ? "bg-biscuit/60 text-foreground" : "text-foreground/60"}`}>Rules</button>
+                ) : null}
               </div>
 
               {fineTuneTab === "signals" ? (
@@ -256,7 +285,7 @@ export function VotePanel({
                   ))}
                   {sum <= 0 ? <p className="text-xs font-medium text-primary">Give at least one signal some weight to cast a vote.</p> : null}
                 </div>
-              ) : (
+              ) : fineTuneTab === "topics" ? (
                 <div className="mt-4">
                   <div className="mb-3 flex items-start justify-between gap-4 text-xs leading-relaxed text-foreground/55">
                     <p>Topic weights shape the relevance signal. Every ballot carries all {topicCatalog.length} values.</p>
@@ -300,6 +329,42 @@ export function VotePanel({
                     })}
                   </div>
                   {visibleTopics.length === 0 ? <p className="mt-4 text-xs text-foreground/55">No topics match these filters.</p> : null}
+                </div>
+              ) : (
+                <div className="mt-4">
+                  <p className="text-xs leading-relaxed text-foreground/60">
+                    Propose keywords to exclude. A rule is adopted when at least {contentRuleThreshold} of {contentRuleElectorate} ballots back it.
+                  </p>
+
+                  {suggestedExcludeKeywords.length > 0 ? (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {suggestedExcludeKeywords.map((suggestion) => {
+                        const active = excludeKeywords.includes(suggestion.keyword)
+                        return (
+                          <button
+                            key={suggestion.keyword}
+                            type="button"
+                            onClick={() => toggleSuggestedKeyword(suggestion.keyword)}
+                            aria-pressed={active}
+                            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${FOCUS} ${active ? "border-tongue/40 bg-tongue/15 text-tongue-foreground" : "border-border bg-background text-foreground/70 hover:border-tongue/30"}`}
+                          >
+                            <span className="font-mono">−{suggestion.keyword}</span>
+                            <span className="text-foreground/45">{suggestion.matchCount} posts</span>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  ) : null}
+
+                  <div className="mt-4">
+                    <KeywordInput
+                      label="Exclude keywords"
+                      keywords={excludeKeywords}
+                      variant="exclude"
+                      onChange={setExcludeKeywords}
+                      maxKeywords={SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS}
+                    />
+                  </div>
                 </div>
               )}
             </div>

--- a/web-next/components/demo/vote-panel.tsx
+++ b/web-next/components/demo/vote-panel.tsx
@@ -3,8 +3,11 @@
 import { useMemo, useState } from "react"
 import { RotateCcw, Search, SlidersHorizontal } from "lucide-react"
 import {
+  SHADOW_DEMO_CONTENT_RULE_SUPPORT_THRESHOLD,
   SHADOW_DEMO_MAX_EXCLUDE_KEYWORDS,
+  SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH,
   SHADOW_DEMO_SIGNAL_KEYS,
+  SHADOW_DEMO_TOTAL_DEMO_VOTERS,
   type ShadowDemoContentRulesSummary,
   type ShadowDemoSuggestedExcludeKeyword,
   type ShadowDemoTopicCatalogEntry,
@@ -31,8 +34,11 @@ import { DEMO_PANEL_FRAME_CLASS, DEMO_PANEL_SCROLL_BODY_CLASS } from "./panel-la
 import { TopicPolicy, topicLabel } from "./topic-policy"
 import { WeightBars } from "./weight-bars"
 
-const CONTENT_RULE_FALLBACK_THRESHOLD = 8
-const CONTENT_RULE_FALLBACK_ELECTORATE = 25
+const CONTENT_RULE_FALLBACK_ELECTORATE = SHADOW_DEMO_TOTAL_DEMO_VOTERS
+const CONTENT_RULE_FALLBACK_THRESHOLD = Math.max(
+  1,
+  Math.ceil(SHADOW_DEMO_TOTAL_DEMO_VOTERS * SHADOW_DEMO_CONTENT_RULE_SUPPORT_THRESHOLD),
+)
 
 const FOCUS =
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
@@ -204,7 +210,13 @@ export function VotePanel({
   }
 
   function toggleSuggestedKeyword(keyword: string): void {
-    const normalized = keyword.trim().toLowerCase().slice(0, 50)
+    // Mirrors KeywordInput's add-path normalization so a suggested keyword
+    // dedupes against an equivalent manually-typed one.
+    const normalized = keyword
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .slice(0, SHADOW_DEMO_MAX_EXCLUDE_KEYWORD_LENGTH)
     if (normalized.length === 0) return
     setExcludeKeywords((current) => current.includes(normalized)
       ? current.filter((entry) => entry !== normalized)

--- a/web-next/components/ui/keyword-input.tsx
+++ b/web-next/components/ui/keyword-input.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, KeyboardEvent } from "react"
 
 const MAX_KEYWORDS = 20
-const MAX_KEYWORD_LENGTH = 50
+export const KEYWORD_MAX_LENGTH = 50
 
 interface KeywordInputProps {
   label: string
@@ -33,7 +33,7 @@ export function KeywordInput({
   const atMax = keywords.length >= maxKeywords
 
   const add = (raw: string) => {
-    const word = raw.trim().toLowerCase().replace(/\s+/g, "-").slice(0, MAX_KEYWORD_LENGTH)
+    const word = raw.trim().toLowerCase().replace(/\s+/g, "-").slice(0, KEYWORD_MAX_LENGTH)
     if (!word || keywords.includes(word) || atMax) return
     onChange([...keywords, word])
     setInputValue("")

--- a/web-next/components/ui/keyword-input.tsx
+++ b/web-next/components/ui/keyword-input.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, KeyboardEvent } from "react"
 
 const MAX_KEYWORDS = 20
+const MAX_KEYWORD_LENGTH = 50
 
 interface KeywordInputProps {
   label: string
@@ -13,6 +14,8 @@ interface KeywordInputProps {
   disabled?: boolean
   communityVotes?: Record<string, number>   // optional: show vote count on chips
   totalVoters?: number
+  /** Caps the keyword list; defaults to 20 for the production vote page. */
+  maxKeywords?: number
 }
 
 export function KeywordInput({
@@ -23,13 +26,14 @@ export function KeywordInput({
   disabled = false,
   communityVotes,
   totalVoters,
+  maxKeywords = MAX_KEYWORDS,
 }: KeywordInputProps) {
   const [inputValue, setInputValue] = useState("")
   const inputRef = useRef<HTMLInputElement>(null)
-  const atMax = keywords.length >= MAX_KEYWORDS
+  const atMax = keywords.length >= maxKeywords
 
   const add = (raw: string) => {
-    const word = raw.trim().toLowerCase().replace(/\s+/g, "-")
+    const word = raw.trim().toLowerCase().replace(/\s+/g, "-").slice(0, MAX_KEYWORD_LENGTH)
     if (!word || keywords.includes(word) || atMax) return
     onChange([...keywords, word])
     setInputValue("")
@@ -67,7 +71,7 @@ export function KeywordInput({
           className={`text-xs font-mono tabular-nums transition-colors
             ${atMax ? "text-tongue-foreground font-semibold" : "text-foreground/50"}`}
         >
-          {keywords.length}/{MAX_KEYWORDS}
+          {keywords.length}/{maxKeywords}
         </span>
       </div>
 


### PR DESCRIPTION
Linear: PROJ-1806

## What

Adds an exclude-keyword content-rules ballot channel to the shadow demo, behind `DEMO_CONTENT_RULES_ENABLED` (default **off** — flag-off payloads are contract-identical to shipped v4).

- New `src/demo/content-rules.ts`: production-semantics validation (`normalizeKeywords`), support-threshold aggregation (adopt at `ceil(0.3 x electorate)` = 8 of 25, mirroring `KEYWORD_THRESHOLD`), deterministic per-bloc reviewer-echo + prior-policy inertia ballots (seeded FNV, same pattern as vote jitter), corpus split via production `checkContentRules`, and deterministic corpus-grounded keyword suggestions.
- Service wiring: reviewer `excludeKeywords` on votes, synthetic keyword ballots, `contentRules` on epoch aggregates, withheld posts excluded from ranking and listed in the feed payload with keyword + support, receipt `contentRules` section on visible posts, explicit error naming the rule/support for withheld-post receipts. Counterfactual and previous-rank paths apply each epoch's own adopted rules so movement stays attributable.
- Session seed became an injectable dependency (defaults to `randomUUID`) for deterministic tests.
- web-next: third fine-tune tab "Rules" (rendered only when the server reports `contentRulesEnabled`), suggested-keyword chips with match counts, support/threshold display in the community step, "Withheld by community rule" section with `-keyword · support/electorate` badges, step-5 copy adjusted only when posts were withheld.
- `/vote` copy bug fix: the content-rules blurb rendered the absolute vote-count threshold as a percentage ("100% community support"); now states the real 30%-of-content-voters rule.
- `docs/lab/demo-shadow-governance-contract.md`: new flag-gated Content Rules section, including the three documented divergences from production (exclude-only, full-electorate denominator, no safety-net defaults).

## Why

Production ballots have three channels (weights, topic preferences, content rules) but the demo exposed only two. The RecSys demo needs the discrete-rule channel and its distinct threshold aggregation visible next to the trimmed-mean channels. Flag enablement and deploy are a separate decision after smoke (see PROJ-1806 acceptance).

## Verification

- Backend: `npm run build` clean; full vitest run **143 files / 1,527 tests passed**, including 9 new tests in `tests/demo-content-rules.test.ts` (normalization, 8-of-25 adopt/reject edges, matcher split, suggestion bounds, synthetic-ballot replay, flag-off parity, adopted end-to-end with withheld feed + receipt error, rejected end-to-end, byte-identical session replay). Deterministic outcomes pinned via injected session seeds verified against the echo hash.
- Existing demo suites (9 files / 149 tests) pass unchanged with the flag off.
- web-next: `tsc --noEmit` clean, `npm run lint` clean, `npm run build` (static export incl. /demo and /vote) clean; all 13 `tests/web-next-*` files / 179 tests plus the frontend release-blocker guard pass.
- `npm run docs:verify` passes (14 tracked docs).

## Rollout

Flag stays **off** through merge and deploy. Enabling requires: deploy, public smoke (keyword adopted at 8/25, post visibly withheld, receipt error names the rule), then the RecSys claim-ledger gate flips. If not enabled by submission time, the paper says content rules are production-only.