### PR TITLE
[PROJ-1818] Align production governance lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Dedicated support guide (`SUPPORT.md`) and issue-template contact links for support/security routing
 
 ### Changed
+- Production governance now closes voting into an explicit results-review phase, applies approved signal weights, topic weights, and content rules together, and performs a full same-epoch rescore before the updated policy is treated as active.
 - Public `web-next` homepage refreshed around the reviewer-safe live snapshot, anonymized receipt copy, and demo-first CTA path.
 - README command examples and tooling descriptions updated to match current CLI and MCP behavior
 - PR template and contributing checklist now enforce changelog and security/audit validation gates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Dedicated support guide (`SUPPORT.md`) and issue-template contact links for support/security routing
 
 ### Changed
-- Production governance now closes voting into an explicit results-review phase, applies approved signal weights, topic weights, and content rules together, and performs a full same-epoch rescore before the updated policy is treated as active.
+- Production governance now closes voting into an explicit results-review phase, applies approved signal weights, topic weights, and content rules together, and durably requests a full same-epoch rescore for the updated policy.
 - Public `web-next` homepage refreshed around the reviewer-safe live snapshot, anonymized receipt copy, and demo-first CTA path.
 - README command examples and tooling descriptions updated to match current CLI and MCP behavior
 - PR template and contributing checklist now enforce changelog and security/audit validation gates

--- a/ops/receipts/2026-07-13/PROJ-1818/coderabbit-exemptable-timeout.md
+++ b/ops/receipts/2026-07-13/PROJ-1818/coderabbit-exemptable-timeout.md
@@ -1,0 +1,43 @@
+---
+bypass: true
+bypass_reason: "audited CodeRabbit exemptable timeout, PR #355, zero unresolved CodeRabbit threads"
+auditor: "Codex/GPT-5"
+---
+
+# PROJ-1818 CodeRabbit Exemptable Timeout Receipt
+
+Linear issue: PROJ-1818
+PR: https://github.com/andrewnordstrom-eng/bluesky-community-feed/pull/355
+Decision: apply the audited `coderabbit:exempt` path.
+
+## CodeRabbit Gate Snapshot
+
+- Reviewed code head at timeout: `38a8e88f679e578bf5230aac4e25fa5e36882f6a`.
+- Latest completed CodeRabbit review SHA: `3f237687bc5b3c6ea625153ee317532017fa3ef1`.
+- That completed review's seven actionable findings were addressed in the reviewed code head.
+- The sanctioned wrapper requested a fresh full review at 2026-07-13 11:43 UTC.
+- CodeRabbit remained `Review in progress` without producing a current-head review object.
+- Unresolved live CodeRabbit threads at both bounded timeouts: `0`.
+- A 900-second bounded wait returned `state: exemptable`, followed by a final 300-second grace wait that returned the same state with zero live threads.
+
+## Deterministic Verification
+
+- Focused governance lifecycle suite: 5 files and 47 tests passed.
+- Full backend suite: 148 files and 1,618 tests passed.
+- `npm run verify` passed, including root, CLI, SDK, legacy web, and `web-next` builds.
+- `npm run docs:verify` passed: 14 tracked docs and 37 Markdown files scanned.
+- `web-next` lint, TypeScript `--noEmit`, and production build passed.
+- Current-head GitHub checks passed for backend, frontend, docs, reports, CodeQL, Aikido, secrets, security, Linear policy, and quality gates.
+- `web-next` has no package-level `test` script; the root Vitest run is the canonical test gate.
+
+## Why The Prior Review Is Obsolete
+
+- The prior review covered `3f237687bc5b3c6ea625153ee317532017fa3ef1`.
+- The reviewed code head adds strict persisted-topic parsing, a transactional generation-based rescore outbox, retry-safe cache invalidation, generation-safe completion, and the requested regression coverage.
+- No implementation files change in this receipt-only commit.
+
+## Scope Of The Exemption
+
+- The exemption applies only to CodeRabbit's failure to publish a current-head review object within the bounded wait.
+- It does not waive deterministic tests, security checks, Linear closeout, branch protection, migration verification, deployment, or production smoke tests.
+- Remove or invalidate this exemption if implementation code changes after the reviewed code head.

--- a/ops/receipts/2026-07-13/PROJ-1818/coderabbit-exemptable-timeout.md
+++ b/ops/receipts/2026-07-13/PROJ-1818/coderabbit-exemptable-timeout.md
@@ -10,6 +10,10 @@ Linear issue: PROJ-1818
 PR: https://github.com/andrewnordstrom-eng/bluesky-community-feed/pull/355
 Decision: apply the audited `coderabbit:exempt` path.
 
+Outcome: invalidated before merge. CodeRabbit published a delayed current-code-head
+review immediately after this receipt was pushed. The exemption label was removed
+before implementing those findings, and this receipt no longer authorizes a merge.
+
 ## CodeRabbit Gate Snapshot
 
 - Reviewed code head at timeout: `38a8e88f679e578bf5230aac4e25fa5e36882f6a`.

--- a/src/admin/routes/epochs.ts
+++ b/src/admin/routes/epochs.ts
@@ -13,8 +13,6 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import { db } from '../../db/client.js';
 import { getAdminDid } from '../../auth/admin.js';
-import { config } from '../../config.js';
-import { forceEpochTransition, triggerEpochTransition } from '../../governance/epoch-manager.js';
 import { readEpochWeightsForMultipleEpochs } from '../../governance/weight-longtable.js';
 import { logger } from '../../lib/logger.js';
 import { adminSecurity } from '../../lib/openapi.js';
@@ -173,127 +171,22 @@ export function registerEpochRoutes(app: FastifyInstance): void {
   app.post('/epochs/transition', {
     schema: {
       tags: ['Admin'],
-      summary: 'Trigger epoch transition',
-      description: 'Manually transitions to the next epoch, optionally forcing past the minimum-vote quorum.',
+      summary: 'Direct transition disabled',
+      description: 'Direct epoch transitions are disabled. Use the voting lifecycle: start voting, close voting, review results, then approve the complete policy.',
       security: adminSecurity,
     },
   }, async (request: FastifyRequest, reply: FastifyReply) => {
-    const adminDid = getAdminDid(request);
+    getAdminDid(request);
     const parseResult = TransitionSchema.safeParse(request.body || {});
 
     if (!parseResult.success) {
       return reply.status(400).send({ error: 'Invalid request body', details: parseResult.error.issues });
     }
 
-    const body = parseResult.data;
-
-    // Get current epoch info before transition. The "weight votes" count
-    // (votes that include a complete weight vector, as opposed to
-    // content-only votes that only touch include/exclude keywords) is
-    // computed differently for each storage backend:
-    //   - Wide path: a vote is a "weight vote" iff all 5 named columns are
-    //     non-null (legacy behavior).
-    //   - Long path: a vote is a "weight vote" iff it has any rows in
-    //     governance_vote_weights (the writer skips null/undefined values,
-    //     so a vote with all-null weights is not represented).
-    //
-    // After PROJ-819 (P5) the wide columns are dropped and only the long
-    // branch remains.
-    const weightVoteCountSql = config.GOVERNANCE_LONGTABLE_READ_ENABLED
-      ? `(SELECT COUNT(*)::int
-          FROM governance_votes v
-          WHERE v.epoch_id = governance_epochs.id
-            AND EXISTS (
-              SELECT 1 FROM governance_vote_weights vw WHERE vw.vote_id = v.id
-            ))`
-      : `(SELECT COUNT(*)::int
-          FROM governance_votes
-          WHERE epoch_id = governance_epochs.id
-            AND recency_weight IS NOT NULL
-            AND engagement_weight IS NOT NULL
-            AND bridging_weight IS NOT NULL
-            AND source_diversity_weight IS NOT NULL
-            AND relevance_weight IS NOT NULL)`;
-
-    const current = await db.query(`
-      SELECT id,
-        (SELECT COUNT(*)::int FROM governance_votes WHERE epoch_id = governance_epochs.id) as vote_count,
-        ${weightVoteCountSql} as weight_vote_count
-      FROM governance_epochs
-      WHERE status IN ('active', 'voting')
-      ORDER BY id DESC
-      LIMIT 1
-    `);
-
-    if (current.rows.length === 0) {
-      return reply.status(404).send({ error: 'No active epoch found' });
-    }
-
-    const previousEpochId = current.rows[0].id;
-    const voteCount = parseInt(current.rows[0].vote_count, 10);
-    const weightVoteCount = parseInt(current.rows[0].weight_vote_count, 10);
-
-    // Check minimum votes unless forcing
-    const minVotes = config.GOVERNANCE_MIN_VOTES;
-    if (!body.force && weightVoteCount < minVotes) {
-      return reply.status(400).send({
-        error: `Insufficient weight votes for transition. Need ${minVotes}, have ${weightVoteCount}. Use force=true to override.`,
-      });
-    }
-
-    try {
-      // Use normal transition unless explicitly forced.
-      let newEpochId: number;
-      if (body.force) {
-        newEpochId = await forceEpochTransition();
-      } else {
-        const transitionResult = await triggerEpochTransition();
-        if (!transitionResult.success || !transitionResult.newEpochId) {
-          return reply.status(400).send({
-            error: transitionResult.error ?? 'Epoch transition failed',
-          });
-        }
-        newEpochId = transitionResult.newEpochId;
-      }
-
-      // Log to audit
-      await db.query(
-        `INSERT INTO governance_audit_log (action, epoch_id, actor_did, details)
-         VALUES ('epoch_transition', $1, $2, $3)`,
-        [
-          newEpochId,
-          adminDid,
-          JSON.stringify({
-            fromEpoch: previousEpochId,
-            forced: body.force,
-            voteCount,
-            weightVoteCount,
-          }),
-        ]
-      );
-
-      logger.info(
-        { fromEpoch: previousEpochId, toEpoch: newEpochId, forced: body.force, adminDid },
-        'Epoch transition triggered by admin'
-      );
-
-      // Get new epoch data
-      const newEpoch = await db.query(`SELECT * FROM governance_epochs WHERE id = $1`, [newEpochId]);
-
-      return reply.send({
-        success: true,
-        previousEpochId,
-        newEpoch: {
-          id: newEpochId,
-          status: newEpoch.rows[0].status,
-        },
-        voteCount,
-        weightVoteCount,
-      });
-    } catch (err) {
-      logger.error({ err }, 'Epoch transition failed');
-      return reply.status(500).send({ error: 'Epoch transition failed' });
-    }
+    return reply.status(409).send({
+      error: 'DirectTransitionDisabled',
+      message: 'Direct epoch transitions are disabled. Start voting, close voting, review the proposed policy, and approve results.',
+    });
   });
 
   // Note: close-voting and open-voting endpoints removed

--- a/src/admin/routes/governance.ts
+++ b/src/admin/routes/governance.ts
@@ -21,12 +21,15 @@ import {
   toContentRules,
 } from '../../governance/governance.types.js';
 import { invalidateContentRulesCache } from '../../governance/content-filter.js';
-import { invalidateGovernanceGateCache } from '../../ingestion/governance-gate.js';
 import {
   aggregateContentVotes,
   aggregateTopicWeights,
   aggregateVotes,
 } from '../../governance/aggregation.js';
+import {
+  parseStoredProposedTopicWeights,
+  parseStoredTopicWeights,
+} from '../../governance/topic-weights.js';
 import {
   readEpochWeightsForMultipleEpochs,
   writeEpochWeights,
@@ -283,27 +286,6 @@ function toProposedContentRules(raw: unknown): ContentRules | null {
   return toContentRules(raw as any);
 }
 
-function toTopicWeights(raw: unknown): Record<string, number> {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return {};
-  }
-
-  const weights: Record<string, number> = {};
-  for (const [slug, value] of Object.entries(raw)) {
-    if (typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1) {
-      weights[slug] = value;
-    }
-  }
-  return weights;
-}
-
-function toProposedTopicWeights(raw: unknown): Record<string, number> | null {
-  if (raw === null || raw === undefined) {
-    return null;
-  }
-  return toTopicWeights(raw);
-}
-
 function toContentRulesPayload(rules: ContentRules): { include_keywords: string[]; exclude_keywords: string[] } {
   return {
     include_keywords: rules.includeKeywords,
@@ -355,11 +337,17 @@ function mapRound(
     resultsApprovedAt: row.results_approved_at,
     resultsApprovedBy: row.results_approved_by,
     proposedWeights: toProposedWeights(row.proposed_weights),
-    proposedTopicWeights: toProposedTopicWeights(row.proposed_topic_weights),
+    proposedTopicWeights: parseStoredProposedTopicWeights(
+      row.proposed_topic_weights,
+      `governance epoch ${row.id} proposed policy`
+    ),
     proposedContentRules: toProposedContentRules(row.proposed_content_rules),
     autoTransition: row.auto_transition,
     weights: toWeights(row, weightsOverride),
-    topicWeights: toTopicWeights(row.topic_weights),
+    topicWeights: parseStoredTopicWeights(
+      row.topic_weights,
+      `governance epoch ${row.id} active policy`
+    ),
     contentRules: {
       includeKeywords: contentRules.includeKeywords,
       excludeKeywords: contentRules.excludeKeywords,
@@ -382,13 +370,48 @@ async function getCurrentEpochForUpdate(client: PoolClient): Promise<GovernanceE
 
 async function triggerManualRescore(reason: string): Promise<boolean> {
   requestFullRescore();
-  const triggered = await tryTriggerManualScoringRun();
+  try {
+    const triggered = await tryTriggerManualScoringRun();
 
-  if (!triggered) {
-    logger.warn({ reason }, 'Manual rescore skipped because scoring pipeline is already running');
+    if (!triggered) {
+      logger.warn({ reason }, 'Manual rescore skipped because scoring pipeline is already running');
+    }
+
+    return triggered;
+  } catch (error) {
+    logger.error(
+      { error, reason },
+      'Manual rescore trigger failed; durable policy rescore remains pending'
+    );
+    return false;
+  }
+}
+
+async function enqueuePolicyRescore(client: PoolClient, epochId: number): Promise<number> {
+  const result = await client.query<{ requested_generation: number | string }>(
+    `INSERT INTO governance_rescore_requests (
+       epoch_id,
+       requested_generation,
+       completed_generation,
+       requested_at,
+       completed_at
+     )
+     VALUES ($1, 1, 0, NOW(), NULL)
+     ON CONFLICT (epoch_id) DO UPDATE
+     SET requested_generation = governance_rescore_requests.requested_generation + 1,
+         requested_at = NOW(),
+         completed_at = NULL
+     RETURNING requested_generation`,
+    [epochId]
+  );
+  const generation = Number.parseInt(String(result.rows[0]?.requested_generation ?? ''), 10);
+  if (!Number.isSafeInteger(generation) || generation <= 0) {
+    throw new Error(
+      `Failed to enqueue policy rescore for governance epoch ${epochId}: invalid generation`
+    );
   }
 
-  return triggered;
+  return generation;
 }
 
 async function getVoteCounts(
@@ -680,7 +703,10 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
 
       const voteCounts = await getVoteCounts(client, epoch.id);
       const previousWeights = toWeights(epoch);
-      const previousTopicWeights = toTopicWeights(epoch.topic_weights);
+      const previousTopicWeights = parseStoredTopicWeights(
+        epoch.topic_weights,
+        `governance epoch ${epoch.id} active policy`
+      );
       const previousRules = toContentRules((epoch.content_rules ?? null) as any);
 
       let proposedWeights = previousWeights;
@@ -823,10 +849,16 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       }
 
       const oldWeights = toWeights(epoch);
-      const oldTopicWeights = toTopicWeights(epoch.topic_weights);
+      const oldTopicWeights = parseStoredTopicWeights(
+        epoch.topic_weights,
+        `governance epoch ${epoch.id} active policy`
+      );
       const oldContentRules = toContentRules((epoch.content_rules ?? null) as any);
       const newWeights = toProposedWeights(epoch.proposed_weights) ?? oldWeights;
-      const newTopicWeights = toProposedTopicWeights(epoch.proposed_topic_weights) ?? oldTopicWeights;
+      const newTopicWeights = parseStoredProposedTopicWeights(
+        epoch.proposed_topic_weights,
+        `governance epoch ${epoch.id} proposed policy`
+      ) ?? oldTopicWeights;
       const newContentRules = toProposedContentRules(epoch.proposed_content_rules) ?? oldContentRules;
 
       const updatedResult = await client.query<GovernanceEpochRow>(
@@ -866,6 +898,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       }
 
       const voteCounts = await getVoteCounts(client, epoch.id);
+      const rescoreGeneration = await enqueuePolicyRescore(client, epoch.id);
 
       await client.query(
         `INSERT INTO governance_audit_log (action, actor_did, epoch_id, details)
@@ -880,6 +913,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
             new_topic_weights: newTopicWeights,
             old_content_rules: toDbContentRules(oldContentRules),
             new_content_rules: toDbContentRules(newContentRules),
+            rescore_generation: rescoreGeneration,
             announce,
           }),
         ]
@@ -887,8 +921,6 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
 
       await client.query('COMMIT');
 
-      await invalidateContentRulesCache();
-      await invalidateGovernanceGateCache();
       const rescoreTriggered = await triggerManualRescore('admin_approve_results');
 
       if (announce) {
@@ -1779,10 +1811,16 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       const voteCount = parseInt(voteCountResult.rows[0]?.count ?? '0', 10);
 
       const previousWeights = toWeights(epoch);
-      const previousTopicWeights = toTopicWeights(epoch.topic_weights);
+      const previousTopicWeights = parseStoredTopicWeights(
+        epoch.topic_weights,
+        `governance epoch ${epoch.id} active policy`
+      );
       const previousRules = toContentRules((epoch.content_rules ?? null) as any);
       const nextWeights = toProposedWeights(epoch.proposed_weights) ?? previousWeights;
-      const nextTopicWeights = toProposedTopicWeights(epoch.proposed_topic_weights) ?? previousTopicWeights;
+      const nextTopicWeights = parseStoredProposedTopicWeights(
+        epoch.proposed_topic_weights,
+        `governance epoch ${epoch.id} proposed policy`
+      ) ?? previousTopicWeights;
       const nextRules = toProposedContentRules(epoch.proposed_content_rules) ?? previousRules;
 
       const updatedResult = await client.query<GovernanceEpochRow>(
@@ -1824,6 +1862,8 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         await writeEpochWeights(client, epoch.id, nextWeights);
       }
 
+      const rescoreGeneration = await enqueuePolicyRescore(client, epoch.id);
+
       await client.query(
         `INSERT INTO governance_audit_log (action, actor_did, epoch_id, details)
          VALUES ('admin_apply_results', $1, $2, $3)`,
@@ -1838,14 +1878,13 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
             new_topic_weights: nextTopicWeights,
             old_content_rules: toContentRulesPayload(previousRules),
             new_content_rules: toContentRulesPayload(nextRules),
+            rescore_generation: rescoreGeneration,
           }),
         ]
       );
 
       await client.query('COMMIT');
 
-      await invalidateContentRulesCache();
-      await invalidateGovernanceGateCache();
       const rescoreTriggered = await triggerManualRescore('admin_apply_results');
 
       return reply.send({

--- a/src/admin/routes/governance.ts
+++ b/src/admin/routes/governance.ts
@@ -27,9 +27,11 @@ import {
   aggregateVotes,
 } from '../../governance/aggregation.js';
 import {
+  InvalidStoredTopicWeightsError,
   parseStoredProposedTopicWeights,
   parseStoredTopicWeights,
 } from '../../governance/topic-weights.js';
+import { readGovernanceVoteCounts } from '../../governance/vote-counts.js';
 import {
   readEpochWeightsForMultipleEpochs,
   writeEpochWeights,
@@ -414,35 +416,6 @@ async function enqueuePolicyRescore(client: PoolClient, epochId: number): Promis
   return generation;
 }
 
-async function getVoteCounts(
-  client: PoolClient,
-  epochId: number
-): Promise<{ total: number; content: number; topic: number }> {
-  const result = await client.query<{ total: string; content: string; topic: string }>(
-    `SELECT
-      COUNT(*)::int AS total,
-      COUNT(*) FILTER (
-        WHERE
-          (include_keywords IS NOT NULL AND array_length(include_keywords, 1) > 0)
-          OR
-          (exclude_keywords IS NOT NULL AND array_length(exclude_keywords, 1) > 0)
-      )::int AS content,
-      COUNT(*) FILTER (
-        WHERE topic_weight_votes IS NOT NULL
-          AND topic_weight_votes != '{}'::jsonb
-      )::int AS topic
-     FROM governance_votes
-     WHERE epoch_id = $1`,
-    [epochId]
-  );
-
-  return {
-    total: parseInt(result.rows[0]?.total ?? '0', 10),
-    content: parseInt(result.rows[0]?.content ?? '0', 10),
-    topic: parseInt(result.rows[0]?.topic ?? '0', 10),
-  };
-}
-
 function mapScheduledVote(row: ScheduledVoteRow) {
   return {
     id: row.id,
@@ -474,6 +447,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
             autoTransition: { type: 'boolean' },
           },
         },
+        500: ErrorResponseSchema,
       },
     },
   }, async (_request: FastifyRequest, reply: FastifyReply) => {
@@ -508,9 +482,21 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
 
     const roundEpochIds = roundsResult.rows.map((row) => row.id);
     const weightsByEpoch = await readEpochWeightsForMultipleEpochs({ epochIds: roundEpochIds });
-    const rounds = roundsResult.rows.map((row) =>
-      mapRound(row, parseInt(row.vote_count, 10), weightsByEpoch[row.id])
-    );
+    let rounds: ReturnType<typeof mapRound>[];
+    try {
+      rounds = roundsResult.rows.map((row) =>
+        mapRound(row, Number.parseInt(row.vote_count, 10), weightsByEpoch[row.id])
+      );
+    } catch (error) {
+      if (!(error instanceof InvalidStoredTopicWeightsError)) {
+        throw error;
+      }
+      logger.error({ error }, 'Stored governance policy is invalid in overview');
+      return reply.code(500).send({
+        error: 'InvalidGovernancePolicy',
+        message: 'Stored governance policy is invalid',
+      });
+    }
     const currentRound = rounds.find((round) => round.status === 'active' || round.status === 'voting') ?? null;
 
     return reply.send({
@@ -605,7 +591,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         [durationHours, epoch.id]
       );
 
-      const voteCounts = await getVoteCounts(client, epoch.id);
+      const voteCounts = await readGovernanceVoteCounts(client, epoch.id);
 
       await client.query(
         `INSERT INTO governance_audit_log (action, actor_did, epoch_id, details)
@@ -701,7 +687,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         });
       }
 
-      const voteCounts = await getVoteCounts(client, epoch.id);
+      const voteCounts = await readGovernanceVoteCounts(client, epoch.id);
       const previousWeights = toWeights(epoch);
       const previousTopicWeights = parseStoredTopicWeights(
         epoch.topic_weights,
@@ -897,7 +883,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         await writeEpochWeights(client, epoch.id, newWeights);
       }
 
-      const voteCounts = await getVoteCounts(client, epoch.id);
+      const voteCounts = await readGovernanceVoteCounts(client, epoch.id);
       const rescoreGeneration = await enqueuePolicyRescore(client, epoch.id);
 
       await client.query(
@@ -921,6 +907,9 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
 
       await client.query('COMMIT');
 
+      // The durable rescore worker invalidates both policy caches before it
+      // reads this generation. Keeping invalidation there makes post-commit
+      // failures retryable instead of masking an already-approved policy.
       const rescoreTriggered = await triggerManualRescore('admin_approve_results');
 
       if (announce) {
@@ -1009,7 +998,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         [epoch.id]
       );
 
-      const voteCounts = await getVoteCounts(client, epoch.id);
+      const voteCounts = await readGovernanceVoteCounts(client, epoch.id);
 
       await client.query(
         `INSERT INTO governance_audit_log (action, actor_did, epoch_id, details)
@@ -1885,6 +1874,8 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
 
       await client.query('COMMIT');
 
+      // Cache invalidation belongs to the durable worker for the same
+      // post-commit retry guarantee as the canonical approval route.
       const rescoreTriggered = await triggerManualRescore('admin_apply_results');
 
       return reply.send({
@@ -1960,6 +1951,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         },
         400: ErrorResponseSchema,
         404: ErrorResponseSchema,
+        500: ErrorResponseSchema,
       },
     },
   }, async (request: FastifyRequest, reply: FastifyReply) => {
@@ -2069,8 +2061,22 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
     const endMs = round.closed_at ? new Date(round.closed_at).getTime() : nowMs;
     const durationMs = Math.max(0, endMs - startMs);
 
+    let mappedRound: ReturnType<typeof mapRound>;
+    try {
+      mappedRound = mapRound(round, voteCount);
+    } catch (error) {
+      if (!(error instanceof InvalidStoredTopicWeightsError)) {
+        throw error;
+      }
+      logger.error({ error, roundId }, 'Stored governance policy is invalid in round detail');
+      return reply.code(500).send({
+        error: 'InvalidGovernancePolicy',
+        message: 'Stored governance policy is invalid',
+      });
+    }
+
     return reply.send({
-      round: mapRound(round, voteCount),
+      round: mappedRound,
       startingWeights,
       endingWeights,
       startingRules,

--- a/src/admin/routes/governance.ts
+++ b/src/admin/routes/governance.ts
@@ -32,6 +32,7 @@ import {
   writeEpochWeights,
 } from '../../governance/weight-longtable.js';
 import { tryTriggerManualScoringRun } from '../../scoring/scheduler.js';
+import { requestFullRescore } from '../../scoring/pipeline.js';
 import { forceEpochTransition, triggerEpochTransition } from '../../governance/epoch-manager.js';
 import {
   announceResultsApproved,
@@ -380,6 +381,7 @@ async function getCurrentEpochForUpdate(client: PoolClient): Promise<GovernanceE
 }
 
 async function triggerManualRescore(reason: string): Promise<boolean> {
+  requestFullRescore();
   const triggered = await tryTriggerManualScoringRun();
 
   if (!triggered) {

--- a/src/admin/routes/governance.ts
+++ b/src/admin/routes/governance.ts
@@ -38,7 +38,6 @@ import {
 } from '../../governance/weight-longtable.js';
 import { tryTriggerManualScoringRun } from '../../scoring/scheduler.js';
 import { requestFullRescore } from '../../scoring/pipeline.js';
-import { forceEpochTransition, triggerEpochTransition } from '../../governance/epoch-manager.js';
 import {
   announceResultsApproved,
   announceVoteScheduled,
@@ -834,6 +833,15 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         });
       }
 
+      const voteCounts = await readGovernanceVoteCounts(client, epoch.id);
+      if (voteCounts.total === 0) {
+        await client.query('ROLLBACK');
+        return reply.code(409).send({
+          error: 'NoBallots',
+          message: 'Results cannot be approved because this voting window received no ballots.',
+        });
+      }
+
       const oldWeights = toWeights(epoch);
       const oldTopicWeights = parseStoredTopicWeights(
         epoch.topic_weights,
@@ -883,7 +891,6 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         await writeEpochWeights(client, epoch.id, newWeights);
       }
 
-      const voteCounts = await readGovernanceVoteCounts(client, epoch.id);
       const rescoreGeneration = await enqueuePolicyRescore(client, epoch.id);
 
       await client.query(
@@ -1707,11 +1714,8 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         [hours, epoch.id]
       );
 
-      const voteCountResult = await client.query<{ count: string }>(
-        `SELECT COUNT(*)::int AS count FROM governance_votes WHERE epoch_id = $1`,
-        [epoch.id]
-      );
-      const voteCount = parseInt(voteCountResult.rows[0]?.count ?? '0', 10);
+      const voteCounts = await readGovernanceVoteCounts(client, epoch.id);
+      const voteCount = voteCounts.total;
 
       await client.query(
         `INSERT INTO governance_audit_log (action, actor_did, epoch_id, details)
@@ -1793,11 +1797,15 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         });
       }
 
-      const voteCountResult = await client.query<{ count: string }>(
-        `SELECT COUNT(*)::int AS count FROM governance_votes WHERE epoch_id = $1`,
-        [epoch.id]
-      );
-      const voteCount = parseInt(voteCountResult.rows[0]?.count ?? '0', 10);
+      const voteCounts = await readGovernanceVoteCounts(client, epoch.id);
+      if (voteCounts.total === 0) {
+        await client.query('ROLLBACK');
+        return reply.code(409).send({
+          error: 'NoBallots',
+          message: 'Results cannot be approved because this voting window received no ballots.',
+        });
+      }
+      const voteCount = voteCounts.total;
 
       const previousWeights = toWeights(epoch);
       const previousTopicWeights = parseStoredTopicWeights(
@@ -2111,8 +2119,8 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
   app.post('/governance/end-round', {
     schema: {
       tags: ['Admin'],
-      summary: 'End round and start new one',
-      description: 'Closes the current epoch and creates a new one with current weights carried forward. Use force=true to skip validation checks.',
+      summary: 'Direct transition disabled',
+      description: 'Direct round transitions are disabled. Use start voting, end voting, results review, and approval so the complete policy is applied before rescoring.',
       security: adminSecurity,
       body: {
         type: 'object',
@@ -2135,7 +2143,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       },
     },
   }, async (request: FastifyRequest, reply: FastifyReply) => {
-    const adminDid = getAdminDid(request);
+    getAdminDid(request);
     const parseResult = z
       .object({ force: z.boolean().optional().default(false) })
       .safeParse(request.body ?? {});
@@ -2148,40 +2156,9 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       });
     }
 
-    const { force } = parseResult.data;
-
-    try {
-      let newEpochId: number | undefined;
-
-      if (force) {
-        newEpochId = await forceEpochTransition();
-      } else {
-        const result = await triggerEpochTransition();
-        if (!result.success || !result.newEpochId) {
-          return reply.code(409).send({
-            error: 'TransitionBlocked',
-            message: result.error ?? 'Unable to transition round without force',
-          });
-        }
-        newEpochId = result.newEpochId;
-      }
-
-      await db.query(
-        `INSERT INTO governance_audit_log (action, actor_did, epoch_id, details)
-         VALUES ('admin_end_round', $1, $2, $3)`,
-        [adminDid, newEpochId, JSON.stringify({ force })]
-      );
-
-      return reply.send({
-        success: true,
-        newRoundId: newEpochId,
-      });
-    } catch (error) {
-      logger.error({ error, adminDid }, 'Failed to end and start round');
-      return reply.code(500).send({
-        error: 'RoundTransitionFailed',
-        message: 'Failed to end current round and start a new one',
-      });
-    }
+    return reply.code(409).send({
+      error: 'DirectTransitionDisabled',
+      message: 'Direct round transitions are disabled. Start voting, close voting, review the proposed policy, and approve results.',
+    });
   });
 }

--- a/src/admin/routes/governance.ts
+++ b/src/admin/routes/governance.ts
@@ -9,6 +9,7 @@ import type { PoolClient } from 'pg';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { db } from '../../db/client.js';
+import { config } from '../../config.js';
 import { getAdminDid } from '../../auth/admin.js';
 import { logger } from '../../lib/logger.js';
 import { adminSecurity, ErrorResponseSchema } from '../../lib/openapi.js';
@@ -20,8 +21,16 @@ import {
   toContentRules,
 } from '../../governance/governance.types.js';
 import { invalidateContentRulesCache } from '../../governance/content-filter.js';
-import { aggregateContentVotes, aggregateVotes } from '../../governance/aggregation.js';
-import { readEpochWeightsForMultipleEpochs } from '../../governance/weight-longtable.js';
+import { invalidateGovernanceGateCache } from '../../ingestion/governance-gate.js';
+import {
+  aggregateContentVotes,
+  aggregateTopicWeights,
+  aggregateVotes,
+} from '../../governance/aggregation.js';
+import {
+  readEpochWeightsForMultipleEpochs,
+  writeEpochWeights,
+} from '../../governance/weight-longtable.js';
 import { tryTriggerManualScoringRun } from '../../scoring/scheduler.js';
 import { forceEpochTransition, triggerEpochTransition } from '../../governance/epoch-manager.js';
 import {
@@ -122,6 +131,12 @@ const contentRulesSchema = {
   },
 };
 
+/** Reusable schema fragment for a topic slug to weight map. */
+const topicWeightsSchema = {
+  type: 'object' as const,
+  additionalProperties: { type: 'number' as const, minimum: 0, maximum: 1 },
+};
+
 /** Reusable schema fragment for a governance round object. */
 const roundSchema = {
   type: 'object' as const,
@@ -138,9 +153,11 @@ const roundSchema = {
     resultsApprovedAt: { type: 'string' as const, format: 'date-time', nullable: true },
     resultsApprovedBy: { type: 'string' as const, nullable: true },
     proposedWeights: { ...weightsSchema, nullable: true },
+    proposedTopicWeights: { ...topicWeightsSchema, nullable: true },
     proposedContentRules: { ...contentRulesSchema, nullable: true },
     autoTransition: { type: 'boolean' as const },
     weights: weightsSchema,
+    topicWeights: topicWeightsSchema,
     contentRules: contentRulesSchema,
   },
 };
@@ -155,6 +172,7 @@ interface GovernanceEpochRow {
   results_approved_at: string | null;
   results_approved_by: string | null;
   proposed_weights: unknown;
+  proposed_topic_weights: unknown;
   proposed_content_rules: unknown;
   auto_transition: boolean;
   recency_weight: number | string;
@@ -163,6 +181,7 @@ interface GovernanceEpochRow {
   source_diversity_weight: number | string;
   relevance_weight: number | string;
   content_rules: unknown;
+  topic_weights: unknown;
   created_at: string;
   closed_at: string | null;
 }
@@ -263,6 +282,27 @@ function toProposedContentRules(raw: unknown): ContentRules | null {
   return toContentRules(raw as any);
 }
 
+function toTopicWeights(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
+  }
+
+  const weights: Record<string, number> = {};
+  for (const [slug, value] of Object.entries(raw)) {
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1) {
+      weights[slug] = value;
+    }
+  }
+  return weights;
+}
+
+function toProposedTopicWeights(raw: unknown): Record<string, number> | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  return toTopicWeights(raw);
+}
+
 function toContentRulesPayload(rules: ContentRules): { include_keywords: string[]; exclude_keywords: string[] } {
   return {
     include_keywords: rules.includeKeywords,
@@ -314,9 +354,11 @@ function mapRound(
     resultsApprovedAt: row.results_approved_at,
     resultsApprovedBy: row.results_approved_by,
     proposedWeights: toProposedWeights(row.proposed_weights),
+    proposedTopicWeights: toProposedTopicWeights(row.proposed_topic_weights),
     proposedContentRules: toProposedContentRules(row.proposed_content_rules),
     autoTransition: row.auto_transition,
     weights: toWeights(row, weightsOverride),
+    topicWeights: toTopicWeights(row.topic_weights),
     contentRules: {
       includeKeywords: contentRules.includeKeywords,
       excludeKeywords: contentRules.excludeKeywords,
@@ -347,8 +389,11 @@ async function triggerManualRescore(reason: string): Promise<boolean> {
   return triggered;
 }
 
-async function getVoteCounts(client: PoolClient, epochId: number): Promise<{ total: number; content: number }> {
-  const result = await client.query<{ total: string; content: string }>(
+async function getVoteCounts(
+  client: PoolClient,
+  epochId: number
+): Promise<{ total: number; content: number; topic: number }> {
+  const result = await client.query<{ total: string; content: string; topic: string }>(
     `SELECT
       COUNT(*)::int AS total,
       COUNT(*) FILTER (
@@ -356,7 +401,11 @@ async function getVoteCounts(client: PoolClient, epochId: number): Promise<{ tot
           (include_keywords IS NOT NULL AND array_length(include_keywords, 1) > 0)
           OR
           (exclude_keywords IS NOT NULL AND array_length(exclude_keywords, 1) > 0)
-      )::int AS content
+      )::int AS content,
+      COUNT(*) FILTER (
+        WHERE topic_weight_votes IS NOT NULL
+          AND topic_weight_votes != '{}'::jsonb
+      )::int AS topic
      FROM governance_votes
      WHERE epoch_id = $1`,
     [epochId]
@@ -365,6 +414,7 @@ async function getVoteCounts(client: PoolClient, epochId: number): Promise<{ tot
   return {
     total: parseInt(result.rows[0]?.total ?? '0', 10),
     content: parseInt(result.rows[0]?.content ?? '0', 10),
+    topic: parseInt(result.rows[0]?.topic ?? '0', 10),
   };
 }
 
@@ -416,8 +466,10 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         e.results_approved_at,
         e.results_approved_by,
         e.proposed_weights,
+        e.proposed_topic_weights,
         e.proposed_content_rules,
         e.auto_transition,
+        e.topic_weights,
         e.content_rules,
         e.created_at,
         e.closed_at,
@@ -521,6 +573,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
              results_approved_at = NULL,
              results_approved_by = NULL,
              proposed_weights = NULL,
+             proposed_topic_weights = NULL,
              proposed_content_rules = NULL
          WHERE id = $2
          RETURNING *`,
@@ -578,6 +631,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
             success: { type: 'boolean' },
             voteCount: { type: 'integer' },
             proposedWeights: weightsSchema,
+            proposedTopicWeights: topicWeightsSchema,
             proposedContentRules: contentRulesSchema,
             round: roundSchema,
           },
@@ -624,9 +678,11 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
 
       const voteCounts = await getVoteCounts(client, epoch.id);
       const previousWeights = toWeights(epoch);
+      const previousTopicWeights = toTopicWeights(epoch.topic_weights);
       const previousRules = toContentRules((epoch.content_rules ?? null) as any);
 
       let proposedWeights = previousWeights;
+      let proposedTopicWeights = previousTopicWeights;
       let proposedRules = previousRules;
 
       if (voteCounts.total > 0) {
@@ -640,16 +696,26 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         proposedRules = await aggregateContentVotes(epoch.id);
       }
 
+      if (voteCounts.topic > 0) {
+        proposedTopicWeights = await aggregateTopicWeights(epoch.id);
+      }
+
       const updatedResult = await client.query<GovernanceEpochRow>(
         `UPDATE governance_epochs
          SET phase = 'results',
              voting_closed_at = NOW(),
              auto_transition = FALSE,
              proposed_weights = $1,
-             proposed_content_rules = $2
-         WHERE id = $3
+             proposed_content_rules = $2,
+             proposed_topic_weights = $3
+         WHERE id = $4
          RETURNING *`,
-        [JSON.stringify(proposedWeights), JSON.stringify(toDbContentRules(proposedRules)), epoch.id]
+        [
+          JSON.stringify(proposedWeights),
+          JSON.stringify(toDbContentRules(proposedRules)),
+          JSON.stringify(proposedTopicWeights),
+          epoch.id,
+        ]
       );
 
       await client.query(
@@ -661,7 +727,9 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
           JSON.stringify({
             vote_count: voteCounts.total,
             content_vote_count: voteCounts.content,
+            topic_vote_count: voteCounts.topic,
             proposed_weights: proposedWeights,
+            proposed_topic_weights: proposedTopicWeights,
             proposed_content_rules: toDbContentRules(proposedRules),
             announce,
           }),
@@ -678,6 +746,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         success: true,
         voteCount: voteCounts.total,
         proposedWeights,
+        proposedTopicWeights,
         proposedContentRules: proposedRules,
         round: mapRound(updatedResult.rows[0], voteCounts.total),
       });
@@ -697,7 +766,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
     schema: {
       tags: ['Admin'],
       summary: 'Approve voting results',
-      description: 'Approves aggregated voting results, applying the proposed weights and content rules to the active epoch. Triggers a rescore.',
+      description: 'Approves aggregated voting results, applying the proposed signal weights, topic weights, and content rules to the active epoch before triggering a rescore.',
       security: adminSecurity,
       body: ApproveResultsJsonSchema,
       response: {
@@ -706,6 +775,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
           properties: {
             success: { type: 'boolean' },
             weights: weightsSchema,
+            topicWeights: topicWeightsSchema,
             contentRules: contentRulesSchema,
             rescoreTriggered: { type: 'boolean' },
             round: roundSchema,
@@ -751,8 +821,10 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       }
 
       const oldWeights = toWeights(epoch);
+      const oldTopicWeights = toTopicWeights(epoch.topic_weights);
       const oldContentRules = toContentRules((epoch.content_rules ?? null) as any);
       const newWeights = toProposedWeights(epoch.proposed_weights) ?? oldWeights;
+      const newTopicWeights = toProposedTopicWeights(epoch.proposed_topic_weights) ?? oldTopicWeights;
       const newContentRules = toProposedContentRules(epoch.proposed_content_rules) ?? oldContentRules;
 
       const updatedResult = await client.query<GovernanceEpochRow>(
@@ -762,15 +834,17 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
              bridging_weight = $3,
              source_diversity_weight = $4,
              relevance_weight = $5,
-             content_rules = $6,
+             topic_weights = $6,
+             content_rules = $7,
              phase = 'running',
              voting_ends_at = NULL,
              auto_transition = FALSE,
              proposed_weights = NULL,
+             proposed_topic_weights = NULL,
              proposed_content_rules = NULL,
              results_approved_at = NOW(),
-             results_approved_by = $7
-         WHERE id = $8
+             results_approved_by = $8
+         WHERE id = $9
          RETURNING *`,
         [
           newWeights.recency,
@@ -778,11 +852,16 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
           newWeights.bridging,
           newWeights.sourceDiversity,
           newWeights.relevance,
+          JSON.stringify(newTopicWeights),
           JSON.stringify(toDbContentRules(newContentRules)),
           adminDid,
           epoch.id,
         ]
       );
+
+      if (config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED) {
+        await writeEpochWeights(client, epoch.id, newWeights);
+      }
 
       const voteCounts = await getVoteCounts(client, epoch.id);
 
@@ -795,6 +874,8 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
           JSON.stringify({
             old_weights: oldWeights,
             new_weights: newWeights,
+            old_topic_weights: oldTopicWeights,
+            new_topic_weights: newTopicWeights,
             old_content_rules: toDbContentRules(oldContentRules),
             new_content_rules: toDbContentRules(newContentRules),
             announce,
@@ -805,6 +886,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       await client.query('COMMIT');
 
       await invalidateContentRulesCache();
+      await invalidateGovernanceGateCache();
       const rescoreTriggered = await triggerManualRescore('admin_approve_results');
 
       if (announce) {
@@ -822,6 +904,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       return reply.send({
         success: true,
         weights: newWeights,
+        topicWeights: newTopicWeights,
         contentRules: newContentRules,
         rescoreTriggered,
         round: mapRound(updatedResult.rows[0], voteCounts.total),
@@ -885,6 +968,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
              voting_ends_at = NULL,
              auto_transition = FALSE,
              proposed_weights = NULL,
+             proposed_topic_weights = NULL,
              proposed_content_rules = NULL
          WHERE id = $1
          RETURNING *`,
@@ -1642,8 +1726,8 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
   app.post('/governance/apply-results', {
     schema: {
       tags: ['Admin'],
-      summary: 'Apply results directly',
-      description: 'Aggregates votes and applies results in a single step, bypassing the approve/reject flow. Triggers a rescore.',
+      summary: 'Approve pending results (legacy alias)',
+      description: 'Deprecated compatibility alias for approving an already-reviewed results phase. It cannot bypass voting closure or results review.',
       security: adminSecurity,
       response: {
         200: {
@@ -1653,6 +1737,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
             voteCount: { type: 'integer' },
             appliedWeights: { type: 'boolean', description: 'Whether aggregated weights were applied (false if no votes)' },
             weights: weightsSchema,
+            topicWeights: topicWeightsSchema,
             contentRules: contentRulesSchema,
             round: roundSchema,
             rescoreTriggered: { type: 'boolean' },
@@ -1660,6 +1745,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
           required: ['success'],
         },
         404: ErrorResponseSchema,
+        409: ErrorResponseSchema,
         500: ErrorResponseSchema,
       },
     },
@@ -1676,6 +1762,14 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         return reply.code(404).send({ error: 'NoActiveRound', message: 'No active round found' });
       }
 
+      if (toPhase(epoch) !== 'results') {
+        await client.query('ROLLBACK');
+        return reply.code(409).send({
+          error: 'ResultsNotPending',
+          message: 'Close voting and review the proposed policy before approving results',
+        });
+      }
+
       const voteCountResult = await client.query<{ count: string }>(
         `SELECT COUNT(*)::int AS count FROM governance_votes WHERE epoch_id = $1`,
         [epoch.id]
@@ -1683,19 +1777,11 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       const voteCount = parseInt(voteCountResult.rows[0]?.count ?? '0', 10);
 
       const previousWeights = toWeights(epoch);
+      const previousTopicWeights = toTopicWeights(epoch.topic_weights);
       const previousRules = toContentRules((epoch.content_rules ?? null) as any);
-
-      let nextWeights = previousWeights;
-      let nextRules = previousRules;
-
-      if (voteCount > 0) {
-        const aggregatedWeights = await aggregateVotes(epoch.id);
-        if (aggregatedWeights) {
-          nextWeights = aggregatedWeights;
-        }
-
-        nextRules = await aggregateContentVotes(epoch.id);
-      }
+      const nextWeights = toProposedWeights(epoch.proposed_weights) ?? previousWeights;
+      const nextTopicWeights = toProposedTopicWeights(epoch.proposed_topic_weights) ?? previousTopicWeights;
+      const nextRules = toProposedContentRules(epoch.proposed_content_rules) ?? previousRules;
 
       const updatedResult = await client.query<GovernanceEpochRow>(
         `UPDATE governance_epochs
@@ -1704,17 +1790,19 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
              bridging_weight = $3,
              source_diversity_weight = $4,
              relevance_weight = $5,
-             content_rules = $6,
-             vote_count = $7,
+             topic_weights = $6,
+             content_rules = $7,
+             vote_count = $8,
              phase = 'running',
              voting_closed_at = NOW(),
              voting_ends_at = NULL,
              auto_transition = FALSE,
              proposed_weights = NULL,
+             proposed_topic_weights = NULL,
              proposed_content_rules = NULL,
              results_approved_at = NOW(),
-             results_approved_by = $8
-         WHERE id = $9
+             results_approved_by = $9
+         WHERE id = $10
          RETURNING *`,
         [
           nextWeights.recency,
@@ -1722,12 +1810,17 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
           nextWeights.bridging,
           nextWeights.sourceDiversity,
           nextWeights.relevance,
+          JSON.stringify(nextTopicWeights),
           JSON.stringify(toContentRulesPayload(nextRules)),
           voteCount,
           adminDid,
           epoch.id,
         ]
       );
+
+      if (config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED) {
+        await writeEpochWeights(client, epoch.id, nextWeights);
+      }
 
       await client.query(
         `INSERT INTO governance_audit_log (action, actor_did, epoch_id, details)
@@ -1739,6 +1832,8 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
             vote_count: voteCount,
             old_weights: previousWeights,
             new_weights: nextWeights,
+            old_topic_weights: previousTopicWeights,
+            new_topic_weights: nextTopicWeights,
             old_content_rules: toContentRulesPayload(previousRules),
             new_content_rules: toContentRulesPayload(nextRules),
           }),
@@ -1748,6 +1843,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
       await client.query('COMMIT');
 
       await invalidateContentRulesCache();
+      await invalidateGovernanceGateCache();
       const rescoreTriggered = await triggerManualRescore('admin_apply_results');
 
       return reply.send({
@@ -1755,6 +1851,7 @@ export function registerGovernanceRoutes(app: FastifyInstance): void {
         voteCount,
         appliedWeights: voteCount > 0,
         weights: nextWeights,
+        topicWeights: nextTopicWeights,
         contentRules: nextRules,
         round: mapRound(updatedResult.rows[0], voteCount),
         rescoreTriggered,

--- a/src/db/migrations/034_governance_proposed_topic_weights.sql
+++ b/src/db/migrations/034_governance_proposed_topic_weights.sql
@@ -5,3 +5,24 @@ ADD COLUMN IF NOT EXISTS proposed_topic_weights JSONB;
 
 COMMENT ON COLUMN governance_epochs.proposed_topic_weights IS
   'Aggregated topic-weight proposal awaiting operator approval in results phase';
+
+-- Approval and the request to score the approved policy must commit together.
+-- A generation counter makes retries idempotent while preserving a newer
+-- request that arrives during an in-flight scoring run.
+CREATE TABLE IF NOT EXISTS governance_rescore_requests (
+  epoch_id INTEGER PRIMARY KEY REFERENCES governance_epochs(id) ON DELETE CASCADE,
+  requested_generation BIGINT NOT NULL DEFAULT 1,
+  completed_generation BIGINT NOT NULL DEFAULT 0,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  CONSTRAINT governance_rescore_generation_positive
+    CHECK (requested_generation >= 1),
+  CONSTRAINT governance_rescore_generation_ordered
+    CHECK (
+      completed_generation >= 0
+      AND completed_generation <= requested_generation
+    )
+);
+
+COMMENT ON TABLE governance_rescore_requests IS
+  'Durable generations requiring a full same-epoch rescore after governance policy approval';

--- a/src/db/migrations/034_governance_proposed_topic_weights.sql
+++ b/src/db/migrations/034_governance_proposed_topic_weights.sql
@@ -26,3 +26,39 @@ CREATE TABLE IF NOT EXISTS governance_rescore_requests (
 
 COMMENT ON TABLE governance_rescore_requests IS
   'Durable generations requiring a full same-epoch rescore after governance policy approval';
+
+-- A pre-review deployment briefly allowed an empty voting window to enter the
+-- results phase. Empty results have no community proposal to approve, so put
+-- any such active row back into the ordinary running phase. This preserves the
+-- already-active policy and records the repair without manufacturing a vote.
+WITH reconciled AS (
+  UPDATE governance_epochs epoch
+  SET phase = 'running',
+      voting_started_at = NULL,
+      voting_ends_at = NULL,
+      voting_closed_at = NULL,
+      auto_transition = FALSE,
+      proposed_weights = NULL,
+      proposed_topic_weights = NULL,
+      proposed_content_rules = NULL,
+      results_approved_at = NULL,
+      results_approved_by = NULL
+  WHERE epoch.status = 'active'
+    AND epoch.phase = 'results'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM governance_votes vote
+      WHERE vote.epoch_id = epoch.id
+    )
+  RETURNING epoch.id
+)
+INSERT INTO governance_audit_log (action, actor_did, epoch_id, details)
+SELECT
+  'migration_reconcile_zero_ballot_results',
+  'system:migration:034',
+  reconciled.id,
+  jsonb_build_object(
+    'reason', 'results phase had zero ballots',
+    'restored_phase', 'running'
+  )
+FROM reconciled;

--- a/src/db/migrations/034_governance_proposed_topic_weights.sql
+++ b/src/db/migrations/034_governance_proposed_topic_weights.sql
@@ -1,0 +1,7 @@
+-- Keep topic-weight results reviewable alongside signal weights and content
+-- rules before an operator approves the complete policy.
+ALTER TABLE governance_epochs
+ADD COLUMN IF NOT EXISTS proposed_topic_weights JSONB;
+
+COMMENT ON COLUMN governance_epochs.proposed_topic_weights IS
+  'Aggregated topic-weight proposal awaiting operator approval in results phase';

--- a/src/db/queries/epochs.ts
+++ b/src/db/queries/epochs.ts
@@ -7,19 +7,64 @@
 import { db } from '../client.js';
 import type { GovernanceEpoch } from '../../scoring/score.types.js';
 import { toGovernanceEpoch } from '../../scoring/score.types.js';
+import { parseStoredTopicWeights } from '../../governance/topic-weights.js';
+
+export interface ScoringGovernanceEpoch extends GovernanceEpoch {
+  pendingRescoreGeneration: number | null;
+}
+
+function parsePendingRescoreGeneration(raw: unknown, epochId: number): number | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+
+  const generation = Number.parseInt(String(raw), 10);
+  if (!Number.isSafeInteger(generation) || generation <= 0) {
+    throw new Error(
+      `Invalid governance rescore generation for epoch ${epochId}: ${String(raw)}`
+    );
+  }
+
+  return generation;
+}
 
 /**
  * Get the currently active governance epoch.
  * Returns null if no active epoch exists.
  */
-export async function getActiveEpoch(): Promise<GovernanceEpoch | null> {
+export async function getActiveEpoch(): Promise<ScoringGovernanceEpoch | null> {
   const result = await db.query(
-    `SELECT * FROM governance_epochs WHERE status = 'active' ORDER BY id DESC LIMIT 1`
+    `SELECT
+       epoch.*,
+       CASE
+         WHEN rescore.requested_generation > rescore.completed_generation
+           THEN rescore.requested_generation
+         ELSE NULL
+       END AS pending_rescore_generation
+     FROM governance_epochs epoch
+     LEFT JOIN governance_rescore_requests rescore ON rescore.epoch_id = epoch.id
+     WHERE epoch.status = 'active'
+     ORDER BY epoch.id DESC
+     LIMIT 1`
   );
 
   if (result.rows.length === 0) {
     return null;
   }
 
-  return toGovernanceEpoch(result.rows[0]);
+  const row = result.rows[0];
+  const epoch = toGovernanceEpoch({
+    ...row,
+    topic_weights: parseStoredTopicWeights(
+      row.topic_weights,
+      `governance epoch ${String(row.id)} active scoring policy`
+    ),
+  });
+  return {
+    ...epoch,
+    pendingRescoreGeneration: parsePendingRescoreGeneration(
+      row.pending_rescore_generation,
+      epoch.id
+    ),
+  };
 }

--- a/src/governance/content-filter.ts
+++ b/src/governance/content-filter.ts
@@ -170,13 +170,33 @@ async function loadCurrentContentRulesFromDb(): Promise<ContentRules | null> {
 }
 
 /**
+ * Read the active policy directly from PostgreSQL.
+ *
+ * Scoring uses this strict path so a cache or database failure can never be
+ * mistaken for an intentionally empty content policy.
+ */
+export async function getCurrentContentRulesFromDatabase(): Promise<ContentRules> {
+  const contentRules = await loadCurrentContentRulesFromDb();
+  if (!contentRules) {
+    throw new Error('No active governance epoch found while loading content rules');
+  }
+
+  return contentRules;
+}
+
+/** Invalidate the cache and propagate failures to a durability-sensitive caller. */
+export async function invalidateContentRulesCacheStrict(): Promise<void> {
+  await redis.del(CACHE_KEY);
+  logger.debug('Content rules cache invalidated');
+}
+
+/**
  * Invalidate the content rules cache.
  * Call this when epoch changes or content rules are updated.
  */
 export async function invalidateContentRulesCache(): Promise<void> {
   try {
-    await redis.del(CACHE_KEY);
-    logger.debug('Content rules cache invalidated');
+    await invalidateContentRulesCacheStrict();
   } catch (error) {
     logger.error({ error }, 'Failed to invalidate content rules cache');
   }

--- a/src/governance/routes/epochs.ts
+++ b/src/governance/routes/epochs.ts
@@ -15,7 +15,6 @@ import { logger } from '../../lib/logger.js';
 import { ErrorResponseSchema, governanceSecurity } from '../../lib/openapi.js';
 import { toEpochInfo, toContentRules, ContentRulesRow } from '../governance.types.js';
 import { getAuthenticatedDid, SessionStoreUnavailableError } from '../auth.js';
-import { triggerEpochTransition, forceEpochTransition, getCurrentEpochStatus } from '../epoch-manager.js';
 
 const EpochListQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
@@ -441,10 +440,9 @@ export function registerEpochsRoute(app: FastifyInstance): void {
   app.post('/api/governance/epochs/transition', {
     schema: {
       tags: ['Admin'],
-      summary: 'Trigger epoch transition',
+      summary: 'Direct transition disabled',
       description:
-        'Triggers a governance epoch transition (admin only). Tallies votes, creates a new epoch with updated weights. ' +
-        'Use force=true to skip vote count validation.',
+        'Direct epoch transitions are disabled. Use the reviewed voting lifecycle to start voting, close voting, inspect the proposed policy, and approve results.',
       security: governanceSecurity,
       querystring: {
         type: 'object',
@@ -465,6 +463,7 @@ export function registerEpochsRoute(app: FastifyInstance): void {
           required: ['success', 'newEpochId', 'forced'],
         },
         400: ErrorResponseSchema,
+        409: ErrorResponseSchema,
         401: ErrorResponseSchema,
         403: ErrorResponseSchema,
         503: ErrorResponseSchema,
@@ -507,60 +506,9 @@ export function registerEpochsRoute(app: FastifyInstance): void {
         details: queryParseResult.error.issues,
       });
     }
-    const { force } = queryParseResult.data;
-
-    try {
-      // Get current status first
-      const status = await getCurrentEpochStatus();
-      if (!status) {
-        return reply.code(400).send({
-          error: 'NoActiveEpoch',
-          message: 'No active epoch to transition',
-        });
-      }
-
-      if (force) {
-        logger.warn(
-          { adminDid: requesterDid, epochId: status.epochId, voteCount: status.voteCount },
-          'Admin forcing epoch transition'
-        );
-        const newEpochId = await forceEpochTransition();
-        return reply.send({
-          success: true,
-          newEpochId,
-          forced: true,
-          previousEpochId: status.epochId,
-          voteCount: status.voteCount,
-        });
-      }
-
-      const result = await triggerEpochTransition();
-      if (!result.success) {
-        return reply.code(400).send({
-          error: 'TransitionFailed',
-          message: result.error,
-          currentStatus: status,
-        });
-      }
-
-      logger.info(
-        { adminDid: requesterDid, newEpochId: result.newEpochId },
-        'Admin triggered epoch transition'
-      );
-
-      return reply.send({
-        success: true,
-        newEpochId: result.newEpochId,
-        forced: false,
-        previousEpochId: status.epochId,
-        voteCount: status.voteCount,
-      });
-    } catch (err) {
-      logger.error({ err, adminDid: requesterDid }, 'Failed to trigger epoch transition');
-      return reply.code(500).send({
-        error: 'InternalError',
-        message: 'Failed to trigger epoch transition',
-      });
-    }
+    return reply.code(409).send({
+      error: 'DirectTransitionDisabled',
+      message: 'Direct epoch transitions are disabled. Start voting, close voting, review the proposed policy, and approve results.',
+    });
   });
 }

--- a/src/governance/routes/vote.ts
+++ b/src/governance/routes/vote.ts
@@ -334,9 +334,8 @@ export function registerVoteRoute(app: FastifyInstance): void {
 
     const epochId = epoch.rows[0].id;
     const epochPhase = epoch.rows[0].phase as string | null;
-    const votingEndsAt = epoch.rows[0].voting_ends_at as string | null;
 
-    if (epochPhase !== 'voting' || (votingEndsAt !== null && new Date(votingEndsAt).getTime() <= Date.now())) {
+    if (epochPhase !== 'voting') {
       return reply.code(409).send({
         error: 'VotingClosed',
         message: 'Voting is currently closed for this round.',
@@ -357,6 +356,7 @@ export function registerVoteRoute(app: FastifyInstance): void {
           SELECT id
           FROM governance_epochs
           WHERE id = $2
+            AND status IN ('active', 'voting')
             AND phase = 'voting'
             AND (voting_ends_at IS NULL OR voting_ends_at > NOW())
           FOR SHARE

--- a/src/governance/routes/vote.ts
+++ b/src/governance/routes/vote.ts
@@ -320,7 +320,7 @@ export function registerVoteRoute(app: FastifyInstance): void {
 
     // 5. Get current epoch (must be active or voting)
     const epoch = await db.query(
-      `SELECT id, status, phase FROM governance_epochs
+      `SELECT id, status, phase, voting_ends_at FROM governance_epochs
        WHERE status IN ('active', 'voting')
        ORDER BY id DESC LIMIT 1`
     );
@@ -334,8 +334,9 @@ export function registerVoteRoute(app: FastifyInstance): void {
 
     const epochId = epoch.rows[0].id;
     const epochPhase = epoch.rows[0].phase as string | null;
+    const votingEndsAt = epoch.rows[0].voting_ends_at as string | null;
 
-    if (epochPhase !== 'voting') {
+    if (epochPhase !== 'voting' || (votingEndsAt !== null && new Date(votingEndsAt).getTime() <= Date.now())) {
       return reply.code(409).send({
         error: 'VotingClosed',
         message: 'Voting is currently closed for this round.',
@@ -352,13 +353,23 @@ export function registerVoteRoute(app: FastifyInstance): void {
           : null;
 
       const voteResult = await db.query(
-        `INSERT INTO governance_votes (
+        `WITH open_epoch AS (
+          SELECT id
+          FROM governance_epochs
+          WHERE id = $2
+            AND phase = 'voting'
+            AND (voting_ends_at IS NULL OR voting_ends_at > NOW())
+          FOR SHARE
+        )
+        INSERT INTO governance_votes (
           voter_did, epoch_id,
           recency_weight, engagement_weight, bridging_weight,
           source_diversity_weight, relevance_weight,
           include_keywords, exclude_keywords,
           topic_weight_votes
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        )
+        SELECT $1, open_epoch.id, $3, $4, $5, $6, $7, $8, $9, $10
+        FROM open_epoch
         ON CONFLICT (voter_did, epoch_id) DO UPDATE SET
           recency_weight = COALESCE($3, governance_votes.recency_weight),
           engagement_weight = COALESCE($4, governance_votes.engagement_weight),
@@ -381,6 +392,13 @@ export function registerVoteRoute(app: FastifyInstance): void {
           topicWeightsJson,
         ]
       );
+
+      if (voteResult.rows.length === 0) {
+        return reply.code(409).send({
+          error: 'VotingClosed',
+          message: 'Voting closed before this ballot could be recorded.',
+        });
+      }
 
       const isNewVote = voteResult.rows[0].is_new_vote;
       const voteId = voteResult.rows[0].id as string;

--- a/src/governance/routes/vote.ts
+++ b/src/governance/routes/vote.ts
@@ -11,6 +11,7 @@
  */
 
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { PoolClient } from 'pg';
 import { z } from 'zod';
 import { db } from '../../db/client.js';
 import { config } from '../../config.js';
@@ -27,7 +28,7 @@ import {
   normalizeKeywords,
 } from '../governance.types.js';
 import type { VotePayload } from '../governance.types.js';
-import { writeVoteWeights } from '../weight-longtable.js';
+import { writeVoteWeightsWithClient } from '../weight-longtable.js';
 
 const weightFieldSchemas = Object.fromEntries(
   VOTABLE_WEIGHT_PARAMS.map((param) => [
@@ -342,7 +343,22 @@ export function registerVoteRoute(app: FastifyInstance): void {
       });
     }
 
+    let client: PoolClient;
     try {
+      client = await db.connect();
+    } catch (err) {
+      logger.error({ err, voterDid, epochId }, 'Failed to acquire vote transaction connection');
+      return reply.code(500).send({
+        error: 'VoteFailed',
+        message: 'Failed to record your vote. Please try again.',
+      });
+    }
+    let transactionOpen = false;
+
+    try {
+      await client.query('BEGIN');
+      transactionOpen = true;
+
       // 6. UPSERT vote with weights, keywords, and/or topic weights
       // Use xmax = 0 to detect if this was an INSERT (new) or UPDATE (existing)
       // Use COALESCE to preserve existing values when only updating one aspect
@@ -351,7 +367,7 @@ export function registerVoteRoute(app: FastifyInstance): void {
           ? JSON.stringify(vote.topic_weights)
           : null;
 
-      const voteResult = await db.query(
+      const voteResult = await client.query(
         `WITH open_epoch AS (
           SELECT id
           FROM governance_epochs
@@ -394,6 +410,8 @@ export function registerVoteRoute(app: FastifyInstance): void {
       );
 
       if (voteResult.rows.length === 0) {
+        await client.query('ROLLBACK');
+        transactionOpen = false;
         return reply.code(409).send({
           error: 'VotingClosed',
           message: 'Voting closed before this ballot could be recorded.',
@@ -404,25 +422,15 @@ export function registerVoteRoute(app: FastifyInstance): void {
       const voteId = voteResult.rows[0].id as string;
       const auditAction = isNewVote ? 'vote_cast' : 'vote_updated';
 
-      // 6b. Dual-write per-component weights into governance_vote_weights
-      // (PROJ-815 / P2). Only when the submission carried weights; keyword-only
-      // updates leave prior long-table rows in place, mirroring the COALESCE
-      // semantics of the wide-row UPSERT above. A failure here does NOT roll
-      // back the wide row — same eventual-consistency contract as PROJ-814.
-      // Backfill (scripts/backfill-governance-weights.ts) converges any gap.
+      // 6b. Dual-write per-component weights in the same transaction as the
+      // wide ballot. Result closure takes an exclusive epoch lock, so it can
+      // never observe one representation without the other.
       if (config.GOVERNANCE_LONGTABLE_DUALWRITE_ENABLED && normalized) {
-        try {
-          await writeVoteWeights(voteId, normalized);
-        } catch (longTableErr) {
-          logger.warn(
-            { err: longTableErr, voteId, epochId },
-            'Long-table vote weight write failed; wide row remains authoritative'
-          );
-        }
+        await writeVoteWeightsWithClient(client, voteId, normalized);
       }
 
       // 7. Log to audit trail with appropriate action
-      await db.query(
+      await client.query(
         `INSERT INTO governance_audit_log (action, actor_did, epoch_id, details)
          VALUES ($1, $2, $3, $4)`,
         [
@@ -444,6 +452,9 @@ export function registerVoteRoute(app: FastifyInstance): void {
           }),
         ]
       );
+
+      await client.query('COMMIT');
+      transactionOpen = false;
 
       logger.info(
         {
@@ -474,11 +485,20 @@ export function registerVoteRoute(app: FastifyInstance): void {
         message,
       });
     } catch (err) {
+      if (transactionOpen) {
+        try {
+          await client.query('ROLLBACK');
+        } catch (rollbackError) {
+          logger.error({ rollbackError, voterDid, epochId }, 'Failed to roll back vote transaction');
+        }
+      }
       logger.error({ err, voterDid, epochId }, 'Failed to record vote');
       return reply.code(500).send({
         error: 'VoteFailed',
         message: 'Failed to record your vote. Please try again.',
       });
+    } finally {
+      client.release();
     }
   });
 

--- a/src/governance/topic-weights.ts
+++ b/src/governance/topic-weights.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+const StoredTopicWeightsSchema = z.record(
+  z.number().finite().min(0).max(1)
+);
+
+export class InvalidStoredTopicWeightsError extends Error {
+  constructor(context: string, issueSummary: string) {
+    super(`Invalid stored topic weights for ${context}: ${issueSummary}`);
+    this.name = 'InvalidStoredTopicWeightsError';
+  }
+}
+
+export function parseStoredTopicWeights(
+  raw: unknown,
+  context: string
+): Record<string, number> {
+  if (raw === null || raw === undefined) {
+    return {};
+  }
+
+  const result = StoredTopicWeightsSchema.safeParse(raw);
+  if (!result.success) {
+    const issueSummary = result.error.issues
+      .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+      .join('; ');
+    throw new InvalidStoredTopicWeightsError(context, issueSummary);
+  }
+
+  return result.data;
+}
+
+export function parseStoredProposedTopicWeights(
+  raw: unknown,
+  context: string
+): Record<string, number> | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+
+  return parseStoredTopicWeights(raw, context);
+}

--- a/src/governance/vote-counts.ts
+++ b/src/governance/vote-counts.ts
@@ -1,0 +1,36 @@
+import type { PoolClient } from 'pg';
+
+export interface GovernanceVoteCounts {
+  total: number;
+  content: number;
+  topic: number;
+}
+
+export async function readGovernanceVoteCounts(
+  client: PoolClient,
+  epochId: number
+): Promise<GovernanceVoteCounts> {
+  const result = await client.query<{ total: string; content: string; topic: string }>(
+    `SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (
+        WHERE
+          (include_keywords IS NOT NULL AND array_length(include_keywords, 1) > 0)
+          OR
+          (exclude_keywords IS NOT NULL AND array_length(exclude_keywords, 1) > 0)
+      )::int AS content,
+      COUNT(*) FILTER (
+        WHERE topic_weight_votes IS NOT NULL
+          AND topic_weight_votes != '{}'::jsonb
+      )::int AS topic
+     FROM governance_votes
+     WHERE epoch_id = $1`,
+    [epochId]
+  );
+
+  return {
+    total: Number.parseInt(result.rows[0]?.total ?? '0', 10),
+    content: Number.parseInt(result.rows[0]?.content ?? '0', 10),
+    topic: Number.parseInt(result.rows[0]?.topic ?? '0', 10),
+  };
+}

--- a/src/governance/weight-longtable.ts
+++ b/src/governance/weight-longtable.ts
@@ -208,10 +208,8 @@ export async function writeEpochWeights(
  * Mirrors COALESCE semantics from the wide-row UPSERT: keys with null/undefined
  * values are skipped (preserves prior long-table rows on a partial update).
  *
- * Uses the autocommit pool `db` since the caller in routes/vote.ts is not
- * already inside a transaction. A failure here does not roll back the wide
- * row — the same eventual-consistency contract that PROJ-814 (P1) established
- * for scoring decomposition. Backfill converges any gap.
+ * Transactional callers should use writeVoteWeightsWithClient so the wide row
+ * and normalized rows either commit together or both roll back.
  */
 export async function writeVoteWeights(
   voteId: string,
@@ -229,6 +227,35 @@ export async function writeVoteWeights(
   const { placeholders, params } = buildWeightRows(voteId, fullWeights);
 
   await db.query(
+    `INSERT INTO governance_vote_weights (vote_id, component_key, weight)
+     VALUES ${placeholders}
+     ON CONFLICT (vote_id, component_key) DO UPDATE SET weight = EXCLUDED.weight`,
+    params
+  );
+}
+
+/**
+ * Transactional variant used by the public ballot route. Keeping the
+ * normalized rows in the same transaction prevents result closure from
+ * observing a new wide ballot before its component rows exist.
+ */
+export async function writeVoteWeightsWithClient(
+  client: PoolClient,
+  voteId: string,
+  weights: Partial<Record<GovernanceWeightKey, number | null | undefined>>
+): Promise<void> {
+  const nonNull = Object.entries(weights).filter(
+    ([, weight]) => typeof weight === 'number' && Number.isFinite(weight)
+  ) as Array<[GovernanceWeightKey, number]>;
+
+  if (nonNull.length === 0) {
+    return;
+  }
+
+  const fullWeights = Object.fromEntries(nonNull) as Record<GovernanceWeightKey, number>;
+  const { placeholders, params } = buildWeightRows(voteId, fullWeights);
+
+  await client.query(
     `INSERT INTO governance_vote_weights (vote_id, component_key, weight)
      VALUES ${placeholders}
      ON CONFLICT (vote_id, component_key) DO UPDATE SET weight = EXCLUDED.weight`,

--- a/src/ingestion/governance-gate.ts
+++ b/src/ingestion/governance-gate.ts
@@ -211,10 +211,14 @@ export async function checkGovernanceGate(topicVector: TopicVector): Promise<Gat
  * Invalidate the governance gate topic weights cache.
  * Call when epoch changes or topic weights are updated.
  */
+export async function invalidateGovernanceGateCacheStrict(): Promise<void> {
+  await redis.del(CACHE_KEY);
+  logger.debug('Governance gate topic weights cache invalidated');
+}
+
 export async function invalidateGovernanceGateCache(): Promise<void> {
   try {
-    await redis.del(CACHE_KEY);
-    logger.debug('Governance gate topic weights cache invalidated');
+    await invalidateGovernanceGateCacheStrict();
   } catch (error) {
     logger.error({ error }, 'Failed to invalidate governance gate cache');
   }

--- a/src/lib/startup-checks.ts
+++ b/src/lib/startup-checks.ts
@@ -10,7 +10,7 @@ import { redis } from '../db/redis.js';
 import { logger } from './logger.js';
 
 const STARTUP_CHECK_TIMEOUT = 5000; // 5 seconds per check
-const MIN_REQUIRED_MIGRATION = 14;
+const MIN_REQUIRED_MIGRATION = 34;
 
 /**
  * Run all startup checks.

--- a/src/scheduler/epoch-scheduler.ts
+++ b/src/scheduler/epoch-scheduler.ts
@@ -11,7 +11,11 @@ import cron from 'node-cron';
 import type { ScheduledTask } from 'node-cron';
 import type { PoolClient } from 'pg';
 import { db } from '../db/client.js';
-import { aggregateContentVotes, aggregateVotes } from '../governance/aggregation.js';
+import {
+  aggregateContentVotes,
+  aggregateTopicWeights,
+  aggregateVotes,
+} from '../governance/aggregation.js';
 import { readEpochWeights } from '../governance/weight-longtable.js';
 import { toContentRules, type ContentRules, type GovernanceWeights } from '../governance/governance.types.js';
 import {
@@ -26,6 +30,7 @@ interface ActiveEpochRow {
   phase: string | null;
   voting_ends_at: string | null;
   content_rules: unknown;
+  topic_weights: unknown;
   recency_weight: number | string;
   engagement_weight: number | string;
   bridging_weight: number | string;
@@ -75,8 +80,25 @@ function toDbContentRules(rules: ContentRules): { include_keywords: string[]; ex
   };
 }
 
-async function getVoteCounts(client: PoolClient, epochId: number): Promise<{ total: number; content: number }> {
-  const result = await client.query<{ total: string; content: string }>(
+function toTopicWeights(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
+  }
+
+  const weights: Record<string, number> = {};
+  for (const [slug, value] of Object.entries(raw)) {
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1) {
+      weights[slug] = value;
+    }
+  }
+  return weights;
+}
+
+async function getVoteCounts(
+  client: PoolClient,
+  epochId: number
+): Promise<{ total: number; content: number; topic: number }> {
+  const result = await client.query<{ total: string; content: string; topic: string }>(
     `SELECT
       COUNT(*)::int AS total,
       COUNT(*) FILTER (
@@ -84,7 +106,11 @@ async function getVoteCounts(client: PoolClient, epochId: number): Promise<{ tot
           (include_keywords IS NOT NULL AND array_length(include_keywords, 1) > 0)
           OR
           (exclude_keywords IS NOT NULL AND array_length(exclude_keywords, 1) > 0)
-      )::int AS content
+      )::int AS content,
+      COUNT(*) FILTER (
+        WHERE topic_weight_votes IS NOT NULL
+          AND topic_weight_votes != '{}'::jsonb
+      )::int AS topic
      FROM governance_votes
      WHERE epoch_id = $1`,
     [epochId]
@@ -93,6 +119,7 @@ async function getVoteCounts(client: PoolClient, epochId: number): Promise<{ tot
   return {
     total: parseInt(result.rows[0]?.total ?? '0', 10),
     content: parseInt(result.rows[0]?.content ?? '0', 10),
+    topic: parseInt(result.rows[0]?.topic ?? '0', 10),
   };
 }
 
@@ -142,6 +169,7 @@ async function startDueScheduledVotes(): Promise<{ started: number; errors: numb
              voting_ends_at = NOW() + make_interval(hours => $1),
              auto_transition = TRUE,
              proposed_weights = NULL,
+             proposed_topic_weights = NULL,
              proposed_content_rules = NULL
          WHERE id = $2`,
         [scheduled.duration_hours, epoch.id]
@@ -203,6 +231,11 @@ async function closeExpiredVotingWindows(): Promise<{ transitioned: number; erro
         `SELECT *
          FROM governance_epochs
          WHERE id = $1
+           AND status = 'active'
+           AND phase = 'voting'
+           AND auto_transition = TRUE
+           AND voting_ends_at IS NOT NULL
+           AND voting_ends_at <= NOW()
          FOR UPDATE`,
         [row.id]
       );
@@ -223,9 +256,11 @@ async function closeExpiredVotingWindows(): Promise<{ transitioned: number; erro
       // committed atomically by the previous scheduler tick / PATCH route.
       const currentWeights = (await readEpochWeights({ epochId: epoch.id })) ?? toWeights(epoch);
       const currentRules = toContentRules((epoch.content_rules ?? null) as any);
+      const currentTopicWeights = toTopicWeights(epoch.topic_weights);
 
       let proposedWeights = currentWeights;
       let proposedRules = currentRules;
+      let proposedTopicWeights = currentTopicWeights;
 
       if (voteCounts.total > 0) {
         const aggregatedWeights = await aggregateVotes(epoch.id);
@@ -238,15 +273,25 @@ async function closeExpiredVotingWindows(): Promise<{ transitioned: number; erro
         proposedRules = await aggregateContentVotes(epoch.id);
       }
 
+      if (voteCounts.topic > 0) {
+        proposedTopicWeights = await aggregateTopicWeights(epoch.id);
+      }
+
       await client.query(
         `UPDATE governance_epochs
          SET phase = 'results',
              voting_closed_at = NOW(),
              auto_transition = FALSE,
              proposed_weights = $1,
-             proposed_content_rules = $2
-         WHERE id = $3`,
-        [JSON.stringify(proposedWeights), JSON.stringify(toDbContentRules(proposedRules)), epoch.id]
+             proposed_content_rules = $2,
+             proposed_topic_weights = $3
+         WHERE id = $4`,
+        [
+          JSON.stringify(proposedWeights),
+          JSON.stringify(toDbContentRules(proposedRules)),
+          JSON.stringify(proposedTopicWeights),
+          epoch.id,
+        ]
       );
 
       await client.query(
@@ -257,7 +302,9 @@ async function closeExpiredVotingWindows(): Promise<{ transitioned: number; erro
           JSON.stringify({
             vote_count: voteCounts.total,
             content_vote_count: voteCounts.content,
+            topic_vote_count: voteCounts.topic,
             proposed_weights: proposedWeights,
+            proposed_topic_weights: proposedTopicWeights,
             proposed_content_rules: toDbContentRules(proposedRules),
           }),
         ]
@@ -330,7 +377,7 @@ async function sendVotingReminders(): Promise<{ reminders: number; errors: numbe
   return { reminders, errors };
 }
 
-async function checkScheduledTransitions(): Promise<{
+export async function checkScheduledTransitions(): Promise<{
   startedVotes: number;
   transitionedToResults: number;
   remindersSent: number;

--- a/src/scheduler/epoch-scheduler.ts
+++ b/src/scheduler/epoch-scheduler.ts
@@ -18,6 +18,7 @@ import {
 } from '../governance/aggregation.js';
 import { readEpochWeights } from '../governance/weight-longtable.js';
 import { toContentRules, type ContentRules, type GovernanceWeights } from '../governance/governance.types.js';
+import { parseStoredTopicWeights } from '../governance/topic-weights.js';
 import {
   announceVotingClosed,
   announceVotingOpen,
@@ -78,20 +79,6 @@ function toDbContentRules(rules: ContentRules): { include_keywords: string[]; ex
     include_keywords: rules.includeKeywords,
     exclude_keywords: rules.excludeKeywords,
   };
-}
-
-function toTopicWeights(raw: unknown): Record<string, number> {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return {};
-  }
-
-  const weights: Record<string, number> = {};
-  for (const [slug, value] of Object.entries(raw)) {
-    if (typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1) {
-      weights[slug] = value;
-    }
-  }
-  return weights;
 }
 
 async function getVoteCounts(
@@ -256,7 +243,10 @@ async function closeExpiredVotingWindows(): Promise<{ transitioned: number; erro
       // committed atomically by the previous scheduler tick / PATCH route.
       const currentWeights = (await readEpochWeights({ epochId: epoch.id })) ?? toWeights(epoch);
       const currentRules = toContentRules((epoch.content_rules ?? null) as any);
-      const currentTopicWeights = toTopicWeights(epoch.topic_weights);
+      const currentTopicWeights = parseStoredTopicWeights(
+        epoch.topic_weights,
+        `governance epoch ${epoch.id} active policy`
+      );
 
       let proposedWeights = currentWeights;
       let proposedRules = currentRules;

--- a/src/scheduler/epoch-scheduler.ts
+++ b/src/scheduler/epoch-scheduler.ts
@@ -9,7 +9,6 @@
 
 import cron from 'node-cron';
 import type { ScheduledTask } from 'node-cron';
-import type { PoolClient } from 'pg';
 import { db } from '../db/client.js';
 import {
   aggregateContentVotes,
@@ -19,6 +18,7 @@ import {
 import { readEpochWeights } from '../governance/weight-longtable.js';
 import { toContentRules, type ContentRules, type GovernanceWeights } from '../governance/governance.types.js';
 import { parseStoredTopicWeights } from '../governance/topic-weights.js';
+import { readGovernanceVoteCounts } from '../governance/vote-counts.js';
 import {
   announceVotingClosed,
   announceVotingOpen,
@@ -78,35 +78,6 @@ function toDbContentRules(rules: ContentRules): { include_keywords: string[]; ex
   return {
     include_keywords: rules.includeKeywords,
     exclude_keywords: rules.excludeKeywords,
-  };
-}
-
-async function getVoteCounts(
-  client: PoolClient,
-  epochId: number
-): Promise<{ total: number; content: number; topic: number }> {
-  const result = await client.query<{ total: string; content: string; topic: string }>(
-    `SELECT
-      COUNT(*)::int AS total,
-      COUNT(*) FILTER (
-        WHERE
-          (include_keywords IS NOT NULL AND array_length(include_keywords, 1) > 0)
-          OR
-          (exclude_keywords IS NOT NULL AND array_length(exclude_keywords, 1) > 0)
-      )::int AS content,
-      COUNT(*) FILTER (
-        WHERE topic_weight_votes IS NOT NULL
-          AND topic_weight_votes != '{}'::jsonb
-      )::int AS topic
-     FROM governance_votes
-     WHERE epoch_id = $1`,
-    [epochId]
-  );
-
-  return {
-    total: parseInt(result.rows[0]?.total ?? '0', 10),
-    content: parseInt(result.rows[0]?.content ?? '0', 10),
-    topic: parseInt(result.rows[0]?.topic ?? '0', 10),
   };
 }
 
@@ -233,7 +204,7 @@ async function closeExpiredVotingWindows(): Promise<{ transitioned: number; erro
         continue;
       }
 
-      const voteCounts = await getVoteCounts(client, epoch.id);
+      const voteCounts = await readGovernanceVoteCounts(client, epoch.id);
       // Read current epoch weights via the storage-agnostic helper. Behind
       // GOVERNANCE_LONGTABLE_READ_ENABLED this queries governance_epoch_weights;
       // off, it projects from the wide columns. The autocommit pool used by

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -33,8 +33,10 @@ import {
   getCurrentContentRules,
   filterPosts,
   hasActiveContentRules,
+  invalidateContentRulesCache,
 } from '../governance/content-filter.js';
 import type { ContentRules } from '../governance/governance.types.js';
+import { invalidateGovernanceGateCache } from '../ingestion/governance-gate.js';
 import { updateScoringStatus } from '../admin/status-tracker.js';
 import { calculateAuthorConcentration } from '../transparency/metrics.js';
 import { applyFeedUrlDedup, FEED_URL_DEDUP_DECAY } from './feed-publication.js';
@@ -211,6 +213,30 @@ export function requestFullRescore(): void {
   fullRescoreRequestGeneration++;
 }
 
+async function completeGovernanceRescoreGeneration(
+  epochId: number,
+  generation: number
+): Promise<void> {
+  const result = await db.query<{ requested_generation: number | string }>(
+    `UPDATE governance_rescore_requests
+     SET completed_generation = GREATEST(completed_generation, $2),
+         completed_at = CASE
+           WHEN requested_generation <= $2 THEN NOW()
+           ELSE completed_at
+         END
+     WHERE epoch_id = $1
+       AND requested_generation >= $2
+     RETURNING requested_generation`,
+    [epochId, generation]
+  );
+
+  if (!result.rows[0]) {
+    throw new Error(
+      `Failed to complete governance rescore generation ${generation} for epoch ${epochId}`
+    );
+  }
+}
+
 /**
  * Run the complete scoring pipeline with timeout.
  * This is the main entry point called by the scheduler.
@@ -272,6 +298,12 @@ async function runScoringPipelineInternal(): Promise<void> {
       return;
     }
     const runId = randomUUID();
+    const durableRescoreGeneration = epoch.pendingRescoreGeneration;
+
+    if (durableRescoreGeneration !== null) {
+      await invalidateContentRulesCache();
+      await invalidateGovernanceGateCache();
+    }
 
     logger.info({ epochId: epoch.id, runId }, 'Using governance epoch');
 
@@ -282,7 +314,9 @@ async function runScoringPipelineInternal(): Promise<void> {
 
     // Force a full rescore periodically to catch recency decay
     const fullRescoreDue = incrementalRunCount >= config.SCORING_FULL_RESCORE_INTERVAL;
-    const policyRescoreDue = requestedFullRescoreGeneration > completedFullRescoreRequestGeneration;
+    const policyRescoreDue =
+      requestedFullRescoreGeneration > completedFullRescoreRequestGeneration
+      || durableRescoreGeneration !== null;
     const useIncremental = !isFirstRun && !epochChanged && !fullRescoreDue && !policyRescoreDue;
 
     if (fullRescoreDue && !isFirstRun && !epochChanged) {
@@ -366,6 +400,10 @@ async function runScoringPipelineInternal(): Promise<void> {
     // previous scores remain in post_scores. Reading from DB gives the
     // complete, correctly-ranked feed.
     const feedPublication = await writeToRedisFromDb(epoch.id, runId);
+
+    if (!useIncremental && durableRescoreGeneration !== null && feedPublication.published) {
+      await completeGovernanceRescoreGeneration(epoch.id, durableRescoreGeneration);
+    }
 
     const elapsed = Date.now() - startTime;
     logger.info(

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -438,7 +438,7 @@ async function runScoringPipelineInternal(): Promise<void> {
     }
     await updateCurrentRunScope(runId, epoch.id, elapsed, posts.length, allPosts.length - posts.length);
 
-    if (!useIncremental && policyRescoreDue) {
+    if (!useIncremental && policyRescoreDue && feedPublication.published) {
       completedFullRescoreRequestGeneration = Math.max(
         completedFullRescoreRequestGeneration,
         requestedFullRescoreGeneration

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -13,6 +13,7 @@
 
 import { db } from '../db/client.js';
 import { redis } from '../db/redis.js';
+import type { PoolClient } from 'pg';
 import { config } from '../config.js';
 import { invalidateCurrentFeedSnapshot } from '../feed/snapshot-cache.js';
 import { logger } from '../lib/logger.js';
@@ -31,12 +32,13 @@ import type { ScoringContext } from './component.interface.js';
 import type { GovernanceWeightKey } from '../config/votable-params.js';
 import {
   getCurrentContentRules,
+  getCurrentContentRulesFromDatabase,
   filterPosts,
   hasActiveContentRules,
-  invalidateContentRulesCache,
+  invalidateContentRulesCacheStrict,
 } from '../governance/content-filter.js';
 import type { ContentRules } from '../governance/governance.types.js';
-import { invalidateGovernanceGateCache } from '../ingestion/governance-gate.js';
+import { invalidateGovernanceGateCacheStrict } from '../ingestion/governance-gate.js';
 import { updateScoringStatus } from '../admin/status-tracker.js';
 import { calculateAuthorConcentration } from '../transparency/metrics.js';
 import { applyFeedUrlDedup, FEED_URL_DEDUP_DECAY } from './feed-publication.js';
@@ -214,10 +216,11 @@ export function requestFullRescore(): void {
 }
 
 async function completeGovernanceRescoreGeneration(
+  client: PoolClient,
   epochId: number,
   generation: number
 ): Promise<void> {
-  const result = await db.query<{ requested_generation: number | string }>(
+  const result = await client.query<{ requested_generation: number | string }>(
     `UPDATE governance_rescore_requests
      SET completed_generation = GREATEST(completed_generation, $2),
          completed_at = CASE
@@ -234,6 +237,84 @@ async function completeGovernanceRescoreGeneration(
     throw new Error(
       `Failed to complete governance rescore generation ${generation} for epoch ${epochId}`
     );
+  }
+}
+
+class ScoringPolicySupersededError extends Error {
+  constructor(epochId: number) {
+    super(`Governance policy changed while epoch ${epochId} scoring was in progress`);
+    this.name = 'ScoringPolicySupersededError';
+  }
+}
+
+async function publishScoringRunWithFence(options: {
+  epochId: number;
+  runId: string;
+  durableRescoreGeneration: number | null;
+  requestedFullRescoreGeneration: number;
+  currentRunOnly: boolean;
+}): Promise<FeedPublicationResult> {
+  const client = await db.connect();
+
+  try {
+    await client.query('BEGIN');
+    const fenceResult = await client.query<{
+      pending_rescore_generation: number | string | null;
+    }>(
+      `SELECT
+         CASE
+           WHEN rescore.requested_generation > rescore.completed_generation
+             THEN rescore.requested_generation
+           ELSE NULL
+         END AS pending_rescore_generation
+       FROM governance_epochs epoch
+       LEFT JOIN governance_rescore_requests rescore ON rescore.epoch_id = epoch.id
+       WHERE epoch.id = $1
+         AND epoch.status = 'active'
+       FOR SHARE OF epoch`,
+      [options.epochId]
+    );
+
+    const rawPendingGeneration = fenceResult.rows[0]?.pending_rescore_generation ?? null;
+    const pendingGeneration = rawPendingGeneration === null
+      ? null
+      : Number.parseInt(String(rawPendingGeneration), 10);
+    const validPendingGeneration = pendingGeneration === null
+      || (Number.isSafeInteger(pendingGeneration) && pendingGeneration > 0);
+
+    if (
+      fenceResult.rows.length !== 1
+      || !validPendingGeneration
+      || pendingGeneration !== options.durableRescoreGeneration
+      || fullRescoreRequestGeneration !== options.requestedFullRescoreGeneration
+    ) {
+      throw new ScoringPolicySupersededError(options.epochId);
+    }
+
+    const publication = await writeToRedisFromDb(
+      options.epochId,
+      options.runId,
+      options.currentRunOnly
+    );
+    if (
+      options.currentRunOnly
+      && options.durableRescoreGeneration !== null
+      && publication.published
+    ) {
+      await completeGovernanceRescoreGeneration(
+        client,
+        options.epochId,
+        options.durableRescoreGeneration
+      );
+    }
+
+    await client.query('COMMIT');
+    return publication;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
   }
 }
 
@@ -299,16 +380,6 @@ async function runScoringPipelineInternal(): Promise<void> {
     }
     const runId = randomUUID();
     const durableRescoreGeneration = epoch.pendingRescoreGeneration;
-
-    if (durableRescoreGeneration !== null) {
-      await invalidateContentRulesCache();
-      await invalidateGovernanceGateCache();
-    }
-
-    logger.info({ epochId: epoch.id, runId }, 'Using governance epoch');
-
-    // 2. Load content rules and determine scoring mode (full vs incremental).
-    const contentRules = await getCurrentContentRules();
     const epochChanged = lastScoredEpochId !== null && lastScoredEpochId !== epoch.id;
     const isFirstRun = lastSuccessfulRunAt === null;
 
@@ -318,6 +389,21 @@ async function runScoringPipelineInternal(): Promise<void> {
       requestedFullRescoreGeneration > completedFullRescoreRequestGeneration
       || durableRescoreGeneration !== null;
     const useIncremental = !isFirstRun && !epochChanged && !fullRescoreDue && !policyRescoreDue;
+
+    if (policyRescoreDue) {
+      await invalidateContentRulesCacheStrict();
+      await invalidateGovernanceGateCacheStrict();
+    }
+
+    logger.info({ epochId: epoch.id, runId }, 'Using governance epoch');
+
+    // Policy rescoring reads canonical PostgreSQL state directly. A database
+    // failure in that durability-sensitive path must abort rather than look
+    // like an intentionally empty policy. Ordinary runs retain the established
+    // read-through cache.
+    const contentRules = policyRescoreDue
+      ? await getCurrentContentRulesFromDatabase()
+      : await getCurrentContentRules();
 
     if (fullRescoreDue && !isFirstRun && !epochChanged) {
       logger.info(
@@ -399,11 +485,13 @@ async function runScoringPipelineInternal(): Promise<void> {
     // In incremental mode, only new/changed posts were scored above, but
     // previous scores remain in post_scores. Reading from DB gives the
     // complete, correctly-ranked feed.
-    const feedPublication = await writeToRedisFromDb(epoch.id, runId);
-
-    if (!useIncremental && durableRescoreGeneration !== null && feedPublication.published) {
-      await completeGovernanceRescoreGeneration(epoch.id, durableRescoreGeneration);
-    }
+    const feedPublication = await publishScoringRunWithFence({
+      epochId: epoch.id,
+      runId,
+      durableRescoreGeneration,
+      requestedFullRescoreGeneration,
+      currentRunOnly: policyRescoreDue,
+    });
 
     const elapsed = Date.now() - startTime;
     logger.info(
@@ -1132,9 +1220,25 @@ async function storeScoreComponents(
  * Applies the scoring window cutoff so posts older than SCORING_WINDOW_HOURS
  * are excluded even if they have stale scores in post_scores.
  */
-async function writeToRedisFromDb(epochId: number, runId: string): Promise<FeedPublicationResult> {
+async function writeToRedisFromDb(
+  epochId: number,
+  runId: string,
+  currentRunOnly: boolean
+): Promise<FeedPublicationResult> {
   const cutoffMs = config.SCORING_WINDOW_HOURS * 60 * 60 * 1000;
   const cutoff = new Date(Date.now() - cutoffMs);
+  const currentRunClause = currentRunOnly
+    ? `AND ps.component_details->>'run_id' = $5`
+    : '';
+  const queryParams: unknown[] = [
+    epochId,
+    config.FEED_MAX_POSTS,
+    cutoff.toISOString(),
+    config.FEED_MIN_RELEVANCE,
+  ];
+  if (currentRunOnly) {
+    queryParams.push(runId);
+  }
 
   const result = await db.query<{
     post_uri: string;
@@ -1165,9 +1269,10 @@ async function writeToRedisFromDb(epochId: number, runId: string): Promise<FeedP
        -- prunes the post_scores scan to the 72h partitions (18.7s -> 2.6s).
        AND ps.created_at > $3
        AND ps.relevance_score >= $4
+       ${currentRunClause}
      ORDER BY ps.total_score DESC
      LIMIT $2`,
-    [epochId, config.FEED_MAX_POSTS, cutoff.toISOString(), config.FEED_MIN_RELEVANCE]
+    queryParams
   );
 
   const feedCandidates: RedisFeedCandidate[] = result.rows.map((post) => ({

--- a/src/scoring/pipeline.ts
+++ b/src/scoring/pipeline.ts
@@ -98,6 +98,12 @@ let lastScoredEpochId: number | null = null;
 // Count incremental runs since last full rescore (triggers periodic full rescore for recency decay)
 let incrementalRunCount = 0;
 
+// Policy changes within an epoch need a full pass over the existing corpus.
+// Generations prevent a request that arrives during a run from being consumed
+// by that already-started run.
+let fullRescoreRequestGeneration = 0;
+let completedFullRescoreRequestGeneration = 0;
+
 // Avoid repeated warnings when a rollout exposes a missing dynamic component weight.
 let missingWeightWarned = new Set<string>();
 let scoringRunInFlight: Promise<void> | null = null;
@@ -191,8 +197,18 @@ export function __resetPipelineState(): void {
   lastSuccessfulRunAt = null;
   lastScoredEpochId = null;
   incrementalRunCount = 0;
+  fullRescoreRequestGeneration = 0;
+  completedFullRescoreRequestGeneration = 0;
   missingWeightWarned = new Set<string>();
   scoringRunInFlight = null;
+}
+
+/**
+ * Require the next successfully completed scoring pass to cover the full
+ * candidate window, even when the active epoch id has not changed.
+ */
+export function requestFullRescore(): void {
+  fullRescoreRequestGeneration++;
 }
 
 /**
@@ -245,6 +261,7 @@ export async function runScoringPipeline(): Promise<void> {
  */
 async function runScoringPipelineInternal(): Promise<void> {
   const startTime = Date.now();
+  const requestedFullRescoreGeneration = fullRescoreRequestGeneration;
   logger.info('Starting scoring pipeline');
 
   try {
@@ -265,7 +282,8 @@ async function runScoringPipelineInternal(): Promise<void> {
 
     // Force a full rescore periodically to catch recency decay
     const fullRescoreDue = incrementalRunCount >= config.SCORING_FULL_RESCORE_INTERVAL;
-    const useIncremental = !isFirstRun && !epochChanged && !fullRescoreDue;
+    const policyRescoreDue = requestedFullRescoreGeneration > completedFullRescoreRequestGeneration;
+    const useIncremental = !isFirstRun && !epochChanged && !fullRescoreDue && !policyRescoreDue;
 
     if (fullRescoreDue && !isFirstRun && !epochChanged) {
       logger.info(
@@ -294,7 +312,13 @@ async function runScoringPipelineInternal(): Promise<void> {
           mode: 'full',
           postCount: allPosts.length,
           epochId: epoch.id,
-          reason: epochChanged ? 'epoch_changed' : fullRescoreDue ? 'periodic_full_rescore' : 'first_run',
+          reason: policyRescoreDue
+            ? 'policy_changed'
+            : epochChanged
+              ? 'epoch_changed'
+              : fullRescoreDue
+                ? 'periodic_full_rescore'
+                : 'first_run',
           includeKeywords: contentRules.includeKeywords.length,
           excludeKeywords: contentRules.excludeKeywords.length,
         },
@@ -375,6 +399,13 @@ async function runScoringPipelineInternal(): Promise<void> {
       }
     }
     await updateCurrentRunScope(runId, epoch.id, elapsed, posts.length, allPosts.length - posts.length);
+
+    if (!useIncremental && policyRescoreDue) {
+      completedFullRescoreRequestGeneration = Math.max(
+        completedFullRescoreRequestGeneration,
+        requestedFullRescoreGeneration
+      );
+    }
   } catch (err) {
     logger.error({ err }, 'Scoring pipeline failed');
     throw err;

--- a/tests/admin-epochs-transition.test.ts
+++ b/tests/admin-epochs-transition.test.ts
@@ -1,10 +1,8 @@
 import Fastify from 'fastify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { dbQueryMock, forceEpochTransitionMock, triggerEpochTransitionMock } = vi.hoisted(() => ({
+const { dbQueryMock } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
-  forceEpochTransitionMock: vi.fn(),
-  triggerEpochTransitionMock: vi.fn(),
 }));
 
 vi.mock('../src/db/client.js', () => ({
@@ -17,29 +15,14 @@ vi.mock('../src/auth/admin.js', () => ({
   getAdminDid: () => 'did:plc:admin',
 }));
 
-vi.mock('../src/governance/epoch-manager.js', () => ({
-  forceEpochTransition: forceEpochTransitionMock,
-  triggerEpochTransition: triggerEpochTransitionMock,
-}));
-
 import { registerEpochRoutes } from '../src/admin/routes/epochs.js';
 
 describe('admin epoch transition route', () => {
   beforeEach(() => {
     dbQueryMock.mockReset();
-    forceEpochTransitionMock.mockReset();
-    triggerEpochTransitionMock.mockReset();
   });
 
-  it('uses normal transition path when force is false', async () => {
-    dbQueryMock
-      .mockResolvedValueOnce({
-        rows: [{ id: 12, vote_count: '7', weight_vote_count: '7' }],
-      })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ id: 13, status: 'active' }] });
-    triggerEpochTransitionMock.mockResolvedValue({ success: true, newEpochId: 13 });
-
+  it('rejects normal direct transitions in favor of reviewed approval', async () => {
     const app = Fastify();
     registerEpochRoutes(app);
 
@@ -49,37 +32,28 @@ describe('admin epoch transition route', () => {
       payload: { force: false },
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(triggerEpochTransitionMock).toHaveBeenCalledTimes(1);
-    expect(forceEpochTransitionMock).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(409);
     expect(response.json()).toMatchObject({
-      success: true,
-      previousEpochId: 12,
-      voteCount: 7,
-      weightVoteCount: 7,
+      error: 'DirectTransitionDisabled',
     });
+    expect(dbQueryMock).not.toHaveBeenCalled();
 
     await app.close();
   });
 
-  it('blocks non-forced transition when weight-eligible votes are below minimum', async () => {
-    dbQueryMock.mockResolvedValueOnce({
-      rows: [{ id: 12, vote_count: '20', weight_vote_count: '1' }],
-    });
-
+  it('does not allow force to bypass results review', async () => {
     const app = Fastify();
     registerEpochRoutes(app);
 
     const response = await app.inject({
       method: 'POST',
       url: '/epochs/transition',
-      payload: { force: false },
+      payload: { force: true },
     });
 
-    expect(response.statusCode).toBe(400);
-    expect(triggerEpochTransitionMock).not.toHaveBeenCalled();
-    expect(forceEpochTransitionMock).not.toHaveBeenCalled();
-    expect(String(response.json().error)).toContain('Insufficient weight votes');
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'DirectTransitionDisabled' });
+    expect(dbQueryMock).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/tests/content-filter.test.ts
+++ b/tests/content-filter.test.ts
@@ -21,7 +21,12 @@ vi.mock('../src/db/redis.js', () => ({
   },
 }));
 
-import { getCurrentContentRules, checkContentRules } from '../src/governance/content-filter.js';
+import {
+  checkContentRules,
+  getCurrentContentRules,
+  getCurrentContentRulesFromDatabase,
+  invalidateContentRulesCacheStrict,
+} from '../src/governance/content-filter.js';
 
 describe('content filter cache fallback', () => {
   beforeEach(() => {
@@ -104,6 +109,36 @@ describe('content filter cache fallback', () => {
       excludeKeywords: ['politics'],
     });
     expect(dbQueryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads canonical rules directly from PostgreSQL for policy rescoring', async () => {
+    dbQueryMock.mockResolvedValue({
+      rows: [{
+        content_rules: {
+          include_keywords: ['research'],
+          exclude_keywords: ['spam'],
+        },
+      }],
+    });
+
+    await expect(getCurrentContentRulesFromDatabase()).resolves.toEqual({
+      includeKeywords: ['research'],
+      excludeKeywords: ['spam'],
+    });
+    expect(redisGetMock).not.toHaveBeenCalled();
+    expect(redisSetMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the canonical policy cannot be loaded', async () => {
+    dbQueryMock.mockRejectedValue(new Error('database unavailable'));
+
+    await expect(getCurrentContentRulesFromDatabase()).rejects.toThrow('database unavailable');
+  });
+
+  it('propagates strict cache invalidation failures to the rescore worker', async () => {
+    redisDelMock.mockRejectedValue(new Error('redis unavailable'));
+
+    await expect(invalidateContentRulesCacheStrict()).rejects.toThrow('redis unavailable');
   });
 });
 

--- a/tests/governance-admin.test.ts
+++ b/tests/governance-admin.test.ts
@@ -6,8 +6,11 @@ const {
   dbConnectMock,
   clientQueryMock,
   invalidateContentRulesCacheMock,
+  invalidateGovernanceGateCacheMock,
   aggregateVotesMock,
   aggregateContentVotesMock,
+  aggregateTopicWeightsMock,
+  writeEpochWeightsMock,
   tryTriggerManualScoringRunMock,
   forceEpochTransitionMock,
   triggerEpochTransitionMock,
@@ -16,8 +19,11 @@ const {
   dbConnectMock: vi.fn(),
   clientQueryMock: vi.fn(),
   invalidateContentRulesCacheMock: vi.fn(),
+  invalidateGovernanceGateCacheMock: vi.fn(),
   aggregateVotesMock: vi.fn(),
   aggregateContentVotesMock: vi.fn(),
+  aggregateTopicWeightsMock: vi.fn(),
+  writeEpochWeightsMock: vi.fn(),
   tryTriggerManualScoringRunMock: vi.fn(),
   forceEpochTransitionMock: vi.fn(),
   triggerEpochTransitionMock: vi.fn(),
@@ -38,9 +44,19 @@ vi.mock('../src/governance/content-filter.js', () => ({
   invalidateContentRulesCache: invalidateContentRulesCacheMock,
 }));
 
+vi.mock('../src/ingestion/governance-gate.js', () => ({
+  invalidateGovernanceGateCache: invalidateGovernanceGateCacheMock,
+}));
+
 vi.mock('../src/governance/aggregation.js', () => ({
   aggregateVotes: aggregateVotesMock,
   aggregateContentVotes: aggregateContentVotesMock,
+  aggregateTopicWeights: aggregateTopicWeightsMock,
+}));
+
+vi.mock('../src/governance/weight-longtable.js', () => ({
+  readEpochWeightsForMultipleEpochs: vi.fn().mockResolvedValue({}),
+  writeEpochWeights: writeEpochWeightsMock,
 }));
 
 vi.mock('../src/scoring/scheduler.js', () => ({
@@ -69,6 +85,12 @@ function epochRow(overrides: Partial<Record<string, unknown>> = {}) {
       include_keywords: ['ai'],
       exclude_keywords: ['spam'],
     },
+    topic_weights: {
+      'software-development': 0.5,
+    },
+    proposed_weights: null,
+    proposed_topic_weights: null,
+    proposed_content_rules: null,
     created_at: '2026-02-08T00:00:00.000Z',
     closed_at: null,
     ...overrides,
@@ -81,8 +103,11 @@ describe('admin governance routes', () => {
     dbConnectMock.mockReset();
     clientQueryMock.mockReset();
     invalidateContentRulesCacheMock.mockReset();
+    invalidateGovernanceGateCacheMock.mockReset();
     aggregateVotesMock.mockReset();
     aggregateContentVotesMock.mockReset();
+    aggregateTopicWeightsMock.mockReset();
+    writeEpochWeightsMock.mockReset();
     tryTriggerManualScoringRunMock.mockReset();
     forceEpochTransitionMock.mockReset();
     triggerEpochTransitionMock.mockReset();
@@ -93,9 +118,12 @@ describe('admin governance routes', () => {
     });
 
     invalidateContentRulesCacheMock.mockResolvedValue(undefined);
+    invalidateGovernanceGateCacheMock.mockResolvedValue(undefined);
     tryTriggerManualScoringRunMock.mockReturnValue(true);
     aggregateVotesMock.mockResolvedValue(null);
     aggregateContentVotesMock.mockResolvedValue({ includeKeywords: [], excludeKeywords: [] });
+    aggregateTopicWeightsMock.mockResolvedValue({});
+    writeEpochWeightsMock.mockResolvedValue(undefined);
     forceEpochTransitionMock.mockResolvedValue(8);
     triggerEpochTransitionMock.mockResolvedValue({ success: true, newEpochId: 8 });
   });
@@ -250,12 +278,12 @@ describe('admin governance routes', () => {
     await app.close();
   });
 
-  it('apply results without votes keeps existing weights and logs audit entry', async () => {
+  it('legacy apply-results alias requires reviewed results and keeps policy without votes', async () => {
     clientQueryMock
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [epochRow()] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'results' })] })
       .mockResolvedValueOnce({ rows: [{ count: '0' }] })
-      .mockResolvedValueOnce({ rows: [epochRow()] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'running' })] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] });
 
@@ -286,6 +314,144 @@ describe('admin governance routes', () => {
       (call) => typeof call[0] === 'string' && call[0].includes('INSERT INTO governance_audit_log')
     );
     expect(auditInsert).toBeTruthy();
+
+    await app.close();
+  });
+
+  it('does not let the legacy apply-results alias bypass results review', async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'voting' })] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/governance/apply-results',
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'ResultsNotPending' });
+    expect(aggregateVotesMock).not.toHaveBeenCalled();
+    expect(aggregateTopicWeightsMock).not.toHaveBeenCalled();
+    expect(aggregateContentVotesMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('reviews and applies signal, topic, and content-rule proposals before rescoring', async () => {
+    const proposedWeights = {
+      recency: 0.1,
+      engagement: 0.2,
+      bridging: 0.25,
+      sourceDiversity: 0.15,
+      relevance: 0.3,
+    };
+    const proposedTopicWeights = {
+      'science-research': 0.9,
+      'software-development': 0.75,
+    };
+    const proposedContentRules = {
+      include_keywords: ['research'],
+      exclude_keywords: ['spam'],
+    };
+
+    aggregateVotesMock.mockResolvedValue(proposedWeights);
+    aggregateTopicWeightsMock.mockResolvedValue(proposedTopicWeights);
+    aggregateContentVotesMock.mockResolvedValue({
+      includeKeywords: proposedContentRules.include_keywords,
+      excludeKeywords: proposedContentRules.exclude_keywords,
+    });
+
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'voting' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
+      .mockResolvedValueOnce({
+        rows: [epochRow({
+          phase: 'results',
+          proposed_weights: proposedWeights,
+          proposed_topic_weights: proposedTopicWeights,
+          proposed_content_rules: proposedContentRules,
+        })],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+
+    const closed = await app.inject({
+      method: 'POST',
+      url: '/governance/end-voting',
+      payload: { announce: false },
+    });
+
+    expect(closed.statusCode).toBe(200);
+    expect(closed.json()).toMatchObject({
+      voteCount: 25,
+      proposedWeights,
+      proposedTopicWeights,
+      proposedContentRules: {
+        includeKeywords: ['research'],
+        excludeKeywords: ['spam'],
+      },
+    });
+
+    clientQueryMock.mockReset();
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [epochRow({
+          phase: 'results',
+          proposed_weights: proposedWeights,
+          proposed_topic_weights: proposedTopicWeights,
+          proposed_content_rules: proposedContentRules,
+        })],
+      })
+      .mockResolvedValueOnce({
+        rows: [epochRow({
+          phase: 'running',
+          recency_weight: proposedWeights.recency,
+          engagement_weight: proposedWeights.engagement,
+          bridging_weight: proposedWeights.bridging,
+          source_diversity_weight: proposedWeights.sourceDiversity,
+          relevance_weight: proposedWeights.relevance,
+          topic_weights: proposedTopicWeights,
+          content_rules: proposedContentRules,
+        })],
+      })
+      .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const approved = await app.inject({
+      method: 'POST',
+      url: '/governance/approve-results',
+      payload: { announce: false },
+    });
+
+    expect(approved.statusCode).toBe(200);
+    expect(approved.json()).toMatchObject({
+      weights: proposedWeights,
+      topicWeights: proposedTopicWeights,
+      contentRules: {
+        includeKeywords: ['research'],
+        excludeKeywords: ['spam'],
+      },
+      rescoreTriggered: true,
+    });
+    expect(writeEpochWeightsMock).toHaveBeenCalledWith(expect.anything(), 7, proposedWeights);
+    expect(invalidateContentRulesCacheMock).toHaveBeenCalledTimes(1);
+    expect(invalidateGovernanceGateCacheMock).toHaveBeenCalledTimes(1);
+    expect(tryTriggerManualScoringRunMock).toHaveBeenCalledWith();
+
+    const update = clientQueryMock.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('topic_weights = $6')
+    );
+    expect(update?.[1]).toContain(JSON.stringify(proposedTopicWeights));
 
     await app.close();
   });

--- a/tests/governance-admin.test.ts
+++ b/tests/governance-admin.test.ts
@@ -332,13 +332,11 @@ describe('admin governance routes', () => {
     await app.close();
   });
 
-  it('legacy apply-results alias requires reviewed results and keeps policy without votes', async () => {
+  it('legacy apply-results alias rejects a reviewed window with no ballots', async () => {
     clientQueryMock
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [epochRow({ phase: 'results' })] })
-      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
-      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'running' })] })
-      .mockResolvedValueOnce({ rows: [{ requested_generation: '1' }] })
+      .mockResolvedValueOnce({ rows: [{ total: '0', content: '0', topic: '0' }] })
       .mockResolvedValueOnce({ rows: [] });
 
     const app = Fastify();
@@ -349,46 +347,17 @@ describe('admin governance routes', () => {
       url: '/governance/apply-results',
     });
 
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(409);
     expect(response.json()).toMatchObject({
-      success: true,
-      voteCount: 0,
-      appliedWeights: false,
-      weights: {
-        recency: 0.2,
-        engagement: 0.2,
-        bridging: 0.2,
-        sourceDiversity: 0.2,
-        relevance: 0.2,
-      },
+      error: 'NoBallots',
     });
     expect(aggregateVotesMock).not.toHaveBeenCalled();
-
-    const policyUpdate = clientQueryMock.mock.calls.find(
-      (call) => typeof call[0] === 'string' && call[0].includes('vote_count = $8')
-    );
-    expect(policyUpdate?.[1]).toEqual([
-      0.2,
-      0.2,
-      0.2,
-      0.2,
-      0.2,
-      JSON.stringify({ 'software-development': 0.5 }),
-      JSON.stringify({ include_keywords: ['ai'], exclude_keywords: ['spam'] }),
-      0,
-      'did:plc:admin',
-      7,
-    ]);
-
-    const rescoreInsert = clientQueryMock.mock.calls.find(
-      (call) => typeof call[0] === 'string' && call[0].includes('INSERT INTO governance_rescore_requests')
-    );
-    expect(rescoreInsert?.[1]).toEqual([7]);
-
-    const auditInsert = clientQueryMock.mock.calls.find(
-      (call) => typeof call[0] === 'string' && call[0].includes('INSERT INTO governance_audit_log')
-    );
-    expect(auditInsert).toBeTruthy();
+    expect(clientQueryMock).toHaveBeenCalledWith('ROLLBACK');
+    expect(
+      clientQueryMock.mock.calls.some(
+        ([sql]) => typeof sql === 'string' && sql.includes('UPDATE governance_epochs')
+      )
+    ).toBe(false);
 
     await app.close();
   });
@@ -427,6 +396,62 @@ describe('admin governance routes', () => {
         ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO governance_rescore_requests')
       )
     ).toBe(false);
+
+    await app.close();
+  });
+
+  it('rejects canonical approval when the reviewed window has no ballots', async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'results' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '0', content: '0', topic: '0' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/governance/approve-results',
+      payload: { announce: false },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'NoBallots' });
+    expect(clientQueryMock).toHaveBeenCalledWith('ROLLBACK');
+    expect(requestFullRescoreMock).not.toHaveBeenCalled();
+    expect(tryTriggerManualScoringRunMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('rolls back approval when stored proposed topic policy is malformed', async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [epochRow({ phase: 'results', proposed_topic_weights: ['invalid'] })],
+      })
+      .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/governance/approve-results',
+      payload: { announce: false },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toMatchObject({ error: 'ApproveResultsFailed' });
+    expect(clientQueryMock).toHaveBeenCalledWith('ROLLBACK');
+    expect(
+      clientQueryMock.mock.calls.some(
+        ([sql]) => typeof sql === 'string' && sql.includes('UPDATE governance_epochs')
+      )
+    ).toBe(false);
+    expect(requestFullRescoreMock).not.toHaveBeenCalled();
 
     await app.close();
   });
@@ -501,6 +526,7 @@ describe('admin governance routes', () => {
           proposed_content_rules: proposedContentRules,
         })],
       })
+      .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
       .mockResolvedValueOnce({
         rows: [epochRow({
           phase: 'running',
@@ -513,7 +539,6 @@ describe('admin governance routes', () => {
           content_rules: proposedContentRules,
         })],
       })
-      .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
       .mockResolvedValueOnce({ rows: [{ requested_generation: '1' }] })
       .mockResolvedValueOnce({ rows: [] });
 
@@ -569,8 +594,8 @@ describe('admin governance routes', () => {
     clientQueryMock
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [epochRow({ phase: 'results' })] })
-      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'running' })] })
       .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'running' })] })
       .mockRejectedValueOnce(new Error('rescore outbox unavailable'));
 
     const app = Fastify();
@@ -596,8 +621,8 @@ describe('admin governance routes', () => {
     clientQueryMock
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [epochRow({ phase: 'results' })] })
-      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'running' })] })
       .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'running' })] })
       .mockResolvedValueOnce({ rows: [{ requested_generation: '2' }] })
       .mockResolvedValueOnce({ rows: [] });
     tryTriggerManualScoringRunMock.mockRejectedValueOnce(new Error('scoring trigger unavailable'));
@@ -621,6 +646,24 @@ describe('admin governance routes', () => {
     expect(tryTriggerManualScoringRunMock.mock.invocationCallOrder[0]).toBeGreaterThan(
       clientQueryMock.mock.invocationCallOrder[commitCallIndex]
     );
+
+    await app.close();
+  });
+
+  it('rejects the legacy direct end-round bypass even when force is requested', async () => {
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/governance/end-round',
+      payload: { force: true },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'DirectTransitionDisabled' });
+    expect(clientQueryMock).not.toHaveBeenCalled();
+    expect(dbQueryMock).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/tests/governance-admin.test.ts
+++ b/tests/governance-admin.test.ts
@@ -11,6 +11,7 @@ const {
   aggregateContentVotesMock,
   aggregateTopicWeightsMock,
   writeEpochWeightsMock,
+  requestFullRescoreMock,
   tryTriggerManualScoringRunMock,
   forceEpochTransitionMock,
   triggerEpochTransitionMock,
@@ -24,6 +25,7 @@ const {
   aggregateContentVotesMock: vi.fn(),
   aggregateTopicWeightsMock: vi.fn(),
   writeEpochWeightsMock: vi.fn(),
+  requestFullRescoreMock: vi.fn(),
   tryTriggerManualScoringRunMock: vi.fn(),
   forceEpochTransitionMock: vi.fn(),
   triggerEpochTransitionMock: vi.fn(),
@@ -61,6 +63,10 @@ vi.mock('../src/governance/weight-longtable.js', () => ({
 
 vi.mock('../src/scoring/scheduler.js', () => ({
   tryTriggerManualScoringRun: tryTriggerManualScoringRunMock,
+}));
+
+vi.mock('../src/scoring/pipeline.js', () => ({
+  requestFullRescore: requestFullRescoreMock,
 }));
 
 vi.mock('../src/governance/epoch-manager.js', () => ({
@@ -108,6 +114,7 @@ describe('admin governance routes', () => {
     aggregateContentVotesMock.mockReset();
     aggregateTopicWeightsMock.mockReset();
     writeEpochWeightsMock.mockReset();
+    requestFullRescoreMock.mockReset();
     tryTriggerManualScoringRunMock.mockReset();
     forceEpochTransitionMock.mockReset();
     triggerEpochTransitionMock.mockReset();
@@ -446,6 +453,7 @@ describe('admin governance routes', () => {
     expect(writeEpochWeightsMock).toHaveBeenCalledWith(expect.anything(), 7, proposedWeights);
     expect(invalidateContentRulesCacheMock).toHaveBeenCalledTimes(1);
     expect(invalidateGovernanceGateCacheMock).toHaveBeenCalledTimes(1);
+    expect(requestFullRescoreMock).toHaveBeenCalledTimes(1);
     expect(tryTriggerManualScoringRunMock).toHaveBeenCalledWith();
 
     const update = clientQueryMock.mock.calls.find(

--- a/tests/governance-admin.test.ts
+++ b/tests/governance-admin.test.ts
@@ -162,6 +162,46 @@ describe('admin governance routes', () => {
     await app.close();
   });
 
+  it('returns a bounded error when overview policy data is malformed', async () => {
+    dbQueryMock.mockResolvedValueOnce({
+      rows: [{ ...epochRow({ topic_weights: 'malformed' }), vote_count: '1' }],
+    });
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+
+    const response = await app.inject({ method: 'GET', url: '/governance' });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({
+      error: 'InvalidGovernancePolicy',
+      message: 'Stored governance policy is invalid',
+    });
+
+    await app.close();
+  });
+
+  it('returns a bounded error when round detail policy data is malformed', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [epochRow({ topic_weights: 'malformed' })] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ count: '1' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+
+    const response = await app.inject({ method: 'GET', url: '/governance/rounds/7' });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({
+      error: 'InvalidGovernancePolicy',
+      message: 'Stored governance policy is invalid',
+    });
+
+    await app.close();
+  });
+
   it('returns 409 when adding duplicate keyword', async () => {
     clientQueryMock
       .mockResolvedValueOnce({ rows: [] })
@@ -575,6 +615,12 @@ describe('admin governance routes', () => {
     expect(response.json()).toMatchObject({ success: true, rescoreTriggered: false });
     expect(clientQueryMock).toHaveBeenCalledWith('COMMIT');
     expect(requestFullRescoreMock).toHaveBeenCalledTimes(1);
+    expect(tryTriggerManualScoringRunMock).toHaveBeenCalledTimes(1);
+    const commitCallIndex = clientQueryMock.mock.calls.findIndex(([sql]) => sql === 'COMMIT');
+    expect(commitCallIndex).toBeGreaterThanOrEqual(0);
+    expect(tryTriggerManualScoringRunMock.mock.invocationCallOrder[0]).toBeGreaterThan(
+      clientQueryMock.mock.invocationCallOrder[commitCallIndex]
+    );
 
     await app.close();
   });

--- a/tests/governance-admin.test.ts
+++ b/tests/governance-admin.test.ts
@@ -74,6 +74,13 @@ vi.mock('../src/governance/epoch-manager.js', () => ({
   triggerEpochTransition: triggerEpochTransitionMock,
 }));
 
+vi.mock('../src/bot/governance-announcements.js', () => ({
+  announceResultsApproved: vi.fn().mockResolvedValue(undefined),
+  announceVoteScheduled: vi.fn().mockResolvedValue(undefined),
+  announceVotingClosed: vi.fn().mockResolvedValue(undefined),
+  announceVotingOpen: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { registerGovernanceRoutes } from '../src/admin/routes/governance.js';
 
 function epochRow(overrides: Partial<Record<string, unknown>> = {}) {
@@ -291,7 +298,7 @@ describe('admin governance routes', () => {
       .mockResolvedValueOnce({ rows: [epochRow({ phase: 'results' })] })
       .mockResolvedValueOnce({ rows: [{ count: '0' }] })
       .mockResolvedValueOnce({ rows: [epochRow({ phase: 'running' })] })
-      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ requested_generation: '1' }] })
       .mockResolvedValueOnce({ rows: [] });
 
     const app = Fastify();
@@ -316,6 +323,27 @@ describe('admin governance routes', () => {
       },
     });
     expect(aggregateVotesMock).not.toHaveBeenCalled();
+
+    const policyUpdate = clientQueryMock.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('vote_count = $8')
+    );
+    expect(policyUpdate?.[1]).toEqual([
+      0.2,
+      0.2,
+      0.2,
+      0.2,
+      0.2,
+      JSON.stringify({ 'software-development': 0.5 }),
+      JSON.stringify({ include_keywords: ['ai'], exclude_keywords: ['spam'] }),
+      0,
+      'did:plc:admin',
+      7,
+    ]);
+
+    const rescoreInsert = clientQueryMock.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('INSERT INTO governance_rescore_requests')
+    );
+    expect(rescoreInsert?.[1]).toEqual([7]);
 
     const auditInsert = clientQueryMock.mock.calls.find(
       (call) => typeof call[0] === 'string' && call[0].includes('INSERT INTO governance_audit_log')
@@ -344,6 +372,21 @@ describe('admin governance routes', () => {
     expect(aggregateVotesMock).not.toHaveBeenCalled();
     expect(aggregateTopicWeightsMock).not.toHaveBeenCalled();
     expect(aggregateContentVotesMock).not.toHaveBeenCalled();
+    expect(writeEpochWeightsMock).not.toHaveBeenCalled();
+    expect(invalidateContentRulesCacheMock).not.toHaveBeenCalled();
+    expect(invalidateGovernanceGateCacheMock).not.toHaveBeenCalled();
+    expect(requestFullRescoreMock).not.toHaveBeenCalled();
+    expect(tryTriggerManualScoringRunMock).not.toHaveBeenCalled();
+    expect(
+      clientQueryMock.mock.calls.some(
+        ([sql]) => typeof sql === 'string' && sql.includes('UPDATE governance_epochs')
+      )
+    ).toBe(false);
+    expect(
+      clientQueryMock.mock.calls.some(
+        ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO governance_rescore_requests')
+      )
+    ).toBe(false);
 
     await app.close();
   });
@@ -431,7 +474,7 @@ describe('admin governance routes', () => {
         })],
       })
       .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
-      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ requested_generation: '1' }] })
       .mockResolvedValueOnce({ rows: [] });
 
     const approved = await app.inject({
@@ -451,15 +494,87 @@ describe('admin governance routes', () => {
       rescoreTriggered: true,
     });
     expect(writeEpochWeightsMock).toHaveBeenCalledWith(expect.anything(), 7, proposedWeights);
-    expect(invalidateContentRulesCacheMock).toHaveBeenCalledTimes(1);
-    expect(invalidateGovernanceGateCacheMock).toHaveBeenCalledTimes(1);
+    expect(invalidateContentRulesCacheMock).not.toHaveBeenCalled();
+    expect(invalidateGovernanceGateCacheMock).not.toHaveBeenCalled();
     expect(requestFullRescoreMock).toHaveBeenCalledTimes(1);
     expect(tryTriggerManualScoringRunMock).toHaveBeenCalledWith();
 
     const update = clientQueryMock.mock.calls.find(
       (call) => typeof call[0] === 'string' && call[0].includes('topic_weights = $6')
     );
-    expect(update?.[1]).toContain(JSON.stringify(proposedTopicWeights));
+    expect(update?.[1]).toEqual([
+      proposedWeights.recency,
+      proposedWeights.engagement,
+      proposedWeights.bridging,
+      proposedWeights.sourceDiversity,
+      proposedWeights.relevance,
+      JSON.stringify(proposedTopicWeights),
+      JSON.stringify(proposedContentRules),
+      'did:plc:admin',
+      7,
+    ]);
+
+    const rescoreInsert = clientQueryMock.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('INSERT INTO governance_rescore_requests')
+    );
+    expect(rescoreInsert?.[1]).toEqual([7]);
+    expect(rescoreInsert?.[0]).toContain(
+      'requested_generation = governance_rescore_requests.requested_generation + 1'
+    );
+
+    await app.close();
+  });
+
+  it('rolls back approved policy changes when the durable rescore cannot be enqueued', async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'results' })] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'running' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
+      .mockRejectedValueOnce(new Error('rescore outbox unavailable'));
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/governance/approve-results',
+      payload: { announce: false },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toMatchObject({ error: 'ApproveResultsFailed' });
+    expect(clientQueryMock).toHaveBeenCalledWith('ROLLBACK');
+    expect(clientQueryMock).not.toHaveBeenCalledWith('COMMIT');
+    expect(requestFullRescoreMock).not.toHaveBeenCalled();
+    expect(tryTriggerManualScoringRunMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('reports a deferred rescore without undoing a committed policy approval', async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'results' })] })
+      .mockResolvedValueOnce({ rows: [epochRow({ phase: 'running' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '25', content: '8', topic: '25' }] })
+      .mockResolvedValueOnce({ rows: [{ requested_generation: '2' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    tryTriggerManualScoringRunMock.mockRejectedValueOnce(new Error('scoring trigger unavailable'));
+
+    const app = Fastify();
+    registerGovernanceRoutes(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/governance/approve-results',
+      payload: { announce: false },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ success: true, rescoreTriggered: false });
+    expect(clientQueryMock).toHaveBeenCalledWith('COMMIT');
+    expect(requestFullRescoreMock).toHaveBeenCalledTimes(1);
 
     await app.close();
   });

--- a/tests/governance-gate.test.ts
+++ b/tests/governance-gate.test.ts
@@ -38,7 +38,13 @@ vi.mock('../src/lib/logger.js', () => ({
   },
 }));
 
-import { checkGovernanceGate, isGovernanceGateReady, loadGovernanceGateWeights, invalidateGovernanceGateCache } from '../src/ingestion/governance-gate.js';
+import {
+  checkGovernanceGate,
+  invalidateGovernanceGateCache,
+  invalidateGovernanceGateCacheStrict,
+  isGovernanceGateReady,
+  loadGovernanceGateWeights,
+} from '../src/ingestion/governance-gate.js';
 
 /** Standard community weights for testing. */
 const COMMUNITY_WEIGHTS: Record<string, number> = {
@@ -332,5 +338,11 @@ describe('invalidateGovernanceGateCache', () => {
     await invalidateGovernanceGateCache();
 
     expect(redisDelMock).toHaveBeenCalledWith('governance_gate:topic_weights');
+  });
+
+  it('propagates strict invalidation failures to the policy rescore worker', async () => {
+    redisDelMock.mockRejectedValue(new Error('redis unavailable'));
+
+    await expect(invalidateGovernanceGateCacheStrict()).rejects.toThrow('redis unavailable');
   });
 });

--- a/tests/governance-lifecycle.test.ts
+++ b/tests/governance-lifecycle.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  aggregateVotesMock,
+  aggregateContentVotesMock,
+  aggregateTopicWeightsMock,
+  readEpochWeightsMock,
+  announceVotingClosedMock,
+} = vi.hoisted(() => ({
+  dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  aggregateVotesMock: vi.fn(),
+  aggregateContentVotesMock: vi.fn(),
+  aggregateTopicWeightsMock: vi.fn(),
+  readEpochWeightsMock: vi.fn(),
+  announceVotingClosedMock: vi.fn(),
+}));
+
+vi.mock('../src/db/client.js', () => ({
+  db: {
+    query: dbQueryMock,
+    connect: dbConnectMock,
+  },
+}));
+
+vi.mock('../src/governance/aggregation.js', () => ({
+  aggregateVotes: aggregateVotesMock,
+  aggregateContentVotes: aggregateContentVotesMock,
+  aggregateTopicWeights: aggregateTopicWeightsMock,
+}));
+
+vi.mock('../src/governance/weight-longtable.js', () => ({
+  readEpochWeights: readEpochWeightsMock,
+}));
+
+vi.mock('../src/bot/governance-announcements.js', () => ({
+  announceVotingClosed: announceVotingClosedMock,
+  announceVotingOpen: vi.fn(),
+  announceVotingReminder: vi.fn(),
+}));
+
+vi.mock('../src/lib/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { checkScheduledTransitions } from '../src/scheduler/epoch-scheduler.js';
+
+describe('production governance lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    dbConnectMock.mockResolvedValue({
+      query: clientQueryMock,
+      release: vi.fn(),
+    });
+    dbQueryMock.mockImplementation((sql: string) => {
+      if (sql.includes('FROM scheduled_votes')) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("voting_ends_at > NOW() + INTERVAL '23 hours'")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("phase = 'voting'") && sql.includes('voting_ends_at <= NOW()')) {
+        return Promise.resolve({ rows: [{ id: 7 }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  });
+
+  it('moves an expired vote to review with all three proposed policy channels', async () => {
+    const signalWeights = {
+      recency: 0.1,
+      engagement: 0.2,
+      bridging: 0.25,
+      sourceDiversity: 0.15,
+      relevance: 0.3,
+    };
+    const topicWeights = {
+      'science-research': 0.9,
+      'software-development': 0.75,
+    };
+    const contentRules = {
+      includeKeywords: ['research'],
+      excludeKeywords: ['spam'],
+    };
+
+    aggregateVotesMock.mockResolvedValue(signalWeights);
+    aggregateTopicWeightsMock.mockResolvedValue(topicWeights);
+    aggregateContentVotesMock.mockResolvedValue(contentRules);
+    readEpochWeightsMock.mockResolvedValue({
+      recency: 0.2,
+      engagement: 0.2,
+      bridging: 0.2,
+      sourceDiversity: 0.2,
+      relevance: 0.2,
+    });
+    announceVotingClosedMock.mockResolvedValue(undefined);
+
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('SELECT *') && sql.includes('FOR UPDATE')) {
+        return Promise.resolve({
+          rows: [{
+            id: 7,
+            phase: 'voting',
+            voting_ends_at: '2026-07-13T00:00:00.000Z',
+            content_rules: { include_keywords: [], exclude_keywords: [] },
+            topic_weights: { 'science-research': 0.5 },
+            recency_weight: 0.2,
+            engagement_weight: 0.2,
+            bridging_weight: 0.2,
+            source_diversity_weight: 0.2,
+            relevance_weight: 0.2,
+          }],
+        });
+      }
+      if (sql.includes('COUNT(*)::int AS total')) {
+        return Promise.resolve({ rows: [{ total: '25', content: '8', topic: '25' }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const result = await checkScheduledTransitions();
+
+    expect(result).toEqual({
+      startedVotes: 0,
+      transitionedToResults: 1,
+      remindersSent: 0,
+      errors: 0,
+    });
+
+    const resultsUpdate = clientQueryMock.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes("SET phase = 'results'")
+    );
+    expect(resultsUpdate?.[1]).toEqual([
+      JSON.stringify(signalWeights),
+      JSON.stringify({ include_keywords: ['research'], exclude_keywords: ['spam'] }),
+      JSON.stringify(topicWeights),
+      7,
+    ]);
+    expect(aggregateTopicWeightsMock).toHaveBeenCalledWith(7);
+    expect(announceVotingClosedMock).toHaveBeenCalledWith({ id: 7 }, 25);
+  });
+
+  it('does not close a voting window that was extended before the row lock', async () => {
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (sql === 'BEGIN' || sql === 'ROLLBACK') {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('SELECT *') && sql.includes('FOR UPDATE')) {
+        expect(sql).toContain("auto_transition = TRUE");
+        expect(sql).toContain('voting_ends_at <= NOW()');
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const result = await checkScheduledTransitions();
+
+    expect(result).toEqual({
+      startedVotes: 0,
+      transitionedToResults: 0,
+      remindersSent: 0,
+      errors: 0,
+    });
+    expect(aggregateVotesMock).not.toHaveBeenCalled();
+    expect(aggregateTopicWeightsMock).not.toHaveBeenCalled();
+    expect(aggregateContentVotesMock).not.toHaveBeenCalled();
+    expect(announceVotingClosedMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/governance-lifecycle.test.ts
+++ b/tests/governance-lifecycle.test.ts
@@ -4,6 +4,7 @@ const {
   dbQueryMock,
   dbConnectMock,
   clientQueryMock,
+  releaseMock,
   aggregateVotesMock,
   aggregateContentVotesMock,
   aggregateTopicWeightsMock,
@@ -13,6 +14,7 @@ const {
   dbQueryMock: vi.fn(),
   dbConnectMock: vi.fn(),
   clientQueryMock: vi.fn(),
+  releaseMock: vi.fn(),
   aggregateVotesMock: vi.fn(),
   aggregateContentVotesMock: vi.fn(),
   aggregateTopicWeightsMock: vi.fn(),
@@ -60,7 +62,7 @@ describe('production governance lifecycle', () => {
 
     dbConnectMock.mockResolvedValue({
       query: clientQueryMock,
-      release: vi.fn(),
+      release: releaseMock,
     });
     dbQueryMock.mockImplementation((sql: string) => {
       if (sql.includes('FROM scheduled_votes')) {
@@ -178,5 +180,129 @@ describe('production governance lifecycle', () => {
     expect(aggregateTopicWeightsMock).not.toHaveBeenCalled();
     expect(aggregateContentVotesMock).not.toHaveBeenCalled();
     expect(announceVotingClosedMock).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and releases the client when policy aggregation fails', async () => {
+    const currentWeights = {
+      recency: 0.2,
+      engagement: 0.2,
+      bridging: 0.2,
+      sourceDiversity: 0.2,
+      relevance: 0.2,
+    };
+
+    readEpochWeightsMock.mockResolvedValue(currentWeights);
+    aggregateVotesMock.mockResolvedValue(currentWeights);
+    aggregateTopicWeightsMock.mockRejectedValue(new Error('topic aggregation failed'));
+
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (sql === 'BEGIN' || sql === 'ROLLBACK') {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('SELECT *') && sql.includes('FOR UPDATE')) {
+        return Promise.resolve({
+          rows: [{
+            id: 7,
+            phase: 'voting',
+            voting_ends_at: '2026-07-13T00:00:00.000Z',
+            content_rules: { include_keywords: [], exclude_keywords: [] },
+            topic_weights: { 'science-research': 0.5 },
+            recency_weight: 0.2,
+            engagement_weight: 0.2,
+            bridging_weight: 0.2,
+            source_diversity_weight: 0.2,
+            relevance_weight: 0.2,
+          }],
+        });
+      }
+      if (sql.includes('COUNT(*)::int AS total')) {
+        return Promise.resolve({ rows: [{ total: '25', content: '0', topic: '25' }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const result = await checkScheduledTransitions();
+
+    expect(result).toEqual({
+      startedVotes: 0,
+      transitionedToResults: 0,
+      remindersSent: 0,
+      errors: 1,
+    });
+    expect(clientQueryMock).toHaveBeenCalledWith('ROLLBACK');
+    expect(clientQueryMock).not.toHaveBeenCalledWith('COMMIT');
+    expect(announceVotingClosedMock).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves all current policy channels when an expired vote has no ballots', async () => {
+    const currentWeights = {
+      recency: 0.1,
+      engagement: 0.25,
+      bridging: 0.2,
+      sourceDiversity: 0.15,
+      relevance: 0.3,
+    };
+    const currentTopicWeights = {
+      'science-research': 0.85,
+      'software-development': 0.7,
+    };
+    const currentContentRules = {
+      include_keywords: ['research'],
+      exclude_keywords: ['spam'],
+    };
+
+    readEpochWeightsMock.mockResolvedValue(currentWeights);
+    announceVotingClosedMock.mockResolvedValue(undefined);
+
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('SELECT *') && sql.includes('FOR UPDATE')) {
+        return Promise.resolve({
+          rows: [{
+            id: 7,
+            phase: 'voting',
+            voting_ends_at: '2026-07-13T00:00:00.000Z',
+            content_rules: currentContentRules,
+            topic_weights: currentTopicWeights,
+            recency_weight: 0.1,
+            engagement_weight: 0.25,
+            bridging_weight: 0.2,
+            source_diversity_weight: 0.15,
+            relevance_weight: 0.3,
+          }],
+        });
+      }
+      if (sql.includes('COUNT(*)::int AS total')) {
+        return Promise.resolve({ rows: [{ total: '0', content: '0', topic: '0' }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const result = await checkScheduledTransitions();
+
+    expect(result).toEqual({
+      startedVotes: 0,
+      transitionedToResults: 1,
+      remindersSent: 0,
+      errors: 0,
+    });
+    expect(aggregateVotesMock).not.toHaveBeenCalled();
+    expect(aggregateTopicWeightsMock).not.toHaveBeenCalled();
+    expect(aggregateContentVotesMock).not.toHaveBeenCalled();
+
+    const resultsUpdate = clientQueryMock.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes("SET phase = 'results'")
+    );
+    expect(resultsUpdate?.[1]).toEqual([
+      JSON.stringify(currentWeights),
+      JSON.stringify(currentContentRules),
+      JSON.stringify(currentTopicWeights),
+      7,
+    ]);
+    expect(announceVotingClosedMock).toHaveBeenCalledWith({ id: 7 }, 0);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/governance-lifecycle.test.ts
+++ b/tests/governance-lifecycle.test.ts
@@ -240,6 +240,56 @@ describe('production governance lifecycle', () => {
     expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 
+  it('rolls back when the active topic policy is malformed at window close', async () => {
+    readEpochWeightsMock.mockResolvedValue({
+      recency: 0.2,
+      engagement: 0.2,
+      bridging: 0.2,
+      sourceDiversity: 0.2,
+      relevance: 0.2,
+    });
+
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (sql === 'BEGIN' || sql === 'ROLLBACK') {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('SELECT *') && sql.includes('FOR UPDATE')) {
+        return Promise.resolve({
+          rows: [{
+            id: 7,
+            phase: 'voting',
+            voting_ends_at: '2026-07-13T00:00:00.000Z',
+            content_rules: { include_keywords: [], exclude_keywords: [] },
+            topic_weights: ['invalid'],
+            recency_weight: 0.2,
+            engagement_weight: 0.2,
+            bridging_weight: 0.2,
+            source_diversity_weight: 0.2,
+            relevance_weight: 0.2,
+          }],
+        });
+      }
+      if (sql.includes('COUNT(*)::int AS total')) {
+        return Promise.resolve({ rows: [{ total: '25', content: '8', topic: '25' }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const result = await checkScheduledTransitions();
+
+    expect(result).toEqual({
+      startedVotes: 0,
+      transitionedToResults: 0,
+      remindersSent: 0,
+      errors: 1,
+    });
+    expect(clientQueryMock).toHaveBeenCalledWith('ROLLBACK');
+    expect(clientQueryMock).not.toHaveBeenCalledWith('COMMIT');
+    expect(aggregateVotesMock).not.toHaveBeenCalled();
+    expect(announceVotingClosedMock).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
   it('preserves all current policy channels when an expired vote has no ballots', async () => {
     const currentWeights = {
       recency: 0.1,

--- a/tests/governance-lifecycle.test.ts
+++ b/tests/governance-lifecycle.test.ts
@@ -161,6 +161,8 @@ describe('production governance lifecycle', () => {
         return Promise.resolve({ rows: [] });
       }
       if (sql.includes('SELECT *') && sql.includes('FOR UPDATE')) {
+        expect(sql).toContain("status = 'active'");
+        expect(sql).toContain("phase = 'voting'");
         expect(sql).toContain("auto_transition = TRUE");
         expect(sql).toContain('voting_ends_at <= NOW()');
         return Promise.resolve({ rows: [] });
@@ -180,6 +182,9 @@ describe('production governance lifecycle', () => {
     expect(aggregateTopicWeightsMock).not.toHaveBeenCalled();
     expect(aggregateContentVotesMock).not.toHaveBeenCalled();
     expect(announceVotingClosedMock).not.toHaveBeenCalled();
+    expect(clientQueryMock).toHaveBeenCalledWith('ROLLBACK');
+    expect(clientQueryMock).not.toHaveBeenCalledWith('COMMIT');
+    expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 
   it('rolls back and releases the client when policy aggregation fails', async () => {

--- a/tests/governance-query-validation.test.ts
+++ b/tests/governance-query-validation.test.ts
@@ -11,6 +11,20 @@ vi.mock('../src/db/client.js', () => ({
   },
 }));
 
+vi.mock('../src/config.js', () => ({
+  config: {
+    BOT_ADMIN_DIDS: 'did:plc:admin',
+    GOVERNANCE_LONGTABLE_READ_ENABLED: false,
+    LOG_LEVEL: 'silent',
+    NODE_ENV: 'test',
+  },
+}));
+
+vi.mock('../src/governance/auth.js', () => ({
+  getAuthenticatedDid: vi.fn().mockResolvedValue('did:plc:admin'),
+  SessionStoreUnavailableError: class extends Error {},
+}));
+
 import { registerWeightsRoute } from '../src/governance/routes/weights.js';
 import { registerEpochsRoute } from '../src/governance/routes/epochs.js';
 
@@ -82,6 +96,23 @@ describe('governance route query validation', () => {
 
     expect(response.statusCode).toBe(400);
     expect(response.json()).toMatchObject({ error: 'ValidationError' });
+    expect(dbQueryMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('rejects the authenticated direct transition endpoint', async () => {
+    const app = Fastify();
+    app.setValidatorCompiler(() => () => true);
+    registerEpochsRoute(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/governance/epochs/transition?force=true',
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'DirectTransitionDisabled' });
     expect(dbQueryMock).not.toHaveBeenCalled();
 
     await app.close();

--- a/tests/governance-vote-counts.test.ts
+++ b/tests/governance-vote-counts.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PoolClient } from 'pg';
+import { readGovernanceVoteCounts } from '../src/governance/vote-counts.js';
+
+describe('readGovernanceVoteCounts', () => {
+  it('counts all ballots while separating content-rule and topic ballots', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [{ total: '25', content: '8', topic: '19' }],
+    });
+    const client = { query } as unknown as PoolClient;
+
+    await expect(readGovernanceVoteCounts(client, 7)).resolves.toEqual({
+      total: 25,
+      content: 8,
+      topic: 19,
+    });
+
+    const [sql, params] = query.mock.calls[0];
+    expect(String(sql)).toContain('COUNT(*)::int AS total');
+    expect(String(sql)).toContain('array_length(include_keywords, 1) > 0');
+    expect(String(sql)).toContain('array_length(exclude_keywords, 1) > 0');
+    expect(String(sql)).toContain("topic_weight_votes != '{}'::jsonb");
+    expect(params).toEqual([7]);
+  });
+
+  it('returns zeroes for an empty voting window', async () => {
+    const client = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ total: '0', content: '0', topic: '0' }],
+      }),
+    } as unknown as PoolClient;
+
+    await expect(readGovernanceVoteCounts(client, 9)).resolves.toEqual({
+      total: 0,
+      content: 0,
+      topic: 0,
+    });
+  });
+});

--- a/tests/incremental-scoring.test.ts
+++ b/tests/incremental-scoring.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  clientReleaseMock,
   redisPipelineFactoryMock,
   pipelineDelMock,
   pipelineZaddMock,
@@ -16,6 +19,9 @@ const {
   loggerWarnMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   redisPipelineFactoryMock: vi.fn(),
   pipelineDelMock: vi.fn(),
   pipelineZaddMock: vi.fn(),
@@ -33,6 +39,7 @@ const {
 vi.mock('../src/db/client.js', () => ({
   db: {
     query: dbQueryMock,
+    connect: dbConnectMock,
   },
 }));
 
@@ -89,6 +96,13 @@ function setupDefaultMocks() {
   };
   redisPipelineFactoryMock.mockReturnValue(pipeline);
   redisEvalMock.mockResolvedValue(1);
+  clientQueryMock.mockImplementation((sql: string) => {
+    if (sql.includes('pending_rescore_generation')) {
+      return Promise.resolve({ rows: [{ pending_rescore_generation: null }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  dbConnectMock.mockResolvedValue({ query: clientQueryMock, release: clientReleaseMock });
 
   getCurrentContentRulesMock.mockResolvedValue({
     includeKeywords: [],

--- a/tests/pipeline-empty-feed.test.ts
+++ b/tests/pipeline-empty-feed.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  clientReleaseMock,
   redisPipelineFactoryMock,
   pipelineDelMock,
   pipelineZaddMock,
@@ -19,6 +22,9 @@ const {
   loggerWarnMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   redisPipelineFactoryMock: vi.fn(),
   pipelineDelMock: vi.fn(),
   pipelineZaddMock: vi.fn(),
@@ -39,6 +45,7 @@ const {
 vi.mock('../src/db/client.js', () => ({
   db: {
     query: dbQueryMock,
+    connect: dbConnectMock,
   },
 }));
 
@@ -112,6 +119,9 @@ describe('scoring pipeline empty-feed Redis updates', () => {
   beforeEach(() => {
     __resetPipelineState();
     dbQueryMock.mockReset();
+    dbConnectMock.mockReset();
+    clientQueryMock.mockReset();
+    clientReleaseMock.mockReset();
     redisPipelineFactoryMock.mockReset();
     pipelineDelMock.mockReset();
     pipelineZaddMock.mockReset();
@@ -122,6 +132,13 @@ describe('scoring pipeline empty-feed Redis updates', () => {
     redisSetMock.mockReset().mockResolvedValue('OK');
     redisDelMock.mockReset().mockResolvedValue(1);
     redisEvalMock.mockReset().mockResolvedValue(1);
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (sql.includes('pending_rescore_generation')) {
+        return Promise.resolve({ rows: [{ pending_rescore_generation: null }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    dbConnectMock.mockResolvedValue({ query: clientQueryMock, release: clientReleaseMock });
     getCurrentContentRulesMock.mockReset();
     hasActiveContentRulesMock.mockReset();
     filterPostsMock.mockReset();

--- a/tests/relevance-floor.test.ts
+++ b/tests/relevance-floor.test.ts
@@ -12,6 +12,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  clientReleaseMock,
   redisPipelineFactoryMock,
   pipelineDelMock,
   pipelineZaddMock,
@@ -23,6 +26,9 @@ const {
   updateScoringStatusMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   redisPipelineFactoryMock: vi.fn(),
   pipelineDelMock: vi.fn(),
   pipelineZaddMock: vi.fn(),
@@ -37,6 +43,7 @@ const {
 vi.mock('../src/db/client.js', () => ({
   db: {
     query: dbQueryMock,
+    connect: dbConnectMock,
   },
 }));
 
@@ -94,6 +101,9 @@ describe('relevance floor in feed output', () => {
   beforeEach(() => {
     __resetPipelineState();
     dbQueryMock.mockReset();
+    dbConnectMock.mockReset();
+    clientQueryMock.mockReset();
+    clientReleaseMock.mockReset();
     redisPipelineFactoryMock.mockReset();
     pipelineDelMock.mockReset();
     pipelineZaddMock.mockReset();
@@ -112,6 +122,13 @@ describe('relevance floor in feed output', () => {
       exec: pipelineExecMock.mockResolvedValue([]),
     };
     redisPipelineFactoryMock.mockReturnValue(pipeline);
+    clientQueryMock.mockImplementation((sql: string) => {
+      if (sql.includes('pending_rescore_generation')) {
+        return Promise.resolve({ rows: [{ pending_rescore_generation: null }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    dbConnectMock.mockResolvedValue({ query: clientQueryMock, release: clientReleaseMock });
 
     getCurrentContentRulesMock.mockResolvedValue({
       includeKeywords: [],

--- a/tests/scoring-longtable-dualwrite.test.ts
+++ b/tests/scoring-longtable-dualwrite.test.ts
@@ -13,6 +13,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  clientReleaseMock,
   redisPipelineFactoryMock,
   pipelineDelMock,
   pipelineZaddMock,
@@ -25,6 +28,9 @@ const {
   configMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   redisPipelineFactoryMock: vi.fn(),
   pipelineDelMock: vi.fn(),
   pipelineZaddMock: vi.fn(),
@@ -51,7 +57,7 @@ const {
 }));
 
 vi.mock('../src/db/client.js', () => ({
-  db: { query: dbQueryMock },
+  db: { query: dbQueryMock, connect: dbConnectMock },
 }));
 
 vi.mock('../src/db/redis.js', () => ({
@@ -100,6 +106,13 @@ function setupDefaultMocks() {
     exec: pipelineExecMock.mockResolvedValue([]),
   };
   redisPipelineFactoryMock.mockReturnValue(pipeline);
+  clientQueryMock.mockImplementation((sql: string) => {
+    if (sql.includes('pending_rescore_generation')) {
+      return Promise.resolve({ rows: [{ pending_rescore_generation: null }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  dbConnectMock.mockResolvedValue({ query: clientQueryMock, release: clientReleaseMock });
 
   getCurrentContentRulesMock.mockResolvedValue({
     includeKeywords: [],

--- a/tests/scoring-pipeline-embeddings.test.ts
+++ b/tests/scoring-pipeline-embeddings.test.ts
@@ -12,6 +12,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  clientReleaseMock,
   redisPipelineFactoryMock,
   pipelineDelMock,
   pipelineZaddMock,
@@ -23,6 +26,9 @@ const {
   configMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   redisPipelineFactoryMock: vi.fn(),
   pipelineDelMock: vi.fn(),
   pipelineZaddMock: vi.fn(),
@@ -44,7 +50,7 @@ const {
 }));
 
 vi.mock('../src/db/client.js', () => ({
-  db: { query: dbQueryMock },
+  db: { query: dbQueryMock, connect: dbConnectMock },
 }));
 
 vi.mock('../src/db/redis.js', () => ({
@@ -95,6 +101,13 @@ function setupDefaultMocks() {
     exec: pipelineExecMock.mockResolvedValue([]),
   };
   redisPipelineFactoryMock.mockReturnValue(pipeline);
+  clientQueryMock.mockImplementation((sql: string) => {
+    if (sql.includes('pending_rescore_generation')) {
+      return Promise.resolve({ rows: [{ pending_rescore_generation: null }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  dbConnectMock.mockResolvedValue({ query: clientQueryMock, release: clientReleaseMock });
 
   getCurrentContentRulesMock.mockResolvedValue({
     includeKeywords: [],

--- a/tests/scoring-pipeline-rescore.test.ts
+++ b/tests/scoring-pipeline-rescore.test.ts
@@ -99,6 +99,26 @@ async function runEmptyCycle(epochId = 2) {
   await runScoringPipeline();
 }
 
+async function runPublishedCycle(epochId = 2) {
+  dbQueryMock
+    .mockResolvedValueOnce({ rows: [makeEpochRow(epochId)] })
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({
+      rows: [{
+        post_uri: 'at://did:plc:author/app.bsky.feed.post/1',
+        total_score: 0.8,
+        author_did: 'did:plc:author',
+        bridging_score: 0.5,
+        engagement_score: 0.4,
+        embed_url: null,
+        text_length: 120,
+      }],
+    })
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [] });
+  await runScoringPipeline();
+}
+
 /** Check whether the posts query used full mode (no UNION ALL) or incremental (UNION ALL). */
 function getPostsQueryMode(): 'full' | 'incremental' {
   const postsQuery = String(dbQueryMock.mock.calls[1][0]);
@@ -225,7 +245,7 @@ describe('periodic full rescore for recency decay', () => {
 
     dbQueryMock.mockReset();
     setupDefaultMocks();
-    await runEmptyCycle(2);
+    await runPublishedCycle(2);
     expect(getPostsQueryMode()).toBe('full');
 
     dbQueryMock.mockReset();
@@ -240,7 +260,7 @@ describe('periodic full rescore for recency decay', () => {
 
     dbQueryMock.mockReset();
     setupDefaultMocks();
-    await runEmptyCycle(3);
+    await runPublishedCycle(3);
     expect(getPostsQueryMode()).toBe('full');
 
     dbQueryMock.mockReset();
@@ -256,7 +276,7 @@ describe('periodic full rescore for recency decay', () => {
 
     dbQueryMock.mockReset();
     setupDefaultMocks();
-    await runEmptyCycle(2);
+    await runPublishedCycle(2);
     expect(getPostsQueryMode()).toBe('full');
 
     dbQueryMock.mockReset();
@@ -278,6 +298,31 @@ describe('periodic full rescore for recency decay', () => {
     setupDefaultMocks();
     await runEmptyCycle(2);
     expect(getPostsQueryMode()).toBe('full');
+  });
+
+  it('keeps an in-memory policy rescore pending until feed publication succeeds', async () => {
+    await runEmptyCycle(2);
+    requestFullRescore();
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('full');
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('full');
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runPublishedCycle(2);
+    expect(getPostsQueryMode()).toBe('full');
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('incremental');
   });
 
   it('does not consume a policy change requested during an in-flight run', async () => {

--- a/tests/scoring-pipeline-rescore.test.ts
+++ b/tests/scoring-pipeline-rescore.test.ts
@@ -49,7 +49,11 @@ vi.mock('../src/admin/status-tracker.js', () => ({
   updateScoringStatus: updateScoringStatusMock,
 }));
 
-import { runScoringPipeline, __resetPipelineState } from '../src/scoring/pipeline.js';
+import {
+  runScoringPipeline,
+  requestFullRescore,
+  __resetPipelineState,
+} from '../src/scoring/pipeline.js';
 import { buildEpochRow } from './helpers/index.js';
 
 function makeEpochRow(id = 2) {
@@ -196,6 +200,74 @@ describe('periodic full rescore for recency decay', () => {
     setupDefaultMocks();
     await runEmptyCycle(3);
     expect(getPostsQueryMode()).toBe('incremental');
+  });
+
+  it('runs a full pass after policy changes within the same epoch', async () => {
+    await runEmptyCycle(2);
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('incremental');
+
+    requestFullRescore();
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('full');
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('incremental');
+  });
+
+  it('keeps a full-rescore request pending when the attempted run fails', async () => {
+    await runEmptyCycle(2);
+    requestFullRescore();
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    dbQueryMock.mockRejectedValueOnce(new Error('epoch read failed'));
+    await expect(runScoringPipeline()).rejects.toThrow('epoch read failed');
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('full');
+  });
+
+  it('does not consume a policy change requested during an in-flight run', async () => {
+    await runEmptyCycle(2);
+
+    let releaseContentRules: ((value: { includeKeywords: string[]; excludeKeywords: string[] }) => void) | null = null;
+    const pendingContentRules = new Promise<{ includeKeywords: string[]; excludeKeywords: string[] }>((resolve) => {
+      releaseContentRules = resolve;
+    });
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow(2)] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    getCurrentContentRulesMock.mockReturnValueOnce(pendingContentRules);
+
+    const inFlightRun = runScoringPipeline();
+    await vi.waitFor(() => {
+      expect(getCurrentContentRulesMock).toHaveBeenCalled();
+    });
+    requestFullRescore();
+    releaseContentRules?.({ includeKeywords: [], excludeKeywords: [] });
+    await inFlightRun;
+    expect(getPostsQueryMode()).toBe('incremental');
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('full');
   });
 
   it('__resetPipelineState resets the incremental counter', async () => {

--- a/tests/scoring-pipeline-rescore.test.ts
+++ b/tests/scoring-pipeline-rescore.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  clientReleaseMock,
   redisPipelineFactoryMock,
   pipelineDelMock,
   pipelineZaddMock,
@@ -14,6 +17,9 @@ const {
   updateScoringStatusMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   redisPipelineFactoryMock: vi.fn(),
   pipelineDelMock: vi.fn(),
   pipelineZaddMock: vi.fn(),
@@ -29,6 +35,7 @@ const {
 vi.mock('../src/db/client.js', () => ({
   db: {
     query: dbQueryMock,
+    connect: dbConnectMock,
   },
 }));
 
@@ -45,13 +52,14 @@ vi.mock('../src/db/redis.js', () => ({
 
 vi.mock('../src/governance/content-filter.js', () => ({
   getCurrentContentRules: getCurrentContentRulesMock,
+  getCurrentContentRulesFromDatabase: getCurrentContentRulesMock,
   hasActiveContentRules: hasActiveContentRulesMock,
   filterPosts: vi.fn(),
-  invalidateContentRulesCache: invalidateContentRulesCacheMock,
+  invalidateContentRulesCacheStrict: invalidateContentRulesCacheMock,
 }));
 
 vi.mock('../src/ingestion/governance-gate.js', () => ({
-  invalidateGovernanceGateCache: invalidateGovernanceGateCacheMock,
+  invalidateGovernanceGateCacheStrict: invalidateGovernanceGateCacheMock,
 }));
 
 vi.mock('../src/admin/status-tracker.js', () => ({
@@ -64,6 +72,8 @@ import {
   __resetPipelineState,
 } from '../src/scoring/pipeline.js';
 import { buildEpochRow } from './helpers/index.js';
+
+let fencePendingGeneration: string | null = null;
 
 function makeEpochRow(id = 2) {
   return buildEpochRow({ id });
@@ -78,6 +88,21 @@ function setupDefaultMocks() {
     exec: pipelineExecMock.mockResolvedValue([]),
   };
   redisPipelineFactoryMock.mockReturnValue(pipeline);
+  clientQueryMock.mockImplementation((sql: string) => {
+    if (sql.includes('pending_rescore_generation')) {
+      return Promise.resolve({
+        rows: [{ pending_rescore_generation: fencePendingGeneration }],
+      });
+    }
+    if (sql.includes('UPDATE governance_rescore_requests')) {
+      return Promise.resolve({ rows: [{ requested_generation: fencePendingGeneration ?? '1' }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  dbConnectMock.mockResolvedValue({
+    query: clientQueryMock,
+    release: clientReleaseMock,
+  });
 
   getCurrentContentRulesMock.mockResolvedValue({
     includeKeywords: [],
@@ -128,6 +153,7 @@ function getPostsQueryMode(): 'full' | 'incremental' {
 describe('periodic full rescore for recency decay', () => {
   beforeEach(() => {
     __resetPipelineState();
+    fencePendingGeneration = null;
     vi.clearAllMocks();
     setupDefaultMocks();
   });
@@ -325,7 +351,7 @@ describe('periodic full rescore for recency decay', () => {
     expect(getPostsQueryMode()).toBe('incremental');
   });
 
-  it('does not consume a policy change requested during an in-flight run', async () => {
+  it('rejects publication and preserves a policy change requested during an in-flight run', async () => {
     await runEmptyCycle(2);
 
     let releaseContentRules: ((value: { includeKeywords: string[]; excludeKeywords: string[] }) => void) | null = null;
@@ -348,7 +374,9 @@ describe('periodic full rescore for recency decay', () => {
     });
     requestFullRescore();
     releaseContentRules?.({ includeKeywords: [], excludeKeywords: [] });
-    await inFlightRun;
+    await expect(inFlightRun).rejects.toThrow(
+      'Governance policy changed while epoch 2 scoring was in progress'
+    );
     expect(getPostsQueryMode()).toBe('incremental');
 
     dbQueryMock.mockReset();
@@ -396,6 +424,7 @@ describe('periodic full rescore for recency decay', () => {
     dbQueryMock.mockReset();
     vi.clearAllMocks();
     setupDefaultMocks();
+    fencePendingGeneration = '4';
     dbQueryMock
       .mockResolvedValueOnce({
         rows: [{ ...makeEpochRow(2), pending_rescore_generation: '4' }],
@@ -417,6 +446,7 @@ describe('periodic full rescore for recency decay', () => {
   it('completes only the durable generation observed by a published run', async () => {
     dbQueryMock.mockReset();
     setupDefaultMocks();
+    fencePendingGeneration = '4';
     dbQueryMock
       .mockResolvedValueOnce({
         rows: [{ ...makeEpochRow(2), pending_rescore_generation: '4' }],
@@ -433,17 +463,72 @@ describe('periodic full rescore for recency decay', () => {
           text_length: 120,
         }],
       })
-      .mockResolvedValueOnce({ rows: [{ requested_generation: '5' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] });
 
     await runScoringPipeline();
 
-    const completion = dbQueryMock.mock.calls.find(
+    const completion = clientQueryMock.mock.calls.find(
       ([sql]) => String(sql).includes('UPDATE governance_rescore_requests')
     );
     expect(completion?.[1]).toEqual([2, 4]);
     expect(invalidateContentRulesCacheMock).toHaveBeenCalledTimes(1);
     expect(invalidateGovernanceGateCacheMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a stale policy publication when a newer durable generation exists', async () => {
+    fencePendingGeneration = '5';
+    dbQueryMock
+      .mockResolvedValueOnce({
+        rows: [{ ...makeEpochRow(2), pending_rescore_generation: '4' }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(runScoringPipeline()).rejects.toThrow(
+      'Governance policy changed while epoch 2 scoring was in progress'
+    );
+
+    expect(
+      dbQueryMock.mock.calls.some(([sql]) => String(sql).includes('FROM post_scores ps'))
+    ).toBe(false);
+    expect(clientQueryMock).toHaveBeenCalledWith('ROLLBACK');
+    expect(clientReleaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a routine run that started before a policy approval', async () => {
+    fencePendingGeneration = '1';
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [makeEpochRow(2)] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(runScoringPipeline()).rejects.toThrow(
+      'Governance policy changed while epoch 2 scoring was in progress'
+    );
+
+    expect(
+      dbQueryMock.mock.calls.some(([sql]) => String(sql).includes('FROM post_scores ps'))
+    ).toBe(false);
+    expect(invalidateContentRulesCacheMock).not.toHaveBeenCalled();
+    expect(clientQueryMock).toHaveBeenCalledWith('ROLLBACK');
+  });
+
+  it('publishes an approved policy from only scores written by that run', async () => {
+    fencePendingGeneration = '4';
+    dbQueryMock
+      .mockResolvedValueOnce({
+        rows: [{ ...makeEpochRow(2), pending_rescore_generation: '4' }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await runScoringPipeline();
+
+    const publication = dbQueryMock.mock.calls.find(
+      ([sql]) => String(sql).includes('FROM post_scores ps')
+    );
+    expect(String(publication?.[0])).toContain("ps.component_details->>'run_id' = $5");
+    expect(publication?.[1]).toHaveLength(5);
+    expect(publication?.[1]?.[0]).toBe(2);
+    expect(publication?.[1]?.[4]).toEqual(expect.any(String));
   });
 });

--- a/tests/scoring-pipeline-rescore.test.ts
+++ b/tests/scoring-pipeline-rescore.test.ts
@@ -223,6 +223,37 @@ describe('periodic full rescore for recency decay', () => {
     expect(getPostsQueryMode()).toBe('incremental');
   });
 
+  it('clears a pending policy request when an epoch change already causes a full pass', async () => {
+    await runEmptyCycle(2);
+    requestFullRescore();
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(3);
+    expect(getPostsQueryMode()).toBe('full');
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(3);
+    expect(getPostsQueryMode()).toBe('incremental');
+  });
+
+  it('coalesces multiple policy requests into one full pass', async () => {
+    await runEmptyCycle(2);
+    requestFullRescore();
+    requestFullRescore();
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('full');
+
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    await runEmptyCycle(2);
+    expect(getPostsQueryMode()).toBe('incremental');
+  });
+
   it('keeps a full-rescore request pending when the attempted run fails', async () => {
     await runEmptyCycle(2);
     requestFullRescore();

--- a/tests/scoring-pipeline-rescore.test.ts
+++ b/tests/scoring-pipeline-rescore.test.ts
@@ -9,6 +9,8 @@ const {
   pipelineExecMock,
   getCurrentContentRulesMock,
   hasActiveContentRulesMock,
+  invalidateContentRulesCacheMock,
+  invalidateGovernanceGateCacheMock,
   updateScoringStatusMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
@@ -19,6 +21,8 @@ const {
   pipelineExecMock: vi.fn(),
   getCurrentContentRulesMock: vi.fn(),
   hasActiveContentRulesMock: vi.fn(),
+  invalidateContentRulesCacheMock: vi.fn(),
+  invalidateGovernanceGateCacheMock: vi.fn(),
   updateScoringStatusMock: vi.fn(),
 }));
 
@@ -43,6 +47,11 @@ vi.mock('../src/governance/content-filter.js', () => ({
   getCurrentContentRules: getCurrentContentRulesMock,
   hasActiveContentRules: hasActiveContentRulesMock,
   filterPosts: vi.fn(),
+  invalidateContentRulesCache: invalidateContentRulesCacheMock,
+}));
+
+vi.mock('../src/ingestion/governance-gate.js', () => ({
+  invalidateGovernanceGateCache: invalidateGovernanceGateCacheMock,
 }));
 
 vi.mock('../src/admin/status-tracker.js', () => ({
@@ -75,6 +84,8 @@ function setupDefaultMocks() {
     excludeKeywords: [],
   });
   hasActiveContentRulesMock.mockReturnValue(false);
+  invalidateContentRulesCacheMock.mockResolvedValue(undefined);
+  invalidateGovernanceGateCacheMock.mockResolvedValue(undefined);
   updateScoringStatusMock.mockResolvedValue(undefined);
 }
 
@@ -320,5 +331,74 @@ describe('periodic full rescore for recency decay', () => {
     setupDefaultMocks();
     await runEmptyCycle();
     expect(getPostsQueryMode()).toBe('full');
+  });
+
+  it('keeps a durable policy rescore pending when cache invalidation fails', async () => {
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    dbQueryMock
+      .mockResolvedValueOnce({
+        rows: [{ ...makeEpochRow(2), pending_rescore_generation: '4' }],
+      });
+    invalidateContentRulesCacheMock.mockRejectedValueOnce(new Error('cache invalidation failed'));
+
+    await expect(runScoringPipeline()).rejects.toThrow('cache invalidation failed');
+    expect(getCurrentContentRulesMock).not.toHaveBeenCalled();
+    expect(
+      dbQueryMock.mock.calls.some(([sql]) => String(sql).includes('UPDATE governance_rescore_requests'))
+    ).toBe(false);
+
+    dbQueryMock.mockReset();
+    vi.clearAllMocks();
+    setupDefaultMocks();
+    dbQueryMock
+      .mockResolvedValueOnce({
+        rows: [{ ...makeEpochRow(2), pending_rescore_generation: '4' }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await runScoringPipeline();
+
+    expect(getPostsQueryMode()).toBe('full');
+    expect(invalidateContentRulesCacheMock).toHaveBeenCalledTimes(1);
+    expect(invalidateGovernanceGateCacheMock).toHaveBeenCalledTimes(1);
+    expect(
+      dbQueryMock.mock.calls.some(([sql]) => String(sql).includes('UPDATE governance_rescore_requests'))
+    ).toBe(false);
+  });
+
+  it('completes only the durable generation observed by a published run', async () => {
+    dbQueryMock.mockReset();
+    setupDefaultMocks();
+    dbQueryMock
+      .mockResolvedValueOnce({
+        rows: [{ ...makeEpochRow(2), pending_rescore_generation: '4' }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          post_uri: 'at://did:plc:author/app.bsky.feed.post/1',
+          total_score: 0.8,
+          author_did: 'did:plc:author',
+          bridging_score: 0.5,
+          engagement_score: 0.4,
+          embed_url: null,
+          text_length: 120,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ requested_generation: '5' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await runScoringPipeline();
+
+    const completion = dbQueryMock.mock.calls.find(
+      ([sql]) => String(sql).includes('UPDATE governance_rescore_requests')
+    );
+    expect(completion?.[1]).toEqual([2, 4]);
+    expect(invalidateContentRulesCacheMock).toHaveBeenCalledTimes(1);
+    expect(invalidateGovernanceGateCacheMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/scoring-source-diversity-determinism.test.ts
+++ b/tests/scoring-source-diversity-determinism.test.ts
@@ -14,6 +14,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  clientReleaseMock,
   redisPipelineFactoryMock,
   pipelineDelMock,
   pipelineZaddMock,
@@ -26,6 +29,9 @@ const {
   configMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   redisPipelineFactoryMock: vi.fn(),
   pipelineDelMock: vi.fn(),
   pipelineZaddMock: vi.fn(),
@@ -51,7 +57,9 @@ const {
   },
 }));
 
-vi.mock('../src/db/client.js', () => ({ db: { query: dbQueryMock } }));
+vi.mock('../src/db/client.js', () => ({
+  db: { query: dbQueryMock, connect: dbConnectMock },
+}));
 vi.mock('../src/db/redis.js', () => ({
   redis: {
     pipeline: redisPipelineFactoryMock,
@@ -98,6 +106,14 @@ function sourceDiversityByUri(): Map<string, number> {
  * B first. Everything else returns empty.
  */
 function installMock() {
+  clientQueryMock.mockImplementation((sql: string) => {
+    if (sql.includes('pending_rescore_generation')) {
+      return Promise.resolve({ rows: [{ pending_rescore_generation: null }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  dbConnectMock.mockResolvedValue({ query: clientQueryMock, release: clientReleaseMock });
+
   const engagerDelayMs: Record<string, number> = { [URI_A]: 60, [URI_B]: 5, [URI_C]: 30 };
   dbQueryMock.mockImplementation(async (sql: unknown, params?: unknown[]) => {
     const text = String(sql);

--- a/tests/startup-checks-migrations.test.ts
+++ b/tests/startup-checks-migrations.test.ts
@@ -34,20 +34,20 @@ describe('startup migration checks', () => {
     redisPingMock.mockResolvedValue('PONG');
   });
 
-  it('fails startup checks when latest migration is below 014', async () => {
+  it('fails startup checks when latest migration is below 034', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // checkPostgres
       .mockResolvedValueOnce({ rows: [{ max_migration: 1 }] }); // checkMigrationVersion
 
     await expect(runStartupChecks()).rejects.toThrow(
-      /Migration startup check failed: database migrations are behind \(max=1, required=14\)/
+      /Migration startup check failed: database migrations are behind \(max=1, required=34\)/
     );
   });
 
-  it('passes startup checks when latest migration is 014', async () => {
+  it('passes startup checks when latest migration is 034', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // checkPostgres
-      .mockResolvedValueOnce({ rows: [{ max_migration: 14 }] }); // checkMigrationVersion
+      .mockResolvedValueOnce({ rows: [{ max_migration: 34 }] }); // checkMigrationVersion
 
     await expect(runStartupChecks()).resolves.toBeUndefined();
     expect(redisPingMock).toHaveBeenCalledTimes(1);

--- a/tests/startup-checks-migrations.test.ts
+++ b/tests/startup-checks-migrations.test.ts
@@ -44,6 +44,16 @@ describe('startup migration checks', () => {
     );
   });
 
+  it('fails startup checks when latest migration is one below 034', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [{ ok: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ max_migration: 33 }] });
+
+    await expect(runStartupChecks()).rejects.toThrow(
+      /Migration startup check failed: database migrations are behind \(max=33, required=34\)/
+    );
+  });
+
   it('passes startup checks when latest migration is 034', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // checkPostgres

--- a/tests/startup-checks-migrations.test.ts
+++ b/tests/startup-checks-migrations.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
 
 const { dbQueryMock, redisPingMock } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
@@ -61,5 +62,19 @@ describe('startup migration checks', () => {
 
     await expect(runStartupChecks()).resolves.toBeUndefined();
     expect(redisPingMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('migration 034 reconciles only active zero-ballot results and audits the repair', () => {
+    const migration = readFileSync(
+      new URL('../src/db/migrations/034_governance_proposed_topic_weights.sql', import.meta.url),
+      'utf8'
+    );
+
+    expect(migration).toContain("epoch.status = 'active'");
+    expect(migration).toContain("epoch.phase = 'results'");
+    expect(migration).toContain('NOT EXISTS');
+    expect(migration).toContain('FROM governance_votes vote');
+    expect(migration).toContain("SET phase = 'running'");
+    expect(migration).toContain("'migration_reconcile_zero_ballot_results'");
   });
 });

--- a/tests/topic-voting.test.ts
+++ b/tests/topic-voting.test.ts
@@ -44,7 +44,10 @@ vi.mock('../src/lib/logger.js', () => ({
 
 import { registerVoteRoute } from '../src/governance/routes/vote.js';
 import { registerTopicRoutes } from '../src/governance/routes/topics.js';
-import { parseStoredTopicWeights } from '../src/governance/topic-weights.js';
+import {
+  parseStoredProposedTopicWeights,
+  parseStoredTopicWeights,
+} from '../src/governance/topic-weights.js';
 
 interface TopicVoteEpoch {
   id: number;
@@ -217,6 +220,31 @@ describe('GET /api/governance/topics', () => {
 });
 
 describe('stored topic-weight policy parsing', () => {
+  it('returns a validated copy for a well-formed policy', () => {
+    const raw = { 'science-research': 0.5 };
+
+    const parsed = parseStoredTopicWeights(raw, 'test epoch');
+
+    expect(parsed).toEqual(raw);
+    expect(parsed).not.toBe(raw);
+  });
+
+  it('returns an empty active policy for null and undefined', () => {
+    expect(parseStoredTopicWeights(null, 'test epoch')).toEqual({});
+    expect(parseStoredTopicWeights(undefined, 'test epoch')).toEqual({});
+  });
+
+  it('preserves the null sentinel for a missing proposed policy', () => {
+    expect(parseStoredProposedTopicWeights(null, 'test epoch')).toBeNull();
+    expect(parseStoredProposedTopicWeights(undefined, 'test epoch')).toBeNull();
+  });
+
+  it('validates proposed policies with the same strict schema', () => {
+    expect(() => parseStoredProposedTopicWeights([0.5], 'test epoch')).toThrow(
+      'Invalid stored topic weights for test epoch'
+    );
+  });
+
   it.each([
     ['primitive', 'science'],
     ['array', [0.5]],

--- a/tests/topic-voting.test.ts
+++ b/tests/topic-voting.test.ts
@@ -9,14 +9,17 @@ import Fastify from 'fastify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // --- Mocks (vi.hoisted runs before imports) ---
-const { dbQueryMock, getAuthenticatedDidMock } = vi.hoisted(() => ({
+const { dbQueryMock, dbConnectMock, clientReleaseMock, getAuthenticatedDidMock } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   getAuthenticatedDidMock: vi.fn(),
 }));
 
 vi.mock('../src/db/client.js', () => ({
   db: {
     query: dbQueryMock,
+    connect: dbConnectMock,
   },
 }));
 
@@ -94,6 +97,11 @@ function setupDbMock(opts?: {
     : initialEpoch.voting_ends_at;
   const guardedEpochOpen = effectiveGuardedDeadline === null
     || Date.parse(effectiveGuardedDeadline) > Date.parse(DATABASE_NOW);
+
+  dbConnectMock.mockResolvedValue({
+    query: dbQueryMock,
+    release: clientReleaseMock,
+  });
 
   dbQueryMock.mockImplementation((sql: string, _params?: unknown[]) => {
     // Subscriber check
@@ -245,6 +253,22 @@ describe('stored topic-weight policy parsing', () => {
     );
   });
 
+  it('accepts exact zero and one topic-policy boundaries', () => {
+    expect(parseStoredTopicWeights({
+      'science-research': 0,
+      'software-development': 1,
+    }, 'test epoch')).toEqual({
+      'science-research': 0,
+      'software-development': 1,
+    });
+  });
+
+  it('rejects a negative stored topic-policy value', () => {
+    expect(() => parseStoredTopicWeights({ 'science-research': -0.01 }, 'test epoch')).toThrow(
+      'Invalid stored topic weights for test epoch'
+    );
+  });
+
   it.each([
     ['primitive', 'science'],
     ['array', [0.5]],
@@ -298,6 +322,47 @@ describe('POST /api/governance/vote (topic_weights)', () => {
     expect(response.statusCode).toBe(200);
     const body = response.json();
     expect(body.topicWeights).toEqual({ 'software-development': 0.9, 'dogs-pets': 0.4 });
+    expect(dbQueryMock.mock.calls.some(([sql]) => String(sql) === 'BEGIN')).toBe(true);
+    expect(dbQueryMock.mock.calls.some(([sql]) => String(sql) === 'COMMIT')).toBe(true);
+    expect(clientReleaseMock).toHaveBeenCalledTimes(1);
+
+    await app.close();
+  });
+
+  it('rolls back the wide ballot when normalized component storage fails', async () => {
+    getAuthenticatedDidMock.mockResolvedValue('did:plc:voter');
+    setupDbMock();
+    const baseImplementation = dbQueryMock.getMockImplementation();
+    dbQueryMock.mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes('INSERT INTO governance_vote_weights')) {
+        return Promise.reject(new Error('normalized vote storage unavailable'));
+      }
+      if (!baseImplementation) {
+        throw new Error('Expected base database mock implementation');
+      }
+      return baseImplementation(sql, params);
+    });
+
+    const app = Fastify();
+    registerVoteRoute(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/governance/vote',
+      payload: {
+        recency_weight: 0.2,
+        engagement_weight: 0.2,
+        bridging_weight: 0.2,
+        source_diversity_weight: 0.2,
+        relevance_weight: 0.2,
+      },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toMatchObject({ error: 'VoteFailed' });
+    expect(dbQueryMock.mock.calls.some(([sql]) => String(sql) === 'ROLLBACK')).toBe(true);
+    expect(dbQueryMock.mock.calls.some(([sql]) => String(sql) === 'COMMIT')).toBe(false);
+    expect(clientReleaseMock).toHaveBeenCalledTimes(1);
 
     await app.close();
   });
@@ -319,6 +384,7 @@ describe('POST /api/governance/vote (topic_weights)', () => {
 
     expect(response.statusCode).toBe(409);
     expect(response.json()).toMatchObject({ error: 'VotingClosed' });
+    expect(dbQueryMock.mock.calls.some(([sql]) => String(sql) === 'ROLLBACK')).toBe(true);
 
     await app.close();
   });

--- a/tests/topic-voting.test.ts
+++ b/tests/topic-voting.test.ts
@@ -49,6 +49,7 @@ const ACTIVE_EPOCH = {
   id: 5,
   status: 'voting',
   phase: 'voting',
+  voting_ends_at: '2099-01-01T00:00:00.000Z',
   topic_weights: { 'software-development': 0.7, 'dogs-pets': 0.4 },
 };
 
@@ -65,8 +66,9 @@ const ACTIVE_TOPICS = [
 function setupDbMock(opts?: {
   hasSubscriber?: boolean;
   hasExistingVote?: boolean;
+  closesBeforeInsert?: boolean;
 }): void {
-  const { hasSubscriber = true, hasExistingVote = false } = opts ?? {};
+  const { hasSubscriber = true, hasExistingVote = false, closesBeforeInsert = false } = opts ?? {};
 
   dbQueryMock.mockImplementation((sql: string, _params?: unknown[]) => {
     // Subscriber check
@@ -74,6 +76,10 @@ function setupDbMock(opts?: {
       return Promise.resolve({
         rows: hasSubscriber ? [{ did: 'did:plc:voter' }] : [],
       });
+    }
+    // Atomic vote insert locks the still-open epoch in the same statement.
+    if (sql.includes('WITH open_epoch')) {
+      return Promise.resolve({ rows: closesBeforeInsert ? [] : [{ id: 1, is_new_vote: true }] });
     }
     // Active epoch for voting
     if (sql.includes('governance_epochs') && sql.includes('status')) {
@@ -225,6 +231,27 @@ describe('POST /api/governance/vote (topic_weights)', () => {
     expect(response.statusCode).toBe(200);
     const body = response.json();
     expect(body.topicWeights).toEqual({ 'software-development': 0.9, 'dogs-pets': 0.4 });
+
+    await app.close();
+  });
+
+  it('rejects a ballot when voting closes between the initial check and atomic insert', async () => {
+    getAuthenticatedDidMock.mockResolvedValue('did:plc:voter');
+    setupDbMock({ closesBeforeInsert: true });
+
+    const app = Fastify();
+    registerVoteRoute(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/governance/vote',
+      payload: {
+        topic_weights: { 'software-development': 0.9 },
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'VotingClosed' });
 
     await app.close();
   });

--- a/tests/topic-voting.test.ts
+++ b/tests/topic-voting.test.ts
@@ -67,8 +67,14 @@ function setupDbMock(opts?: {
   hasSubscriber?: boolean;
   hasExistingVote?: boolean;
   closesBeforeInsert?: boolean;
+  initialEpoch?: typeof ACTIVE_EPOCH;
 }): void {
-  const { hasSubscriber = true, hasExistingVote = false, closesBeforeInsert = false } = opts ?? {};
+  const {
+    hasSubscriber = true,
+    hasExistingVote = false,
+    closesBeforeInsert = false,
+    initialEpoch = ACTIVE_EPOCH,
+  } = opts ?? {};
 
   dbQueryMock.mockImplementation((sql: string, _params?: unknown[]) => {
     // Subscriber check
@@ -79,11 +85,15 @@ function setupDbMock(opts?: {
     }
     // Atomic vote insert locks the still-open epoch in the same statement.
     if (sql.includes('WITH open_epoch')) {
+      expect(sql).toContain("AND status IN ('active', 'voting')");
+      expect(sql).toContain("AND phase = 'voting'");
+      expect(sql).toContain('AND (voting_ends_at IS NULL OR voting_ends_at > NOW())');
+      expect(sql).toContain('FOR SHARE');
       return Promise.resolve({ rows: closesBeforeInsert ? [] : [{ id: 1, is_new_vote: true }] });
     }
     // Active epoch for voting
     if (sql.includes('governance_epochs') && sql.includes('status')) {
-      return Promise.resolve({ rows: [ACTIVE_EPOCH] });
+      return Promise.resolve({ rows: [initialEpoch] });
     }
     // Topic catalog slug validation
     if (sql.includes('topic_catalog') && sql.includes('is_active')) {
@@ -252,6 +262,34 @@ describe('POST /api/governance/vote (topic_weights)', () => {
 
     expect(response.statusCode).toBe(409);
     expect(response.json()).toMatchObject({ error: 'VotingClosed' });
+
+    await app.close();
+  });
+
+  it('uses the database deadline when an expired voting window reaches the guarded insert', async () => {
+    getAuthenticatedDidMock.mockResolvedValue('did:plc:voter');
+    setupDbMock({
+      closesBeforeInsert: true,
+      initialEpoch: {
+        ...ACTIVE_EPOCH,
+        voting_ends_at: '2020-01-01T00:00:00.000Z',
+      },
+    });
+
+    const app = Fastify();
+    registerVoteRoute(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/governance/vote',
+      payload: {
+        topic_weights: { 'software-development': 0.9 },
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'VotingClosed' });
+    expect(dbQueryMock.mock.calls.some(([sql]) => String(sql).includes('WITH open_epoch'))).toBe(true);
 
     await app.close();
   });

--- a/tests/topic-voting.test.ts
+++ b/tests/topic-voting.test.ts
@@ -44,8 +44,19 @@ vi.mock('../src/lib/logger.js', () => ({
 
 import { registerVoteRoute } from '../src/governance/routes/vote.js';
 import { registerTopicRoutes } from '../src/governance/routes/topics.js';
+import { parseStoredTopicWeights } from '../src/governance/topic-weights.js';
 
-const ACTIVE_EPOCH = {
+interface TopicVoteEpoch {
+  id: number;
+  status: string;
+  phase: string;
+  voting_ends_at: string | null;
+  topic_weights: Record<string, number>;
+}
+
+const DATABASE_NOW = '2026-07-12T12:00:00.000Z';
+
+const ACTIVE_EPOCH: TopicVoteEpoch = {
   id: 5,
   status: 'voting',
   phase: 'voting',
@@ -66,15 +77,20 @@ const ACTIVE_TOPICS = [
 function setupDbMock(opts?: {
   hasSubscriber?: boolean;
   hasExistingVote?: boolean;
-  closesBeforeInsert?: boolean;
-  initialEpoch?: typeof ACTIVE_EPOCH;
+  guardedVotingEndsAt?: string | null;
+  initialEpoch?: TopicVoteEpoch;
 }): void {
   const {
     hasSubscriber = true,
     hasExistingVote = false,
-    closesBeforeInsert = false,
+    guardedVotingEndsAt,
     initialEpoch = ACTIVE_EPOCH,
   } = opts ?? {};
+  const effectiveGuardedDeadline = opts && 'guardedVotingEndsAt' in opts
+    ? guardedVotingEndsAt ?? null
+    : initialEpoch.voting_ends_at;
+  const guardedEpochOpen = effectiveGuardedDeadline === null
+    || Date.parse(effectiveGuardedDeadline) > Date.parse(DATABASE_NOW);
 
   dbQueryMock.mockImplementation((sql: string, _params?: unknown[]) => {
     // Subscriber check
@@ -89,7 +105,7 @@ function setupDbMock(opts?: {
       expect(sql).toContain("AND phase = 'voting'");
       expect(sql).toContain('AND (voting_ends_at IS NULL OR voting_ends_at > NOW())');
       expect(sql).toContain('FOR SHARE');
-      return Promise.resolve({ rows: closesBeforeInsert ? [] : [{ id: 1, is_new_vote: true }] });
+      return Promise.resolve({ rows: guardedEpochOpen ? [{ id: 1, is_new_vote: true }] : [] });
     }
     // Active epoch for voting
     if (sql.includes('governance_epochs') && sql.includes('status')) {
@@ -200,6 +216,19 @@ describe('GET /api/governance/topics', () => {
   });
 });
 
+describe('stored topic-weight policy parsing', () => {
+  it.each([
+    ['primitive', 'science'],
+    ['array', [0.5]],
+    ['out-of-range value', { 'science-research': 1.1 }],
+    ['mixed valid and invalid values', { 'science-research': 0.8, 'software-development': 'high' }],
+  ])('rejects a malformed %s policy without keeping partial values', (_label, raw) => {
+    expect(() => parseStoredTopicWeights(raw, 'test epoch')).toThrow(
+      'Invalid stored topic weights for test epoch'
+    );
+  });
+});
+
 describe('POST /api/governance/vote (topic_weights)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -247,7 +276,7 @@ describe('POST /api/governance/vote (topic_weights)', () => {
 
   it('rejects a ballot when voting closes between the initial check and atomic insert', async () => {
     getAuthenticatedDidMock.mockResolvedValue('did:plc:voter');
-    setupDbMock({ closesBeforeInsert: true });
+    setupDbMock({ guardedVotingEndsAt: DATABASE_NOW });
 
     const app = Fastify();
     registerVoteRoute(app);
@@ -269,7 +298,6 @@ describe('POST /api/governance/vote (topic_weights)', () => {
   it('uses the database deadline when an expired voting window reaches the guarded insert', async () => {
     getAuthenticatedDidMock.mockResolvedValue('did:plc:voter');
     setupDbMock({
-      closesBeforeInsert: true,
       initialEpoch: {
         ...ACTIVE_EPOCH,
         voting_ends_at: '2020-01-01T00:00:00.000Z',
@@ -291,6 +319,55 @@ describe('POST /api/governance/vote (topic_weights)', () => {
     expect(response.json()).toMatchObject({ error: 'VotingClosed' });
     expect(dbQueryMock.mock.calls.some(([sql]) => String(sql).includes('WITH open_epoch'))).toBe(true);
 
+    await app.close();
+  });
+
+  it('accepts a vote when the guarded voting deadline is open-ended', async () => {
+    getAuthenticatedDidMock.mockResolvedValue('did:plc:voter');
+    setupDbMock({
+      initialEpoch: {
+        ...ACTIVE_EPOCH,
+        voting_ends_at: null,
+      },
+    });
+
+    const app = Fastify();
+    registerVoteRoute(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/governance/vote',
+      payload: {
+        topic_weights: { 'software-development': 0.9 },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it('rejects a vote at the exact database deadline boundary', async () => {
+    getAuthenticatedDidMock.mockResolvedValue('did:plc:voter');
+    setupDbMock({
+      initialEpoch: {
+        ...ACTIVE_EPOCH,
+        voting_ends_at: DATABASE_NOW,
+      },
+    });
+
+    const app = Fastify();
+    registerVoteRoute(app);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/governance/vote',
+      payload: {
+        topic_weights: { 'software-development': 0.9 },
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'VotingClosed' });
     await app.close();
   });
 

--- a/tests/url-dedup.test.ts
+++ b/tests/url-dedup.test.ts
@@ -10,6 +10,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
+  dbConnectMock,
+  clientQueryMock,
+  clientReleaseMock,
   redisPipelineFactoryMock,
   pipelineDelMock,
   pipelineZaddMock,
@@ -20,6 +23,9 @@ const {
   updateScoringStatusMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   redisPipelineFactoryMock: vi.fn(),
   pipelineDelMock: vi.fn(),
   pipelineZaddMock: vi.fn(),
@@ -33,6 +39,7 @@ const {
 vi.mock('../src/db/client.js', () => ({
   db: {
     query: dbQueryMock,
+    connect: dbConnectMock,
   },
 }));
 
@@ -74,6 +81,13 @@ function setupDefaultMocks() {
     exec: pipelineExecMock.mockResolvedValue([]),
   };
   redisPipelineFactoryMock.mockReturnValue(pipeline);
+  clientQueryMock.mockImplementation((sql: string) => {
+    if (sql.includes('pending_rescore_generation')) {
+      return Promise.resolve({ rows: [{ pending_rescore_generation: null }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  dbConnectMock.mockResolvedValue({ query: clientQueryMock, release: clientReleaseMock });
 
   getCurrentContentRulesMock.mockResolvedValue({
     includeKeywords: [],

--- a/tests/votable-params-record-shape.test.ts
+++ b/tests/votable-params-record-shape.test.ts
@@ -11,16 +11,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   dbQueryMock,
+  dbConnectMock,
+  clientReleaseMock,
   getAuthenticatedDidMock,
   isParticipantApprovedMock,
 } = vi.hoisted(() => ({
   dbQueryMock: vi.fn(),
+  dbConnectMock: vi.fn(),
+  clientReleaseMock: vi.fn(),
   getAuthenticatedDidMock: vi.fn(),
   isParticipantApprovedMock: vi.fn(),
 }));
 
 vi.mock('../src/db/client.js', () => ({
-  db: { query: dbQueryMock },
+  db: { query: dbQueryMock, connect: dbConnectMock },
 }));
 
 vi.mock('../src/governance/auth.js', () => ({
@@ -90,6 +94,7 @@ describe('votable-params record shape (PROJ-816)', () => {
     vi.clearAllMocks();
     getAuthenticatedDidMock.mockResolvedValue('did:plc:alice');
     isParticipantApprovedMock.mockResolvedValue(true);
+    dbConnectMock.mockResolvedValue({ query: dbQueryMock, release: clientReleaseMock });
     // Active subscriber + active voting epoch.
     dbQueryMock.mockImplementation(async (sql: unknown) => {
       const text = String(sql);


### PR DESCRIPTION
# Pull Request

## Summary

Makes the production governance lifecycle match the product truth required by PROJ-1818: voting closes into review, an operator approves the complete policy, and the scorer durably performs a full same-epoch rescore.

## Changes

- aggregate signal weights, topic weights, and adopted content rules into reviewable proposals
- require results review before either approval endpoint can apply policy
- apply all three policy channels and enqueue their rescore atomically
- retry durable rescore generations across lock contention, failed runs, cache invalidation failures, unpublished runs, and in-flight changes
- disable direct and forced transition routes that bypass results review
- reject zero-ballot approvals and reconcile the existing empty results state without manufacturing a vote
- store ballot wide rows, normalized component rows, and audit records in one transaction
- fence every feed publication against concurrent governance policy changes
- publish policy rescoring output only from the current scoring run so excluded or stale rows cannot re-enter
- fail closed on cache invalidation and malformed persisted policy data in durability-sensitive paths
- add migration and regression coverage for the complete lifecycle

## Verification

- focused lifecycle/scoring suite: 18 files, 204 tests passed
- full backend suite: 149 files, 1,644 tests passed
- `npm run verify`: passed; backend, CLI, SDK, legacy web, and `web-next` builds completed
- `npm run docs:verify`: passed
- `web-next`: lint, TypeScript check, and production export passed; this branch has no `test` script
- disposable Testcontainers preflight: PostgreSQL 16 and Redis 7 started, migrations 001 through 034 applied successfully
- staged path lease validation: passed with zero blockers
- current-head GitHub CI and CodeRabbit: pending

## Review Resolution

- delayed CodeRabbit findings were implemented on `00ad638`; the temporary timeout exemption was invalidated and removed before merge
- policy cache invalidation intentionally remains in the durable scoring worker, which invalidates content-rules and governance-gate caches before reading a pending generation; route-side invalidation would weaken retry semantics after a committed policy update
- current hardening closes independently identified publication, transition-bypass, zero-ballot, and dual-write races
- tests prove unpublished full passes retain the pending generation and malformed stored policy values return bounded errors

## Checklist

- [x] Tests added/updated and full verification passes
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docs verification passes
- [x] Single-purpose change; no unrelated churn
- [x] No secrets, internal infrastructure, or private URLs introduced

Linear: PROJ-1818