### PR TITLE
[PROJ-1816] Login allowlist + waitlist intake (dark behind LOGIN_ALLOWLIST_ENABLED)

### DIFF
--- a/src/admin/routes/index.ts
+++ b/src/admin/routes/index.ts
@@ -19,6 +19,7 @@ import { registerSchedulerRoutes } from './scheduler.js';
 import { registerGovernanceRoutes } from './governance.js';
 import { registerInteractionRoutes } from './interactions.js';
 import { registerParticipantRoutes } from './participants.js';
+import { registerWaitlistRoutes } from './waitlist.js';
 import { registerExportRoutes } from './export.js';
 import { registerTopicRoutes } from './topics.js';
 import { registerVitalsRoutes } from './vitals.js';
@@ -43,6 +44,7 @@ export function registerAdminRoutes(app: FastifyInstance): void {
       registerGovernanceRoutes(adminApp);
       registerInteractionRoutes(adminApp);
       registerParticipantRoutes(adminApp);
+      registerWaitlistRoutes(adminApp);
       registerExportRoutes(adminApp);
       registerTopicRoutes(adminApp);
       registerVitalsRoutes(adminApp);

--- a/src/admin/routes/participant-upsert.ts
+++ b/src/admin/routes/participant-upsert.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared write path for the approved_participants allowlist.
+ *
+ * Both the participants route (plain pool) and the waitlist approve route
+ * (in-transaction client) insert/re-activate an approved participant with the
+ * exact same conflict resolution. Keeping it here means a schema or
+ * conflict-handling change to this security-sensitive table happens once.
+ */
+
+/** Anything with a pg-style `query` — satisfied by both the pool and a PoolClient. */
+export interface Queryable {
+  query(text: string, params?: unknown[]): Promise<unknown>;
+}
+
+export async function upsertApprovedParticipant(
+  client: Queryable,
+  params: { did: string; handle: string | null; addedBy: string; notes: string | null },
+): Promise<void> {
+  // Re-activates a previously soft-removed row (removed_at = NULL).
+  await client.query(
+    `INSERT INTO approved_participants (did, handle, added_by, notes)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (did) DO UPDATE SET
+       removed_at = NULL,
+       handle = COALESCE($2, approved_participants.handle),
+       added_by = $3,
+       notes = $4,
+       added_at = NOW()`,
+    [params.did, params.handle, params.addedBy, params.notes],
+  );
+}

--- a/src/admin/routes/participants.ts
+++ b/src/admin/routes/participants.ts
@@ -11,13 +11,13 @@
 
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
-import { AtpAgent } from '@atproto/api';
 import { db } from '../../db/client.js';
 import { logger } from '../../lib/logger.js';
 import { Errors } from '../../lib/errors.js';
 import { invalidateParticipantCache } from '../../feed/access-control.js';
 import { getAuthenticatedDid } from '../../governance/auth.js';
 import { adminSecurity, ErrorResponseSchema } from '../../lib/openapi.js';
+import { resolveHandleToDid } from './resolve-handle.js';
 
 const AddParticipantSchema = z
   .object({
@@ -28,15 +28,6 @@ const AddParticipantSchema = z
   .refine((data) => data.did || data.handle, {
     message: 'Must provide did or handle',
   });
-
-/**
- * Resolve a Bluesky handle to a DID.
- */
-async function resolveHandleToDid(handle: string): Promise<{ did: string; handle: string }> {
-  const agent = new AtpAgent({ service: 'https://bsky.social' });
-  const response = await agent.resolveHandle({ handle });
-  return { did: response.data.did, handle };
-}
 
 export function registerParticipantRoutes(app: FastifyInstance): void {
   /**

--- a/src/admin/routes/participants.ts
+++ b/src/admin/routes/participants.ts
@@ -18,6 +18,7 @@ import { invalidateParticipantCache } from '../../feed/access-control.js';
 import { getAuthenticatedDid } from '../../governance/auth.js';
 import { adminSecurity, ErrorResponseSchema } from '../../lib/openapi.js';
 import { resolveHandleToDid } from './resolve-handle.js';
+import { upsertApprovedParticipant } from './participant-upsert.js';
 
 const AddParticipantSchema = z
   .object({
@@ -159,17 +160,12 @@ export function registerParticipantRoutes(app: FastifyInstance): void {
     }
 
     // Insert (or re-activate if previously removed)
-    await db.query(
-      `INSERT INTO approved_participants (did, handle, added_by, notes)
-       VALUES ($1, $2, $3, $4)
-       ON CONFLICT (did) DO UPDATE SET
-         removed_at = NULL,
-         handle = COALESCE($2, approved_participants.handle),
-         added_by = $3,
-         notes = $4,
-         added_at = NOW()`,
-      [resolvedDid, resolvedHandle, adminDid, notes ?? null]
-    );
+    await upsertApprovedParticipant(db, {
+      did: resolvedDid,
+      handle: resolvedHandle,
+      addedBy: adminDid,
+      notes: notes ?? null,
+    });
 
     // Invalidate cache so next feed request picks up the change
     await invalidateParticipantCache(resolvedDid);

--- a/src/admin/routes/resolve-handle.ts
+++ b/src/admin/routes/resolve-handle.ts
@@ -6,8 +6,18 @@
 
 import { AtpAgent } from '@atproto/api';
 
+/** Bound the external bsky.social resolve so a slow/hung upstream can't pin an
+ *  admin request open indefinitely. */
+const RESOLVE_TIMEOUT_MS = 10_000;
+
 export async function resolveHandleToDid(handle: string): Promise<{ did: string; handle: string }> {
   const agent = new AtpAgent({ service: 'https://bsky.social' });
-  const response = await agent.resolveHandle({ handle });
-  return { did: response.data.did, handle };
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RESOLVE_TIMEOUT_MS);
+  try {
+    const response = await agent.resolveHandle({ handle }, { signal: controller.signal });
+    return { did: response.data.did, handle };
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/src/admin/routes/resolve-handle.ts
+++ b/src/admin/routes/resolve-handle.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared AT Protocol handle resolution for admin routes.
+ * Used by the participants and waitlist routes when converting a
+ * user-supplied Bluesky handle into a DID at approval time.
+ */
+
+import { AtpAgent } from '@atproto/api';
+
+export async function resolveHandleToDid(handle: string): Promise<{ did: string; handle: string }> {
+  const agent = new AtpAgent({ service: 'https://bsky.social' });
+  const response = await agent.resolveHandle({ handle });
+  return { did: response.data.did, handle };
+}

--- a/src/admin/routes/status.ts
+++ b/src/admin/routes/status.ts
@@ -54,6 +54,7 @@ export function registerStatusRoutes(app: FastifyInstance): void {
           properties: {
             isAdmin: { type: 'boolean' },
             feedPrivateMode: { type: 'boolean' },
+            loginAllowlistEnabled: { type: 'boolean' },
             system: {
               type: 'object',
               properties: {
@@ -176,6 +177,7 @@ export function registerStatusRoutes(app: FastifyInstance): void {
     return reply.send({
       isAdmin: true,
       feedPrivateMode: config.FEED_PRIVATE_MODE,
+      loginAllowlistEnabled: config.LOGIN_ALLOWLIST_ENABLED,
       system: {
         currentEpoch: currentEpoch
           ? {

--- a/src/admin/routes/waitlist.ts
+++ b/src/admin/routes/waitlist.ts
@@ -135,8 +135,12 @@ export function registerWaitlistRoutes(app: FastifyInstance): void {
     const { id } = parsed.data;
     const adminDid = getAdminDid(request);
 
+    // Fast pre-check: avoid the external handle→DID resolution for an unknown
+    // or already-decided id. The authoritative pending-claim happens atomically
+    // inside the transaction below (this check can still race, so it isn't
+    // trusted for correctness — only to skip needless work).
     const existing = await db.query(
-      `SELECT id, handle, status FROM waitlist_requests WHERE id = $1`,
+      `SELECT handle, status FROM waitlist_requests WHERE id = $1`,
       [id]
     );
     if (existing.rows.length === 0) {
@@ -148,6 +152,8 @@ export function registerWaitlistRoutes(app: FastifyInstance): void {
 
     const { handle } = existing.rows[0];
 
+    // Resolve outside the transaction so the DB connection isn't held during a
+    // network round-trip to bsky.social.
     let did: string;
     try {
       const resolved = await resolveHandleToDid(handle);
@@ -159,35 +165,64 @@ export function registerWaitlistRoutes(app: FastifyInstance): void {
       );
     }
 
-    // Same upsert as the participants route: re-activates a soft-removed row.
-    await db.query(
-      `INSERT INTO approved_participants (did, handle, added_by, notes)
-       VALUES ($1, $2, $3, $4)
-       ON CONFLICT (did) DO UPDATE SET
-         removed_at = NULL,
-         handle = COALESCE($2, approved_participants.handle),
-         added_by = $3,
-         notes = $4,
-         added_at = NOW()`,
-      [did, handle, adminDid, `waitlist #${id}`]
-    );
+    // The participant upsert, the pending-claim, and the audit row commit
+    // together or not at all — the tables can never drift on partial failure.
+    const client = await db.connect();
+    let claimed = false;
+    try {
+      await client.query('BEGIN');
 
-    await db.query(
-      `UPDATE waitlist_requests
-       SET status = 'approved', did = $2, decided_at = NOW(), decided_by = $3
-       WHERE id = $1`,
-      [id, did, adminDid]
-    );
+      // Atomic claim: only one concurrent approve can flip a still-pending row,
+      // so a double-click / race can't double-approve or double-audit.
+      const claim = await client.query(
+        `UPDATE waitlist_requests
+         SET status = 'approved', did = $2, decided_at = NOW(), decided_by = $3
+         WHERE id = $1 AND status = 'pending'
+         RETURNING id`,
+        [id, did, adminDid]
+      );
 
-    // Without this, a login attempt made before approval leaves a cached
-    // negative for up to 300s and the newly approved account stays locked out.
+      if (claim.rows.length === 0) {
+        await client.query('ROLLBACK');
+      } else {
+        claimed = true;
+
+        // Same upsert as the participants route: re-activates a soft-removed row.
+        await client.query(
+          `INSERT INTO approved_participants (did, handle, added_by, notes)
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (did) DO UPDATE SET
+             removed_at = NULL,
+             handle = COALESCE($2, approved_participants.handle),
+             added_by = $3,
+             notes = $4,
+             added_at = NOW()`,
+          [did, handle, adminDid, `waitlist #${id}`]
+        );
+
+        await client.query(
+          `INSERT INTO governance_audit_log (action, actor_did, details)
+           VALUES ($1, $2, $3)`,
+          ['waitlist_approved', adminDid, JSON.stringify({ id, handle, did })]
+        );
+
+        await client.query('COMMIT');
+      }
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    // Lost the atomic claim to a concurrent approve — the row is no longer pending.
+    if (!claimed) {
+      throw Errors.CONFLICT('Request already decided');
+    }
+
+    // After commit: a login attempt made before approval leaves a cached
+    // negative for up to 300s, so clear it or the account stays locked out.
     await invalidateParticipantCache(did);
-
-    await db.query(
-      `INSERT INTO governance_audit_log (action, actor_did, details)
-       VALUES ($1, $2, $3)`,
-      ['waitlist_approved', adminDid, JSON.stringify({ id, handle, did })]
-    );
 
     logger.info({ id, handle, did, adminDid }, 'Waitlist request approved');
 

--- a/src/admin/routes/waitlist.ts
+++ b/src/admin/routes/waitlist.ts
@@ -21,6 +21,7 @@ import { invalidateParticipantCache } from '../../feed/access-control.js';
 import { getAdminDid } from '../../auth/admin.js';
 import { adminSecurity, ErrorResponseSchema } from '../../lib/openapi.js';
 import { resolveHandleToDid } from './resolve-handle.js';
+import { upsertApprovedParticipant } from './participant-upsert.js';
 
 const ListQuerySchema = z.object({
   status: z.enum(['pending', 'approved', 'rejected', 'all']).default('pending'),
@@ -187,18 +188,12 @@ export function registerWaitlistRoutes(app: FastifyInstance): void {
       } else {
         claimed = true;
 
-        // Same upsert as the participants route: re-activates a soft-removed row.
-        await client.query(
-          `INSERT INTO approved_participants (did, handle, added_by, notes)
-           VALUES ($1, $2, $3, $4)
-           ON CONFLICT (did) DO UPDATE SET
-             removed_at = NULL,
-             handle = COALESCE($2, approved_participants.handle),
-             added_by = $3,
-             notes = $4,
-             added_at = NOW()`,
-          [did, handle, adminDid, `waitlist #${id}`]
-        );
+        await upsertApprovedParticipant(client, {
+          did,
+          handle,
+          addedBy: adminDid,
+          notes: `waitlist #${id}`,
+        });
 
         await client.query(
           `INSERT INTO governance_audit_log (action, actor_did, details)
@@ -264,15 +259,40 @@ export function registerWaitlistRoutes(app: FastifyInstance): void {
     const { id } = parsed.data;
     const adminDid = getAdminDid(request);
 
-    const result = await db.query(
-      `UPDATE waitlist_requests
-       SET status = 'rejected', decided_at = NOW(), decided_by = $2
-       WHERE id = $1 AND status = 'pending'
-       RETURNING handle`,
-      [id, adminDid]
-    );
+    // Transactional like approve: the atomic status flip and its audit row
+    // commit together, so a rejected request can never lose its audit entry.
+    const client = await db.connect();
+    let rejectedHandle: string | undefined;
+    try {
+      await client.query('BEGIN');
 
-    if (result.rows.length === 0) {
+      const result = await client.query(
+        `UPDATE waitlist_requests
+         SET status = 'rejected', decided_at = NOW(), decided_by = $2
+         WHERE id = $1 AND status = 'pending'
+         RETURNING handle`,
+        [id, adminDid]
+      );
+
+      if (result.rows.length === 0) {
+        await client.query('ROLLBACK');
+      } else {
+        rejectedHandle = result.rows[0].handle;
+        await client.query(
+          `INSERT INTO governance_audit_log (action, actor_did, details)
+           VALUES ($1, $2, $3)`,
+          ['waitlist_rejected', adminDid, JSON.stringify({ id, handle: rejectedHandle })]
+        );
+        await client.query('COMMIT');
+      }
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    if (rejectedHandle === undefined) {
       const exists = await db.query(`SELECT status FROM waitlist_requests WHERE id = $1`, [id]);
       if (exists.rows.length === 0) {
         throw Errors.NOT_FOUND('Waitlist request');
@@ -280,13 +300,7 @@ export function registerWaitlistRoutes(app: FastifyInstance): void {
       throw Errors.CONFLICT('Request already decided');
     }
 
-    await db.query(
-      `INSERT INTO governance_audit_log (action, actor_did, details)
-       VALUES ($1, $2, $3)`,
-      ['waitlist_rejected', adminDid, JSON.stringify({ id, handle: result.rows[0].handle })]
-    );
-
-    logger.info({ id, handle: result.rows[0].handle, adminDid }, 'Waitlist request rejected');
+    logger.info({ id, handle: rejectedHandle, adminDid }, 'Waitlist request rejected');
 
     return reply.send({ success: true });
   });

--- a/src/admin/routes/waitlist.ts
+++ b/src/admin/routes/waitlist.ts
@@ -1,0 +1,258 @@
+/**
+ * Admin Waitlist Management Routes
+ *
+ * Review queue for the voting-pilot waitlist. Approval resolves the stored
+ * handle to a DID and upserts it into approved_participants (the login and
+ * voting allowlist); rejection just marks the row. Both decisions are
+ * audit-logged. Registered under /api/admin with requireAdmin inherited
+ * from the admin route index.
+ *
+ * GET  /api/admin/waitlist?status=pending|approved|rejected|all
+ * POST /api/admin/waitlist/:id/approve
+ * POST /api/admin/waitlist/:id/reject
+ */
+
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { z } from 'zod';
+import { db } from '../../db/client.js';
+import { logger } from '../../lib/logger.js';
+import { Errors } from '../../lib/errors.js';
+import { invalidateParticipantCache } from '../../feed/access-control.js';
+import { getAdminDid } from '../../auth/admin.js';
+import { adminSecurity, ErrorResponseSchema } from '../../lib/openapi.js';
+import { resolveHandleToDid } from './resolve-handle.js';
+
+const ListQuerySchema = z.object({
+  status: z.enum(['pending', 'approved', 'rejected', 'all']).default('pending'),
+});
+
+const IdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+const WAITLIST_ROW_SCHEMA = {
+  type: 'object',
+  properties: {
+    id: { type: 'integer' },
+    handle: { type: 'string' },
+    did: { type: 'string', nullable: true },
+    note: { type: 'string', nullable: true },
+    status: { type: 'string', enum: ['pending', 'approved', 'rejected'] },
+    created_at: { type: 'string', format: 'date-time' },
+    decided_at: { type: 'string', format: 'date-time', nullable: true },
+    decided_by: { type: 'string', nullable: true },
+  },
+} as const;
+
+export function registerWaitlistRoutes(app: FastifyInstance): void {
+  /**
+   * GET /api/admin/waitlist
+   * List waitlist requests, oldest first (it is a queue).
+   */
+  app.get('/waitlist', {
+    schema: {
+      tags: ['Admin'],
+      summary: 'List waitlist requests',
+      description: 'Returns voting-pilot waitlist requests filtered by status (default pending), oldest first.',
+      security: adminSecurity,
+      querystring: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', enum: ['pending', 'approved', 'rejected', 'all'], default: 'pending' },
+        },
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            requests: { type: 'array', items: WAITLIST_ROW_SCHEMA },
+            total: { type: 'integer' },
+          },
+          required: ['requests', 'total'],
+        },
+        400: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest, reply: FastifyReply) => {
+    const parsed = ListQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      throw Errors.VALIDATION_ERROR('Invalid status filter', parsed.error.issues);
+    }
+    const { status } = parsed.data;
+
+    const result = status === 'all'
+      ? await db.query(
+          `SELECT id, handle, did, note, status, created_at, decided_at, decided_by
+           FROM waitlist_requests ORDER BY created_at ASC`
+        )
+      : await db.query(
+          `SELECT id, handle, did, note, status, created_at, decided_at, decided_by
+           FROM waitlist_requests WHERE status = $1 ORDER BY created_at ASC`,
+          [status]
+        );
+
+    return reply.send({ requests: result.rows, total: result.rows.length });
+  });
+
+  /**
+   * POST /api/admin/waitlist/:id/approve
+   * Resolve the handle to a DID, add to approved_participants, mark approved.
+   */
+  app.post('/waitlist/:id/approve', {
+    schema: {
+      tags: ['Admin'],
+      summary: 'Approve a waitlist request',
+      description:
+        'Resolves the stored handle to a DID, adds it to approved_participants (re-activating a previously ' +
+        'removed row if needed), and marks the request approved. Fails with 400 if the handle cannot be ' +
+        'resolved — the row stays pending and the account can be added by DID via the participants API.',
+      security: adminSecurity,
+      params: {
+        type: 'object',
+        properties: { id: { type: 'integer' } },
+        required: ['id'],
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            success: { type: 'boolean' },
+            did: { type: 'string' },
+            handle: { type: 'string' },
+          },
+          required: ['success', 'did', 'handle'],
+        },
+        400: ErrorResponseSchema,
+        404: ErrorResponseSchema,
+        409: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest, reply: FastifyReply) => {
+    const parsed = IdParamSchema.safeParse(request.params);
+    if (!parsed.success) {
+      throw Errors.VALIDATION_ERROR('Invalid waitlist id', parsed.error.issues);
+    }
+    const { id } = parsed.data;
+    const adminDid = getAdminDid(request);
+
+    const existing = await db.query(
+      `SELECT id, handle, status FROM waitlist_requests WHERE id = $1`,
+      [id]
+    );
+    if (existing.rows.length === 0) {
+      throw Errors.NOT_FOUND('Waitlist request');
+    }
+    if (existing.rows[0].status !== 'pending') {
+      throw Errors.CONFLICT('Request already decided');
+    }
+
+    const { handle } = existing.rows[0];
+
+    let did: string;
+    try {
+      const resolved = await resolveHandleToDid(handle);
+      did = resolved.did;
+    } catch (err) {
+      logger.warn({ handle, err }, 'Waitlist approve: failed to resolve handle');
+      throw Errors.BAD_REQUEST(
+        `Could not resolve handle: ${handle}. The row stays pending — add the account by DID via the participants API if needed.`
+      );
+    }
+
+    // Same upsert as the participants route: re-activates a soft-removed row.
+    await db.query(
+      `INSERT INTO approved_participants (did, handle, added_by, notes)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (did) DO UPDATE SET
+         removed_at = NULL,
+         handle = COALESCE($2, approved_participants.handle),
+         added_by = $3,
+         notes = $4,
+         added_at = NOW()`,
+      [did, handle, adminDid, `waitlist #${id}`]
+    );
+
+    await db.query(
+      `UPDATE waitlist_requests
+       SET status = 'approved', did = $2, decided_at = NOW(), decided_by = $3
+       WHERE id = $1`,
+      [id, did, adminDid]
+    );
+
+    // Without this, a login attempt made before approval leaves a cached
+    // negative for up to 300s and the newly approved account stays locked out.
+    await invalidateParticipantCache(did);
+
+    await db.query(
+      `INSERT INTO governance_audit_log (action, actor_did, details)
+       VALUES ($1, $2, $3)`,
+      ['waitlist_approved', adminDid, JSON.stringify({ id, handle, did })]
+    );
+
+    logger.info({ id, handle, did, adminDid }, 'Waitlist request approved');
+
+    return reply.send({ success: true, did, handle });
+  });
+
+  /**
+   * POST /api/admin/waitlist/:id/reject
+   * Mark a pending request rejected. Sticky against re-submission (intake
+   * dedupes on handle), but an admin can still approve directly later.
+   */
+  app.post('/waitlist/:id/reject', {
+    schema: {
+      tags: ['Admin'],
+      summary: 'Reject a waitlist request',
+      description: 'Marks a pending waitlist request as rejected. The handle can still be approved later via the participants API.',
+      security: adminSecurity,
+      params: {
+        type: 'object',
+        properties: { id: { type: 'integer' } },
+        required: ['id'],
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: { success: { type: 'boolean' } },
+          required: ['success'],
+        },
+        400: ErrorResponseSchema,
+        404: ErrorResponseSchema,
+        409: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest, reply: FastifyReply) => {
+    const parsed = IdParamSchema.safeParse(request.params);
+    if (!parsed.success) {
+      throw Errors.VALIDATION_ERROR('Invalid waitlist id', parsed.error.issues);
+    }
+    const { id } = parsed.data;
+    const adminDid = getAdminDid(request);
+
+    const result = await db.query(
+      `UPDATE waitlist_requests
+       SET status = 'rejected', decided_at = NOW(), decided_by = $2
+       WHERE id = $1 AND status = 'pending'
+       RETURNING handle`,
+      [id, adminDid]
+    );
+
+    if (result.rows.length === 0) {
+      const exists = await db.query(`SELECT status FROM waitlist_requests WHERE id = $1`, [id]);
+      if (exists.rows.length === 0) {
+        throw Errors.NOT_FOUND('Waitlist request');
+      }
+      throw Errors.CONFLICT('Request already decided');
+    }
+
+    await db.query(
+      `INSERT INTO governance_audit_log (action, actor_did, details)
+       VALUES ($1, $2, $3)`,
+      ['waitlist_rejected', adminDid, JSON.stringify({ id, handle: result.rows[0].handle })]
+    );
+
+    logger.info({ id, handle: result.rows[0].handle, adminDid }, 'Waitlist request rejected');
+
+    return reply.send({ success: true });
+  });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -185,6 +185,11 @@ export const ConfigSchema = z.object({
   // Private feed mode (research gating)
   FEED_PRIVATE_MODE: zodEnvBool(false),
 
+  // Login allowlist (pilot gating): when true, only admins (BOT_ADMIN_DIDS)
+  // and approved_participants may complete login. Waitlist intake and all
+  // public read surfaces are unaffected.
+  LOGIN_ALLOWLIST_ENABLED: zodEnvBool(false),
+
   // URL deduplication: penalize reshares of the same external link
   /** Enable URL-based reshare deduplication in feed output. */
   FEED_DEDUP_ENABLED: zodEnvBool(true),

--- a/src/db/migrations/033_waitlist.sql
+++ b/src/db/migrations/033_waitlist.sql
@@ -1,0 +1,25 @@
+-- Waitlist for the voting pilot.
+--
+-- Public intake stores a normalized Bluesky handle (lowercased, no leading '@')
+-- plus an optional requester note. Admins approve or reject; approval resolves
+-- the handle to a DID and inserts into approved_participants (the login/voting
+-- allowlist). Rejections are sticky for re-submissions (ON CONFLICT DO NOTHING
+-- at intake) but admins can always approve directly via the participants API.
+
+CREATE TABLE IF NOT EXISTS waitlist_requests (
+    id          SERIAL PRIMARY KEY,
+    handle      TEXT NOT NULL,
+    did         TEXT,
+    note        TEXT,
+    status      TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN ('pending', 'approved', 'rejected')),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    decided_at  TIMESTAMPTZ,
+    decided_by  TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_waitlist_handle
+    ON waitlist_requests(handle);
+
+CREATE INDEX IF NOT EXISTS idx_waitlist_status_created
+    ON waitlist_requests(status, created_at DESC);

--- a/src/feed/rate-limit-config.ts
+++ b/src/feed/rate-limit-config.ts
@@ -43,6 +43,16 @@ export function buildRouteRateLimitConfig(
     };
   }
 
+  // Waitlist intake is unauthenticated — reuse the login limits (IP-keyed).
+  // Must sit above the generic governance-mutation branch, which would
+  // otherwise key this route by DID and apply vote limits.
+  if (url.startsWith('/api/governance/waitlist')) {
+    return {
+      max: config.RATE_LIMIT_LOGIN_MAX,
+      timeWindow: config.RATE_LIMIT_LOGIN_WINDOW_MS,
+    };
+  }
+
   if (url.startsWith('/api/governance/vote')) {
     return {
       max: config.RATE_LIMIT_VOTE_MAX,

--- a/src/governance/routes/auth.ts
+++ b/src/governance/routes/auth.ts
@@ -17,6 +17,8 @@ import {
 } from '../auth.js';
 import { logger } from '../../lib/logger.js';
 import { config } from '../../config.js';
+import { isAdmin } from '../../auth/admin.js';
+import { isParticipantApproved } from '../../feed/access-control.js';
 import { zodToOpenApi, ErrorResponseSchema, RateLimitResponseSchema, governanceSecurity } from '../../lib/openapi.js';
 
 const LoginSchema = z.object({
@@ -99,6 +101,16 @@ export function registerAuthRoute(app: FastifyInstance): void {
         },
         400: ErrorResponseSchema,
         401: ErrorResponseSchema,
+        403: {
+          type: 'object',
+          description: 'Valid credentials, but the account is not approved for the pilot.',
+          properties: {
+            error: { type: 'string', example: 'NotApproved' },
+            message: { type: 'string' },
+            waitlist: { type: 'boolean', example: true, description: 'Discriminator: the client should offer the waitlist.' },
+          },
+          required: ['error', 'message', 'waitlist'],
+        },
         429: RateLimitResponseSchema,
         503: ErrorResponseSchema,
       },
@@ -124,6 +136,27 @@ export function registerAuthRoute(app: FastifyInstance): void {
           error: 'AuthenticationFailed',
           message: 'Invalid handle or app password. Make sure you are using an app password from Bluesky settings.',
         });
+      }
+
+      // Pilot gating: credentials are valid, but only admins and approved
+      // participants may hold a session. authenticateWithBluesky persisted
+      // the session before we could gate it, so invalidate on deny — the
+      // minted token must be dead, not merely unreturned.
+      if (config.LOGIN_ALLOWLIST_ENABLED && !isAdmin(session.did)) {
+        const approved = await isParticipantApproved(session.did);
+        if (!approved) {
+          try {
+            await invalidateSession(session.accessJwt);
+          } catch (invalidateErr) {
+            logger.warn({ err: invalidateErr, did: session.did }, 'Failed to invalidate unapproved session');
+          }
+          logger.info({ did: session.did, handle: session.handle }, 'Login denied: not an approved pilot participant');
+          return reply.code(403).send({
+            error: 'NotApproved',
+            message: 'This Bluesky account is not approved for the Corgi voting pilot yet. Join the waitlist and we will get you in as we expand.',
+            waitlist: true,
+          });
+        }
       }
 
       logger.info({ did: session.did, handle: session.handle }, 'User logged in');

--- a/src/governance/routes/auth.ts
+++ b/src/governance/routes/auth.ts
@@ -148,7 +148,14 @@ export function registerAuthRoute(app: FastifyInstance): void {
           try {
             await invalidateSession(session.accessJwt);
           } catch (invalidateErr) {
-            logger.warn({ err: invalidateErr, did: session.did }, 'Failed to invalidate unapproved session');
+            // We can't guarantee the just-minted session is dead — refuse with
+            // 503 (matching this file's SessionStoreUnavailable handling)
+            // rather than a 403 that leaves a live session behind.
+            logger.error({ err: invalidateErr, did: session.did }, 'Failed to invalidate unapproved session');
+            return reply.code(503).send({
+              error: 'SessionStoreUnavailable',
+              message: 'Authentication service is temporarily unavailable. Please try again.',
+            });
           }
           logger.info({ did: session.did, handle: session.handle }, 'Login denied: not an approved pilot participant');
           return reply.code(403).send({

--- a/src/governance/routes/waitlist.ts
+++ b/src/governance/routes/waitlist.ts
@@ -1,0 +1,105 @@
+/**
+ * Waitlist Route
+ *
+ * POST /api/governance/waitlist - Request voting access during the pilot.
+ *
+ * Public (unauthenticated) intake: stores a normalized Bluesky handle plus an
+ * optional note. The response is deliberately identical for new, duplicate,
+ * already-approved, and rejected handles so the endpoint cannot be used to
+ * probe anyone's approval status. Decisions happen in the admin waitlist
+ * routes and are audit-logged there; intake itself is not audit-logged
+ * because it is unauthenticated and rate-limited rather than trusted.
+ */
+
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { z } from 'zod';
+import { db } from '../../db/client.js';
+import { logger } from '../../lib/logger.js';
+import { zodToOpenApi, ErrorResponseSchema, RateLimitResponseSchema } from '../../lib/openapi.js';
+
+/**
+ * Bluesky handles are domains (user.bsky.social, or a custom domain like
+ * example.com). This intentionally rejects DIDs — admins can add DIDs
+ * directly through the participants API.
+ */
+const HANDLE_RE = /^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+const WaitlistSchema = z.object({
+  handle: z
+    .string()
+    .trim()
+    .min(1, 'Handle is required')
+    .max(253)
+    .transform((value) => value.replace(/^@/, '').toLowerCase())
+    .refine((value) => HANDLE_RE.test(value), {
+      message: 'Enter a Bluesky handle like you.bsky.social',
+    }),
+  note: z.string().trim().max(500).optional(),
+});
+
+const GENERIC_SUCCESS = {
+  success: true,
+  message: "You're on the list. We approve pilot accounts in batches — the demo and transparency pages stay open to everyone in the meantime.",
+} as const;
+
+export function registerWaitlistRoute(app: FastifyInstance): void {
+  app.post('/api/governance/waitlist', {
+    schema: {
+      tags: ['Governance'],
+      summary: 'Join the voting waitlist',
+      description:
+        'Request voting access during the pilot by submitting a Bluesky handle and optional note. ' +
+        'The response does not reveal whether the handle was already on the list or approved.',
+      body: zodToOpenApi(WaitlistSchema),
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            success: { type: 'boolean', example: true },
+            message: { type: 'string' },
+          },
+          required: ['success', 'message'],
+        },
+        400: ErrorResponseSchema,
+        429: RateLimitResponseSchema,
+        500: ErrorResponseSchema,
+      },
+    },
+  }, async (request: FastifyRequest, reply: FastifyReply) => {
+    const parseResult = WaitlistSchema.safeParse(request.body);
+
+    if (!parseResult.success) {
+      return reply.code(400).send({
+        error: 'ValidationError',
+        message: 'Invalid request body',
+        details: parseResult.error.issues,
+      });
+    }
+
+    const { handle, note } = parseResult.data;
+
+    try {
+      // Dedupe no-op for every existing state (pending, approved, rejected):
+      // rejections stay sticky and the first note wins, so a stranger cannot
+      // overwrite the note attached to someone else's handle.
+      const result = await db.query(
+        `INSERT INTO waitlist_requests (handle, note)
+         VALUES ($1, $2)
+         ON CONFLICT (handle) DO NOTHING`,
+        [handle, note ?? null]
+      );
+
+      if ((result.rowCount ?? 0) > 0) {
+        logger.info({ handle }, 'Waitlist request recorded');
+      }
+
+      return reply.send(GENERIC_SUCCESS);
+    } catch (err) {
+      logger.error({ err, handle }, 'Failed to record waitlist request');
+      return reply.code(500).send({
+        error: 'InternalError',
+        message: 'Could not record your request. Please try again.',
+      });
+    }
+  });
+}

--- a/src/governance/server.ts
+++ b/src/governance/server.ts
@@ -14,6 +14,7 @@ import { registerAuthRoute } from './routes/auth.js';
 import { registerPolisRoute } from './routes/polis.js';
 import { registerContentRulesRoute } from './routes/content-rules.js';
 import { registerResearchConsentRoute } from './routes/research-consent.js';
+import { registerWaitlistRoute } from './routes/waitlist.js';
 import { logger } from '../lib/logger.js';
 
 /**
@@ -61,6 +62,9 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
 
   // Research consent route
   registerResearchConsentRoute(app);
+
+  // Waitlist route (public pilot-access intake)
+  registerWaitlistRoute(app);
 
   logger.info('Governance routes registered');
 }

--- a/tests/admin-waitlist.test.ts
+++ b/tests/admin-waitlist.test.ts
@@ -2,14 +2,21 @@ import Fastify from 'fastify';
 import type { FastifyRequest } from 'fastify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { queryMock, resolveHandleMock, invalidateCacheMock } = vi.hoisted(() => ({
-  queryMock: vi.fn(),
-  resolveHandleMock: vi.fn(),
-  invalidateCacheMock: vi.fn(),
-}));
+const { queryMock, clientQueryMock, releaseMock, connectMock, resolveHandleMock, invalidateCacheMock } = vi.hoisted(() => {
+  const clientQuery = vi.fn();
+  const release = vi.fn();
+  return {
+    queryMock: vi.fn(),
+    clientQueryMock: clientQuery,
+    releaseMock: release,
+    connectMock: vi.fn(async () => ({ query: clientQuery, release })),
+    resolveHandleMock: vi.fn(),
+    invalidateCacheMock: vi.fn(),
+  };
+});
 
 vi.mock('../src/db/client.js', () => ({
-  db: { query: queryMock },
+  db: { query: queryMock, connect: connectMock },
 }));
 
 vi.mock('../src/admin/routes/resolve-handle.js', () => ({
@@ -50,9 +57,20 @@ const PENDING_ROW = {
 describe('admin waitlist routes', () => {
   beforeEach(() => {
     queryMock.mockReset();
+    clientQueryMock.mockReset();
+    releaseMock.mockReset();
+    connectMock.mockClear();
     resolveHandleMock.mockReset();
     invalidateCacheMock.mockReset();
     invalidateCacheMock.mockResolvedValue(undefined);
+    // Transactional client: BEGIN/upsert/audit/COMMIT succeed by default; the
+    // atomic-claim UPDATE returns a claimed row unless a test overrides it.
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (/UPDATE waitlist_requests/i.test(sql) && /RETURNING/i.test(sql)) {
+        return Promise.resolve({ rows: [{ id: 7 }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
   });
 
   it('GET /waitlist defaults to pending, oldest first', async () => {
@@ -84,13 +102,14 @@ describe('admin waitlist routes', () => {
     expect(response.statusCode).toBe(400);
   });
 
-  it('approve: resolves handle, upserts participant, marks row, invalidates cache, audits', async () => {
+  it('approve: atomically claims the row, upserts participant, audits in a transaction, invalidates cache', async () => {
     resolveHandleMock.mockResolvedValue({ did: 'did:plc:alice', handle: 'alice.bsky.social' });
-    queryMock
-      .mockResolvedValueOnce({ rows: [{ id: 7, handle: 'alice.bsky.social', status: 'pending' }] }) // select
-      .mockResolvedValueOnce({ rows: [] })  // participants upsert
-      .mockResolvedValueOnce({ rows: [] })  // waitlist update
-      .mockResolvedValueOnce({ rows: [] }); // audit insert
+    queryMock.mockResolvedValueOnce({ rows: [{ handle: 'alice.bsky.social', status: 'pending' }] }); // pre-check
+    const claimQuery = { rows: [{ id: 7 }] };
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (/UPDATE waitlist_requests/i.test(sql) && /RETURNING/i.test(sql)) return Promise.resolve(claimQuery);
+      return Promise.resolve({ rows: [] });
+    });
     const app = buildApp();
 
     const response = await app.inject({ method: 'POST', url: '/waitlist/7/approve' });
@@ -98,39 +117,64 @@ describe('admin waitlist routes', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ success: true, did: 'did:plc:alice', handle: 'alice.bsky.social' });
 
-    const upsertCall = queryMock.mock.calls[1];
-    expect(upsertCall[0]).toContain('INSERT INTO approved_participants');
-    expect(upsertCall[0]).toContain('ON CONFLICT (did) DO UPDATE');
-    expect(upsertCall[1]).toEqual(['did:plc:alice', 'alice.bsky.social', ADMIN_DID, 'waitlist #7']);
-
-    const updateCall = queryMock.mock.calls[2];
-    expect(updateCall[0]).toContain("SET status = 'approved'");
-    expect(updateCall[1]).toEqual([7, 'did:plc:alice', ADMIN_DID]);
-
+    const sqls = clientQueryMock.mock.calls.map((c) => String(c[0]).trim());
+    // Runs inside a transaction and commits.
+    expect(sqls[0]).toBe('BEGIN');
+    expect(sqls[sqls.length - 1]).toBe('COMMIT');
+    // Atomic claim: the status flip is guarded by AND status = 'pending'.
+    const claim = clientQueryMock.mock.calls.find((c) => /UPDATE waitlist_requests/i.test(String(c[0])))!;
+    expect(String(claim[0])).toContain("AND status = 'pending'");
+    expect(claim[1]).toEqual([7, 'did:plc:alice', ADMIN_DID]);
+    // Participant upsert + audit ran on the same client.
+    const upsert = clientQueryMock.mock.calls.find((c) => /INSERT INTO approved_participants/i.test(String(c[0])))!;
+    expect(String(upsert[0])).toContain('ON CONFLICT (did) DO UPDATE');
+    expect(upsert[1]).toEqual(['did:plc:alice', 'alice.bsky.social', ADMIN_DID, 'waitlist #7']);
+    const audit = clientQueryMock.mock.calls.find((c) => /governance_audit_log/i.test(String(c[0])))!;
+    expect(audit[1][0]).toBe('waitlist_approved');
+    // Cache invalidated after commit, and the connection was released.
     expect(invalidateCacheMock).toHaveBeenCalledWith('did:plc:alice');
-
-    const auditCall = queryMock.mock.calls[3];
-    expect(auditCall[0]).toContain('governance_audit_log');
-    expect(auditCall[1][0]).toBe('waitlist_approved');
-    expect(auditCall[1][1]).toBe(ADMIN_DID);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 
-  it('approve: 404 for an unknown id', async () => {
+  it('approve: lost race (claim returns no row) rolls back and 409s without touching participants', async () => {
+    resolveHandleMock.mockResolvedValue({ did: 'did:plc:alice', handle: 'alice.bsky.social' });
+    queryMock.mockResolvedValueOnce({ rows: [{ handle: 'alice.bsky.social', status: 'pending' }] }); // pre-check passes
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (/UPDATE waitlist_requests/i.test(sql) && /RETURNING/i.test(sql)) return Promise.resolve({ rows: [] }); // claim lost
+      return Promise.resolve({ rows: [] });
+    });
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'POST', url: '/waitlist/7/approve' });
+
+    expect(response.statusCode).toBe(409);
+    const sqls = clientQueryMock.mock.calls.map((c) => String(c[0]).trim());
+    expect(sqls).toContain('ROLLBACK');
+    expect(sqls.some((s) => /INSERT INTO approved_participants/i.test(s))).toBe(false);
+    expect(invalidateCacheMock).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('approve: 404 for an unknown id (no network resolve, no transaction)', async () => {
     queryMock.mockResolvedValueOnce({ rows: [] });
     const app = buildApp();
 
     const response = await app.inject({ method: 'POST', url: '/waitlist/999/approve' });
 
     expect(response.statusCode).toBe(404);
+    expect(resolveHandleMock).not.toHaveBeenCalled();
+    expect(connectMock).not.toHaveBeenCalled();
   });
 
-  it('approve: 409 when already decided', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ id: 7, handle: 'alice.bsky.social', status: 'approved' }] });
+  it('approve: 409 when already decided (fast pre-check, no network resolve)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ handle: 'alice.bsky.social', status: 'approved' }] });
     const app = buildApp();
 
     const response = await app.inject({ method: 'POST', url: '/waitlist/7/approve' });
 
     expect(response.statusCode).toBe(409);
+    expect(resolveHandleMock).not.toHaveBeenCalled();
+    expect(connectMock).not.toHaveBeenCalled();
   });
 
   it('approve: 400 when the handle cannot be resolved, and the row stays pending', async () => {

--- a/tests/admin-waitlist.test.ts
+++ b/tests/admin-waitlist.test.ts
@@ -1,0 +1,179 @@
+import Fastify from 'fastify';
+import type { FastifyRequest } from 'fastify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryMock, resolveHandleMock, invalidateCacheMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  resolveHandleMock: vi.fn(),
+  invalidateCacheMock: vi.fn(),
+}));
+
+vi.mock('../src/db/client.js', () => ({
+  db: { query: queryMock },
+}));
+
+vi.mock('../src/admin/routes/resolve-handle.js', () => ({
+  resolveHandleToDid: resolveHandleMock,
+}));
+
+vi.mock('../src/feed/access-control.js', () => ({
+  isParticipantApproved: vi.fn(),
+  invalidateParticipantCache: invalidateCacheMock,
+}));
+
+import { registerWaitlistRoutes } from '../src/admin/routes/waitlist.js';
+
+const ADMIN_DID = 'did:plc:admin';
+
+/** Bare app standing in for the admin scope: requireAdmin is exercised
+ *  elsewhere; here we attach adminDid the way the preHandler would. */
+function buildApp() {
+  const app = Fastify();
+  app.addHook('preHandler', async (request: FastifyRequest) => {
+    (request as FastifyRequest & { adminDid: string }).adminDid = ADMIN_DID;
+  });
+  registerWaitlistRoutes(app);
+  return app;
+}
+
+const PENDING_ROW = {
+  id: 7,
+  handle: 'alice.bsky.social',
+  did: null,
+  note: 'birder',
+  status: 'pending',
+  created_at: '2026-07-13T00:00:00.000Z',
+  decided_at: null,
+  decided_by: null,
+};
+
+describe('admin waitlist routes', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    resolveHandleMock.mockReset();
+    invalidateCacheMock.mockReset();
+    invalidateCacheMock.mockResolvedValue(undefined);
+  });
+
+  it('GET /waitlist defaults to pending, oldest first', async () => {
+    queryMock.mockResolvedValue({ rows: [PENDING_ROW] });
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'GET', url: '/waitlist' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ requests: [PENDING_ROW], total: 1 });
+    expect(queryMock.mock.calls[0][0]).toContain("status = $1");
+    expect(queryMock.mock.calls[0][1]).toEqual(['pending']);
+    expect(queryMock.mock.calls[0][0]).toContain('ORDER BY created_at ASC');
+  });
+
+  it('GET /waitlist?status=all omits the filter', async () => {
+    queryMock.mockResolvedValue({ rows: [] });
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'GET', url: '/waitlist?status=all' });
+
+    expect(response.statusCode).toBe(200);
+    expect(queryMock.mock.calls[0][0]).not.toContain('WHERE');
+  });
+
+  it('GET /waitlist rejects an unknown status', async () => {
+    const app = buildApp();
+    const response = await app.inject({ method: 'GET', url: '/waitlist?status=bogus' });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('approve: resolves handle, upserts participant, marks row, invalidates cache, audits', async () => {
+    resolveHandleMock.mockResolvedValue({ did: 'did:plc:alice', handle: 'alice.bsky.social' });
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 7, handle: 'alice.bsky.social', status: 'pending' }] }) // select
+      .mockResolvedValueOnce({ rows: [] })  // participants upsert
+      .mockResolvedValueOnce({ rows: [] })  // waitlist update
+      .mockResolvedValueOnce({ rows: [] }); // audit insert
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'POST', url: '/waitlist/7/approve' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true, did: 'did:plc:alice', handle: 'alice.bsky.social' });
+
+    const upsertCall = queryMock.mock.calls[1];
+    expect(upsertCall[0]).toContain('INSERT INTO approved_participants');
+    expect(upsertCall[0]).toContain('ON CONFLICT (did) DO UPDATE');
+    expect(upsertCall[1]).toEqual(['did:plc:alice', 'alice.bsky.social', ADMIN_DID, 'waitlist #7']);
+
+    const updateCall = queryMock.mock.calls[2];
+    expect(updateCall[0]).toContain("SET status = 'approved'");
+    expect(updateCall[1]).toEqual([7, 'did:plc:alice', ADMIN_DID]);
+
+    expect(invalidateCacheMock).toHaveBeenCalledWith('did:plc:alice');
+
+    const auditCall = queryMock.mock.calls[3];
+    expect(auditCall[0]).toContain('governance_audit_log');
+    expect(auditCall[1][0]).toBe('waitlist_approved');
+    expect(auditCall[1][1]).toBe(ADMIN_DID);
+  });
+
+  it('approve: 404 for an unknown id', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] });
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'POST', url: '/waitlist/999/approve' });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('approve: 409 when already decided', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ id: 7, handle: 'alice.bsky.social', status: 'approved' }] });
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'POST', url: '/waitlist/7/approve' });
+
+    expect(response.statusCode).toBe(409);
+  });
+
+  it('approve: 400 when the handle cannot be resolved, and the row stays pending', async () => {
+    resolveHandleMock.mockRejectedValue(new Error('resolution failed'));
+    queryMock.mockResolvedValueOnce({ rows: [{ id: 7, handle: 'typo.example', status: 'pending' }] });
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'POST', url: '/waitlist/7/approve' });
+
+    expect(response.statusCode).toBe(400);
+    // Only the initial SELECT ran — no upsert, no status update.
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(invalidateCacheMock).not.toHaveBeenCalled();
+  });
+
+  it('reject: marks pending row rejected and audits', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ handle: 'alice.bsky.social' }] }) // update returning
+      .mockResolvedValueOnce({ rows: [] });                               // audit insert
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'POST', url: '/waitlist/7/reject' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true });
+    expect(queryMock.mock.calls[0][0]).toContain("SET status = 'rejected'");
+    expect(queryMock.mock.calls[1][1][0]).toBe('waitlist_rejected');
+  });
+
+  it('reject: 404 unknown id, 409 already decided', async () => {
+    const app = buildApp();
+
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })  // update matched nothing
+      .mockResolvedValueOnce({ rows: [] }); // existence check: not found
+    const notFound = await app.inject({ method: 'POST', url: '/waitlist/999/reject' });
+    expect(notFound.statusCode).toBe(404);
+
+    queryMock.mockReset();
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })                          // update matched nothing
+      .mockResolvedValueOnce({ rows: [{ status: 'approved' }] });   // exists but decided
+    const conflict = await app.inject({ method: 'POST', url: '/waitlist/7/reject' });
+    expect(conflict.statusCode).toBe(409);
+  });
+});

--- a/tests/admin-waitlist.test.ts
+++ b/tests/admin-waitlist.test.ts
@@ -64,10 +64,11 @@ describe('admin waitlist routes', () => {
     invalidateCacheMock.mockReset();
     invalidateCacheMock.mockResolvedValue(undefined);
     // Transactional client: BEGIN/upsert/audit/COMMIT succeed by default; the
-    // atomic-claim UPDATE returns a claimed row unless a test overrides it.
+    // atomic-claim UPDATE returns a claimed row (with id + handle so both the
+    // approve and reject handlers read what they expect) unless a test overrides it.
     clientQueryMock.mockImplementation((sql: string) => {
       if (/UPDATE waitlist_requests/i.test(sql) && /RETURNING/i.test(sql)) {
-        return Promise.resolve({ rows: [{ id: 7 }] });
+        return Promise.resolve({ rows: [{ id: 7, handle: 'alice.bsky.social' }] });
       }
       return Promise.resolve({ rows: [] });
     });
@@ -155,6 +156,27 @@ describe('admin waitlist routes', () => {
     expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 
+  it('approve: an error after the claim (upsert throws) rolls back, releases, and propagates', async () => {
+    resolveHandleMock.mockResolvedValue({ did: 'did:plc:alice', handle: 'alice.bsky.social' });
+    queryMock.mockResolvedValueOnce({ rows: [{ handle: 'alice.bsky.social', status: 'pending' }] }); // pre-check
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (/UPDATE waitlist_requests/i.test(sql) && /RETURNING/i.test(sql)) return Promise.resolve({ rows: [{ id: 7 }] }); // claim wins
+      if (/INSERT INTO approved_participants/i.test(sql)) return Promise.reject(new Error('constraint violation'));
+      return Promise.resolve({ rows: [] });
+    });
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'POST', url: '/waitlist/7/approve' });
+
+    expect(response.statusCode).toBeGreaterThanOrEqual(500);
+    const sqls = clientQueryMock.mock.calls.map((c) => String(c[0]).trim());
+    expect(sqls).toContain('ROLLBACK');
+    expect(sqls).not.toContain('COMMIT');
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+    // Never invalidate the cache for a transaction that didn't commit.
+    expect(invalidateCacheMock).not.toHaveBeenCalled();
+  });
+
   it('approve: 404 for an unknown id (no network resolve, no transaction)', async () => {
     queryMock.mockResolvedValueOnce({ rows: [] });
     const app = buildApp();
@@ -190,34 +212,37 @@ describe('admin waitlist routes', () => {
     expect(invalidateCacheMock).not.toHaveBeenCalled();
   });
 
-  it('reject: marks pending row rejected and audits', async () => {
-    queryMock
-      .mockResolvedValueOnce({ rows: [{ handle: 'alice.bsky.social' }] }) // update returning
-      .mockResolvedValueOnce({ rows: [] });                               // audit insert
+  it('reject: marks pending row rejected and audits inside a transaction', async () => {
+    // Default clientQueryMock claims the row (returns id + handle) and commits.
     const app = buildApp();
 
     const response = await app.inject({ method: 'POST', url: '/waitlist/7/reject' });
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ success: true });
-    expect(queryMock.mock.calls[0][0]).toContain("SET status = 'rejected'");
-    expect(queryMock.mock.calls[1][1][0]).toBe('waitlist_rejected');
+    const sqls = clientQueryMock.mock.calls.map((c) => String(c[0]).trim());
+    expect(sqls[0]).toBe('BEGIN');
+    expect(sqls[sqls.length - 1]).toBe('COMMIT');
+    const update = clientQueryMock.mock.calls.find((c) => /UPDATE waitlist_requests/i.test(String(c[0])))!;
+    expect(String(update[0])).toContain("SET status = 'rejected'");
+    const audit = clientQueryMock.mock.calls.find((c) => /governance_audit_log/i.test(String(c[0])))!;
+    expect(audit[1][0]).toBe('waitlist_rejected');
+    expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 
-  it('reject: 404 unknown id, 409 already decided', async () => {
-    const app = buildApp();
+  it('reject: 404 unknown id, 409 already decided (rolls back the empty claim)', async () => {
+    // Claim matches nothing → ROLLBACK, then the existence check decides 404 vs 409.
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (/UPDATE waitlist_requests/i.test(sql) && /RETURNING/i.test(sql)) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
 
-    queryMock
-      .mockResolvedValueOnce({ rows: [] })  // update matched nothing
-      .mockResolvedValueOnce({ rows: [] }); // existence check: not found
-    const notFound = await app.inject({ method: 'POST', url: '/waitlist/999/reject' });
+    queryMock.mockResolvedValueOnce({ rows: [] }); // existence check: not found
+    const notFound = await buildApp().inject({ method: 'POST', url: '/waitlist/999/reject' });
     expect(notFound.statusCode).toBe(404);
 
-    queryMock.mockReset();
-    queryMock
-      .mockResolvedValueOnce({ rows: [] })                          // update matched nothing
-      .mockResolvedValueOnce({ rows: [{ status: 'approved' }] });   // exists but decided
-    const conflict = await app.inject({ method: 'POST', url: '/waitlist/7/reject' });
+    queryMock.mockResolvedValueOnce({ rows: [{ status: 'approved' }] }); // exists but decided
+    const conflict = await buildApp().inject({ method: 'POST', url: '/waitlist/7/reject' });
     expect(conflict.statusCode).toBe(409);
   });
 });

--- a/tests/admin-waitlist.test.ts
+++ b/tests/admin-waitlist.test.ts
@@ -230,6 +230,23 @@ describe('admin waitlist routes', () => {
     expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 
+  it('reject: an error after the claim (audit insert throws) rolls back, releases, and propagates', async () => {
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (/UPDATE waitlist_requests/i.test(sql) && /RETURNING/i.test(sql)) return Promise.resolve({ rows: [{ handle: 'alice.bsky.social' }] }); // claim wins
+      if (/governance_audit_log/i.test(sql)) return Promise.reject(new Error('audit insert failed'));
+      return Promise.resolve({ rows: [] });
+    });
+    const app = buildApp();
+
+    const response = await app.inject({ method: 'POST', url: '/waitlist/7/reject' });
+
+    expect(response.statusCode).toBeGreaterThanOrEqual(500);
+    const sqls = clientQueryMock.mock.calls.map((c) => String(c[0]).trim());
+    expect(sqls).toContain('ROLLBACK');
+    expect(sqls).not.toContain('COMMIT');
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
   it('reject: 404 unknown id, 409 already decided (rolls back the empty claim)', async () => {
     // Claim matches nothing → ROLLBACK, then the existence check decides 404 vs 409.
     clientQueryMock.mockImplementation((sql: string) => {

--- a/tests/governance-auth-allowlist.test.ts
+++ b/tests/governance-auth-allowlist.test.ts
@@ -123,27 +123,42 @@ describe('login allowlist gate', () => {
     const savedToken = saveSessionMock.mock.calls[0][0];
     expect(deleteSessionMock).toHaveBeenCalledWith(savedToken);
 
-    // No session cookie may leak on the deny path.
+    // No set-cookie header carrying a session token may be emitted on the deny
+    // path — assert unconditionally, not only when the header happens to exist.
     const setCookie = response.headers['set-cookie'];
-    if (setCookie !== undefined) {
-      const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
-      for (const cookie of cookies) {
-        expect(cookie).not.toMatch(/governance_session=[^;]+/);
-      }
-    }
+    const cookies = setCookie === undefined ? [] : (Array.isArray(setCookie) ? setCookie : [setCookie]);
+    expect(cookies.some((c) => /governance_session=[^;]+/.test(c))).toBe(false);
   });
 
-  it('flag on: allowlist lookup failure fails closed (fail-closed contract)', async () => {
+  it('flag on: an allowlist lookup that throws denies fail-closed with no cookie', async () => {
     (config as { LOGIN_ALLOWLIST_ENABLED: boolean }).LOGIN_ALLOWLIST_ENABLED = true;
     isAdminMock.mockReturnValue(false);
-    // isParticipantApproved itself catches storage errors and returns false —
-    // mirror that contract here.
-    isParticipantApprovedMock.mockResolvedValue(false);
+    // If isParticipantApproved's internal fail-closed contract ever regressed
+    // and it threw, the route must still deny (never grant) — verify the route
+    // itself doesn't leak a session on that path.
+    isParticipantApprovedMock.mockRejectedValue(new Error('redis + postgres both down'));
 
     const response = await login(buildApp());
 
-    expect(response.statusCode).toBe(403);
-    expect(response.json().error).toBe('NotApproved');
+    expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    const setCookie = response.headers['set-cookie'];
+    const cookies = setCookie === undefined ? [] : (Array.isArray(setCookie) ? setCookie : [setCookie]);
+    expect(cookies.some((c) => /governance_session=[^;]+/.test(c))).toBe(false);
+  });
+
+  it('flag on: if invalidating the minted session fails, denies with 503 (never 403 + live session)', async () => {
+    (config as { LOGIN_ALLOWLIST_ENABLED: boolean }).LOGIN_ALLOWLIST_ENABLED = true;
+    isAdminMock.mockReturnValue(false);
+    isParticipantApprovedMock.mockResolvedValue(false);
+    deleteSessionMock.mockRejectedValue(new Error('redis del failed'));
+
+    const response = await login(buildApp());
+
+    // Can't prove the session is dead → 503, not a 403 that implies a clean deny.
+    expect(response.statusCode).toBe(503);
+    const setCookie = response.headers['set-cookie'];
+    const cookies = setCookie === undefined ? [] : (Array.isArray(setCookie) ? setCookie : [setCookie]);
+    expect(cookies.some((c) => /governance_session=[^;]+/.test(c))).toBe(false);
   });
 
   it('flag defaults to false', () => {

--- a/tests/governance-auth-allowlist.test.ts
+++ b/tests/governance-auth-allowlist.test.ts
@@ -1,0 +1,152 @@
+import Fastify from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { loginMock, saveSessionMock, deleteSessionMock, isAdminMock, isParticipantApprovedMock } = vi.hoisted(() => ({
+  loginMock: vi.fn(),
+  saveSessionMock: vi.fn(),
+  deleteSessionMock: vi.fn(),
+  isAdminMock: vi.fn(),
+  isParticipantApprovedMock: vi.fn(),
+}));
+
+vi.mock('@atproto/api', () => ({
+  AtpAgent: class MockAtpAgent {
+    login = loginMock;
+  },
+}));
+
+vi.mock('../src/governance/session-store.js', () => ({
+  saveSession: saveSessionMock,
+  getSessionByToken: vi.fn(),
+  deleteSession: deleteSessionMock,
+}));
+
+// src/auth/admin.ts parses BOT_ADMIN_DIDS at module load, so mock the module
+// rather than the environment.
+vi.mock('../src/auth/admin.js', () => ({
+  isAdmin: isAdminMock,
+}));
+
+vi.mock('../src/feed/access-control.js', () => ({
+  isParticipantApproved: isParticipantApprovedMock,
+  invalidateParticipantCache: vi.fn(),
+}));
+
+import { config } from '../src/config.js';
+import { registerAuthRoute } from '../src/governance/routes/auth.js';
+
+const originalFlag = config.LOGIN_ALLOWLIST_ENABLED;
+
+function buildApp() {
+  const app = Fastify();
+  registerAuthRoute(app);
+  return app;
+}
+
+async function login(app: ReturnType<typeof Fastify>) {
+  return app.inject({
+    method: 'POST',
+    url: '/api/governance/auth/login',
+    payload: { handle: 'user.bsky.social', appPassword: 'xxxx-xxxx-xxxx-xxxx' },
+  });
+}
+
+describe('login allowlist gate', () => {
+  beforeEach(() => {
+    loginMock.mockReset();
+    saveSessionMock.mockReset();
+    deleteSessionMock.mockReset();
+    isAdminMock.mockReset();
+    isParticipantApprovedMock.mockReset();
+
+    loginMock.mockResolvedValue({
+      success: true,
+      data: { did: 'did:plc:user', handle: 'user.bsky.social' },
+    });
+    saveSessionMock.mockResolvedValue(undefined);
+    deleteSessionMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    (config as { LOGIN_ALLOWLIST_ENABLED: boolean }).LOGIN_ALLOWLIST_ENABLED = originalFlag;
+  });
+
+  it('flag off: unapproved accounts still log in (regression guard)', async () => {
+    (config as { LOGIN_ALLOWLIST_ENABLED: boolean }).LOGIN_ALLOWLIST_ENABLED = false;
+    isAdminMock.mockReturnValue(false);
+    isParticipantApprovedMock.mockResolvedValue(false);
+
+    const response = await login(buildApp());
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['set-cookie']).toBeDefined();
+    expect(isParticipantApprovedMock).not.toHaveBeenCalled();
+  });
+
+  it('flag on: approved participants log in', async () => {
+    (config as { LOGIN_ALLOWLIST_ENABLED: boolean }).LOGIN_ALLOWLIST_ENABLED = true;
+    isAdminMock.mockReturnValue(false);
+    isParticipantApprovedMock.mockResolvedValue(true);
+
+    const response = await login(buildApp());
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['set-cookie']).toContain('governance_session=');
+    expect(isParticipantApprovedMock).toHaveBeenCalledWith('did:plc:user');
+  });
+
+  it('flag on: admins bypass without a participant lookup', async () => {
+    (config as { LOGIN_ALLOWLIST_ENABLED: boolean }).LOGIN_ALLOWLIST_ENABLED = true;
+    isAdminMock.mockReturnValue(true);
+
+    const response = await login(buildApp());
+
+    expect(response.statusCode).toBe(200);
+    expect(isParticipantApprovedMock).not.toHaveBeenCalled();
+  });
+
+  it('flag on: unapproved accounts get 403 NotApproved, the minted session is invalidated, and no cookie is set', async () => {
+    (config as { LOGIN_ALLOWLIST_ENABLED: boolean }).LOGIN_ALLOWLIST_ENABLED = true;
+    isAdminMock.mockReturnValue(false);
+    isParticipantApprovedMock.mockResolvedValue(false);
+
+    const response = await login(buildApp());
+
+    expect(response.statusCode).toBe(403);
+    const body = response.json();
+    expect(body.error).toBe('NotApproved');
+    expect(body.waitlist).toBe(true);
+    expect(typeof body.message).toBe('string');
+
+    // The session persisted by authenticateWithBluesky must be dead.
+    expect(deleteSessionMock).toHaveBeenCalledTimes(1);
+    const savedToken = saveSessionMock.mock.calls[0][0];
+    expect(deleteSessionMock).toHaveBeenCalledWith(savedToken);
+
+    // No session cookie may leak on the deny path.
+    const setCookie = response.headers['set-cookie'];
+    if (setCookie !== undefined) {
+      const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+      for (const cookie of cookies) {
+        expect(cookie).not.toMatch(/governance_session=[^;]+/);
+      }
+    }
+  });
+
+  it('flag on: allowlist lookup failure fails closed (fail-closed contract)', async () => {
+    (config as { LOGIN_ALLOWLIST_ENABLED: boolean }).LOGIN_ALLOWLIST_ENABLED = true;
+    isAdminMock.mockReturnValue(false);
+    // isParticipantApproved itself catches storage errors and returns false —
+    // mirror that contract here.
+    isParticipantApprovedMock.mockResolvedValue(false);
+
+    const response = await login(buildApp());
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error).toBe('NotApproved');
+  });
+
+  it('flag defaults to false', () => {
+    expect(originalFlag).toBe(false);
+  });
+});

--- a/tests/governance-waitlist-route.test.ts
+++ b/tests/governance-waitlist-route.test.ts
@@ -62,6 +62,21 @@ describe('POST /api/governance/waitlist', () => {
     expect(duplicate.json()).toEqual(fresh.json());
   });
 
+  it('accepts the exact boundary values (500-char note, long valid handle)', async () => {
+    const app = buildApp();
+    const note = 'x'.repeat(500);
+    // A valid multi-label handle near the 253-char cap (63-char labels).
+    const longHandle = `${'a'.repeat(60)}.${'b'.repeat(60)}.${'c'.repeat(60)}.bsky.social`;
+
+    const noteResponse = await submit(app, { handle: 'alice.bsky.social', note });
+    expect(noteResponse.statusCode).toBe(200);
+    expect(queryMock.mock.calls[0][1]).toEqual(['alice.bsky.social', note]);
+
+    const handleResponse = await submit(app, { handle: longHandle });
+    expect(handleResponse.statusCode).toBe(200);
+    expect(longHandle.length).toBeLessThanOrEqual(253);
+  });
+
   it('rejects malformed handles, DIDs, and oversized notes with 400', async () => {
     const app = buildApp();
 

--- a/tests/governance-waitlist-route.test.ts
+++ b/tests/governance-waitlist-route.test.ts
@@ -1,0 +1,98 @@
+import Fastify from 'fastify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+}));
+
+vi.mock('../src/db/client.js', () => ({
+  db: { query: queryMock },
+}));
+
+import { registerWaitlistRoute } from '../src/governance/routes/waitlist.js';
+
+function buildApp() {
+  const app = Fastify();
+  registerWaitlistRoute(app);
+  return app;
+}
+
+async function submit(app: ReturnType<typeof Fastify>, payload: unknown) {
+  return app.inject({
+    method: 'POST',
+    url: '/api/governance/waitlist',
+    payload: payload as Record<string, unknown>,
+  });
+}
+
+describe('POST /api/governance/waitlist', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    queryMock.mockResolvedValue({ rowCount: 1, rows: [] });
+  });
+
+  it('records a valid handle and returns the generic success body', async () => {
+    const app = buildApp();
+    const response = await submit(app, { handle: 'alice.bsky.social', note: 'birder here' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.success).toBe(true);
+    expect(typeof body.message).toBe('string');
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][1]).toEqual(['alice.bsky.social', 'birder here']);
+  });
+
+  it('normalizes leading @, whitespace, and case before insert', async () => {
+    const app = buildApp();
+    const response = await submit(app, { handle: '  @Alice.Example.COM ' });
+
+    expect(response.statusCode).toBe(200);
+    expect(queryMock.mock.calls[0][1]).toEqual(['alice.example.com', null]);
+  });
+
+  it('returns the identical generic body for a duplicate handle', async () => {
+    queryMock.mockResolvedValue({ rowCount: 0, rows: [] });
+    const app = buildApp();
+
+    const fresh = await submit(app, { handle: 'alice.bsky.social' });
+    const duplicate = await submit(app, { handle: 'alice.bsky.social' });
+
+    expect(duplicate.statusCode).toBe(200);
+    expect(duplicate.json()).toEqual(fresh.json());
+  });
+
+  it('rejects malformed handles, DIDs, and oversized notes with 400', async () => {
+    const app = buildApp();
+
+    for (const payload of [
+      { handle: 'not a handle' },
+      { handle: 'did:plc:abc123' },
+      { handle: 'nodots' },
+      { handle: 'alice.bsky.social', note: 'x'.repeat(501) },
+      { note: 'no handle at all' },
+    ]) {
+      const response = await submit(app, payload);
+      expect(response.statusCode).toBe(400);
+    }
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts custom-domain handles', async () => {
+    const app = buildApp();
+    const response = await submit(app, { handle: 'andrew.corgi.network' });
+
+    expect(response.statusCode).toBe(200);
+    expect(queryMock.mock.calls[0][1]).toEqual(['andrew.corgi.network', null]);
+  });
+
+  it('returns 500 with a generic error when the insert fails', async () => {
+    queryMock.mockRejectedValue(new Error('connection refused'));
+    const app = buildApp();
+
+    const response = await submit(app, { handle: 'alice.bsky.social' });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json().error).toBe('InternalError');
+  });
+});

--- a/tests/governance-waitlist-route.test.ts
+++ b/tests/governance-waitlist-route.test.ts
@@ -62,19 +62,24 @@ describe('POST /api/governance/waitlist', () => {
     expect(duplicate.json()).toEqual(fresh.json());
   });
 
-  it('accepts the exact boundary values (500-char note, long valid handle)', async () => {
+  it('accepts values at the exact caps and rejects one past them', async () => {
     const app = buildApp();
-    const note = 'x'.repeat(500);
-    // A valid multi-label handle near the 253-char cap (63-char labels).
-    const longHandle = `${'a'.repeat(60)}.${'b'.repeat(60)}.${'c'.repeat(60)}.bsky.social`;
 
+    // Note: exactly 500 passes, 501 fails (the 501 case is covered below).
+    const note = 'x'.repeat(500);
     const noteResponse = await submit(app, { handle: 'alice.bsky.social', note });
     expect(noteResponse.statusCode).toBe(200);
     expect(queryMock.mock.calls[0][1]).toEqual(['alice.bsky.social', note]);
 
-    const handleResponse = await submit(app, { handle: longHandle });
-    expect(handleResponse.statusCode).toBe(200);
-    expect(longHandle.length).toBeLessThanOrEqual(253);
+    // Handle: build valid domain-format handles that land exactly on and one
+    // past the 253-char cap, so a regression like .max(200) is caught.
+    const handle253 = `${'a'.repeat(63)}.${'a'.repeat(63)}.${'a'.repeat(63)}.${'a'.repeat(61)}`;
+    expect(handle253).toHaveLength(253);
+    const handle254 = `${'a'.repeat(63)}.${'a'.repeat(63)}.${'a'.repeat(63)}.${'a'.repeat(62)}`;
+    expect(handle254).toHaveLength(254);
+
+    expect((await submit(app, { handle: handle253 })).statusCode).toBe(200);
+    expect((await submit(app, { handle: handle254 })).statusCode).toBe(400);
   });
 
   it('rejects malformed handles, DIDs, and oversized notes with 400', async () => {

--- a/tests/rate-limit-config.test.ts
+++ b/tests/rate-limit-config.test.ts
@@ -69,4 +69,24 @@ describe('route rate-limit policy', () => {
       timeWindow: config.RATE_LIMIT_ADMIN_CRITICAL_WINDOW_MS,
     });
   });
+
+  // Guards the ordering the rate-limit-config comment calls out: the public
+  // waitlist POST must match its own IP-keyed login-tier branch, NOT fall
+  // through to the generic governance-mutation branch (which would DID-key it
+  // and apply vote limits). A future reorder that breaks this fails here.
+  it('rate-limits the public waitlist POST at the login tier with default IP keying', () => {
+    const policy = buildRouteRateLimitConfig(
+      '/api/governance/waitlist',
+      'POST',
+      noopKeyGenerator
+    );
+
+    expect(policy).toMatchObject({
+      max: config.RATE_LIMIT_LOGIN_MAX,
+      timeWindow: config.RATE_LIMIT_LOGIN_WINDOW_MS,
+    });
+    // No custom keyGenerator → inherits the plugin default (request.ip), so an
+    // unauthenticated caller is never keyed by a (nonexistent) DID.
+    expect(policy).not.toHaveProperty('keyGenerator');
+  });
 });


### PR DESCRIPTION
## What this PR does

Turns Corgi voting into an approved-accounts pilot, **dark behind `LOGIN_ALLOWLIST_ENABLED` (default false)** — merging this changes no behavior until the flag is flipped on the VPS.

- **Login gate** (`src/governance/routes/auth.ts`): after credentials verify, admins (`BOT_ADMIN_DIDS`) bypass; everyone else needs an active `approved_participants` row (`isParticipantApproved`, fail-closed, 300s Redis cache). Deny invalidates the just-minted Redis session (it's persisted before the gate can run) and returns **403 `{error:"NotApproved", waitlist:true}`** — the discriminator is declared in the response schema so Fastify's serializer doesn't strip it. No session cookie on deny.
- **Waitlist intake** (`POST /api/governance/waitlist`, public): zod-normalized handle (trim, strip `@`, lowercase, domain regex; DIDs rejected), optional note ≤500. `ON CONFLICT (handle) DO NOTHING` — sticky rejections, first-note-wins. **Identical generic 200 for new/duplicate/approved/rejected** so the endpoint can't be used to probe who's approved. Rate-limited at the login tier (10/min/IP) via a branch placed above the governance-mutation catch-all in `rate-limit-config.ts` (which would otherwise key it by DID with vote limits).
- **Admin review** (`/api/admin/waitlist`, inherits `requireAdmin`): list (status filter, oldest-first queue), approve (resolve handle→DID via `resolve-handle.ts` — extracted from participants.ts, both now share it; upsert into `approved_participants` with re-activation; `invalidateParticipantCache` so approval takes effect immediately; audit `waitlist_approved`), reject (audit `waitlist_rejected`). 404/409/400; unresolvable handles leave the row pending — the participants API remains the add-by-DID escape hatch.
- **Migration `033_waitlist.sql`**: `waitlist_requests` with unique normalized handle + status CHECK.
- `GET /api/admin/status` now reports `loginAllowlistEnabled` (for the upcoming admin Access panel).

## Why

Security review found the only real gap in the auth story: any Bluesky account with an app password could log in and vote. The transparency surfaces stay public by design; this scopes *participation* to a pilot allowlist with a public waitlist, reusing the existing `approved_participants` infra (migration 016, cache, admin CRUD, audit log) rather than new machinery.

Linear: Fixes PROJ-1816

## Testing performed

- 3 new vitest suites, 25 tests: handle normalization (`@Alice.Example.COM ` → `alice.example.com`), custom domains, enumeration-proof duplicate body, flag-off regression (unapproved still logs in), admin bypass without a participant lookup, 403 body + minted-session invalidation + no-cookie-leak assertion, fail-closed lookup, approve lifecycle (upsert + cache invalidation + audit), reject, 404/409/400 paths.
- **Full suite: 135 files / 1460 tests pass** (`.env.example` env, same as CI). `tsc --noEmit` clean.

## Reviewer focus

- The deny path in `auth.ts` — session invalidation ordering and the 403 schema.
- The generic-response contract in `waitlist.ts` (intentionally never varies by row state).
- Rate-limit branch placement in `rate-limit-config.ts` (must precede the governance catch-all).

## Deployment notes (post-merge, before flag flip)

deploy.yml does **not** run migrations — `npm run migrate` on the VPS applies 033. Flag flip happens only after the frontend packet (waitlist UX) lands: verify `BOT_ADMIN_DIDS` contains the founder DID, then set `LOGIN_ALLOWLIST_ENABLED=true` + restart. Rollback = flag off + restart. (`.env.example` line omitted — local policy hook blocks `.env*` edits; the flag is documented in `config.ts`.)