### PR TITLE
[PROJ-1821] Make anonymous session probe console-clean

### DIFF
--- a/docs/docs-site/openapi.json
+++ b/docs/docs-site/openapi.json
@@ -622,14 +622,15 @@
         "tags": [
           "Auth"
         ],
-        "description": "Returns the authenticated user's session info. Requires a valid session cookie or bearer token.",
+        "description": "Returns the current browser session state. Anonymous callers receive authenticated=false.",
         "security": [
           {
             "cookieAuth": []
           },
           {
             "bearerAuth": []
-          }
+          },
+          {}
         ],
         "responses": {
           "200": {
@@ -637,61 +638,57 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "authenticated": {
-                      "type": "boolean",
-                      "example": true
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "authenticated": {
+                          "type": "boolean",
+                          "example": false,
+                          "enum": [
+                            false
+                          ]
+                        }
+                      },
+                      "required": [
+                        "authenticated"
+                      ],
+                      "additionalProperties": false
                     },
-                    "did": {
-                      "type": "string",
-                      "description": "Authenticated user DID",
-                      "example": "did:plc:abc123"
-                    },
-                    "handle": {
-                      "type": "string",
-                      "description": "Bluesky handle",
-                      "example": "alice.bsky.social"
-                    },
-                    "expiresAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Session expiration timestamp"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "authenticated": {
+                          "type": "boolean",
+                          "example": true,
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "did": {
+                          "type": "string",
+                          "description": "Authenticated user DID",
+                          "example": "did:plc:abc123"
+                        },
+                        "handle": {
+                          "type": "string",
+                          "description": "Bluesky handle",
+                          "example": "alice.bsky.social"
+                        },
+                        "expiresAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Session expiration timestamp"
+                        }
+                      },
+                      "required": [
+                        "authenticated",
+                        "did",
+                        "handle",
+                        "expiresAt"
+                      ],
+                      "additionalProperties": false
                     }
-                  },
-                  "required": [
-                    "authenticated",
-                    "did",
-                    "handle",
-                    "expiresAt"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "description": "Error code (e.g. \"ValidationError\", \"NotFound\")"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "Human-readable error message"
-                    },
-                    "correlationId": {
-                      "type": "string",
-                      "description": "Request correlation ID for debugging"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
                   ]
                 }
               }

--- a/docs/openapi-public.json
+++ b/docs/openapi-public.json
@@ -622,14 +622,15 @@
         "tags": [
           "Auth"
         ],
-        "description": "Returns the authenticated user's session info. Requires a valid session cookie or bearer token.",
+        "description": "Returns the current browser session state. Anonymous callers receive authenticated=false.",
         "security": [
           {
             "cookieAuth": []
           },
           {
             "bearerAuth": []
-          }
+          },
+          {}
         ],
         "responses": {
           "200": {
@@ -637,61 +638,57 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "authenticated": {
-                      "type": "boolean",
-                      "example": true
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "authenticated": {
+                          "type": "boolean",
+                          "example": false,
+                          "enum": [
+                            false
+                          ]
+                        }
+                      },
+                      "required": [
+                        "authenticated"
+                      ],
+                      "additionalProperties": false
                     },
-                    "did": {
-                      "type": "string",
-                      "description": "Authenticated user DID",
-                      "example": "did:plc:abc123"
-                    },
-                    "handle": {
-                      "type": "string",
-                      "description": "Bluesky handle",
-                      "example": "alice.bsky.social"
-                    },
-                    "expiresAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Session expiration timestamp"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "authenticated": {
+                          "type": "boolean",
+                          "example": true,
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "did": {
+                          "type": "string",
+                          "description": "Authenticated user DID",
+                          "example": "did:plc:abc123"
+                        },
+                        "handle": {
+                          "type": "string",
+                          "description": "Bluesky handle",
+                          "example": "alice.bsky.social"
+                        },
+                        "expiresAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Session expiration timestamp"
+                        }
+                      },
+                      "required": [
+                        "authenticated",
+                        "did",
+                        "handle",
+                        "expiresAt"
+                      ],
+                      "additionalProperties": false
                     }
-                  },
-                  "required": [
-                    "authenticated",
-                    "did",
-                    "handle",
-                    "expiresAt"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "description": "Error code (e.g. \"ValidationError\", \"NotFound\")"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "Human-readable error message"
-                    },
-                    "correlationId": {
-                      "type": "string",
-                      "description": "Request correlation ID for debugging"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
                   ]
                 }
               }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -622,14 +622,15 @@
         "tags": [
           "Auth"
         ],
-        "description": "Returns the authenticated user's session info. Requires a valid session cookie or bearer token.",
+        "description": "Returns the current browser session state. Anonymous callers receive authenticated=false.",
         "security": [
           {
             "cookieAuth": []
           },
           {
             "bearerAuth": []
-          }
+          },
+          {}
         ],
         "responses": {
           "200": {
@@ -637,61 +638,57 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "authenticated": {
-                      "type": "boolean",
-                      "example": true
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "authenticated": {
+                          "type": "boolean",
+                          "example": false,
+                          "enum": [
+                            false
+                          ]
+                        }
+                      },
+                      "required": [
+                        "authenticated"
+                      ],
+                      "additionalProperties": false
                     },
-                    "did": {
-                      "type": "string",
-                      "description": "Authenticated user DID",
-                      "example": "did:plc:abc123"
-                    },
-                    "handle": {
-                      "type": "string",
-                      "description": "Bluesky handle",
-                      "example": "alice.bsky.social"
-                    },
-                    "expiresAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Session expiration timestamp"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "authenticated": {
+                          "type": "boolean",
+                          "example": true,
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "did": {
+                          "type": "string",
+                          "description": "Authenticated user DID",
+                          "example": "did:plc:abc123"
+                        },
+                        "handle": {
+                          "type": "string",
+                          "description": "Bluesky handle",
+                          "example": "alice.bsky.social"
+                        },
+                        "expiresAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Session expiration timestamp"
+                        }
+                      },
+                      "required": [
+                        "authenticated",
+                        "did",
+                        "handle",
+                        "expiresAt"
+                      ],
+                      "additionalProperties": false
                     }
-                  },
-                  "required": [
-                    "authenticated",
-                    "did",
-                    "handle",
-                    "expiresAt"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "description": "Error code (e.g. \"ValidationError\", \"NotFound\")"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "Human-readable error message"
-                    },
-                    "correlationId": {
-                      "type": "string",
-                      "description": "Request correlation ID for debugging"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
                   ]
                 }
               }

--- a/src/governance/routes/auth.ts
+++ b/src/governance/routes/auth.ts
@@ -198,20 +198,32 @@ export function registerAuthRoute(app: FastifyInstance): void {
     schema: {
       tags: ['Auth'],
       summary: 'Get current session',
-      description: 'Returns the authenticated user\'s session info. Requires a valid session cookie or bearer token.',
-      security: governanceSecurity,
+      description: 'Returns the current browser session state. Anonymous callers receive authenticated=false.',
+      security: [...governanceSecurity, {}],
       response: {
         200: {
-          type: 'object',
-          properties: {
-            authenticated: { type: 'boolean', example: true },
-            did: { type: 'string', description: 'Authenticated user DID', example: 'did:plc:abc123' },
-            handle: { type: 'string', description: 'Bluesky handle', example: 'alice.bsky.social' },
-            expiresAt: { type: 'string', format: 'date-time', description: 'Session expiration timestamp' },
-          },
-          required: ['authenticated', 'did', 'handle', 'expiresAt'],
+          oneOf: [
+            {
+              type: 'object',
+              properties: {
+                authenticated: { type: 'boolean', const: false, example: false },
+              },
+              required: ['authenticated'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: {
+                authenticated: { type: 'boolean', const: true, example: true },
+                did: { type: 'string', description: 'Authenticated user DID', example: 'did:plc:abc123' },
+                handle: { type: 'string', description: 'Bluesky handle', example: 'alice.bsky.social' },
+                expiresAt: { type: 'string', format: 'date-time', description: 'Session expiration timestamp' },
+              },
+              required: ['authenticated', 'did', 'handle', 'expiresAt'],
+              additionalProperties: false,
+            },
+          ],
         },
-        401: ErrorResponseSchema,
         503: ErrorResponseSchema,
       },
     },
@@ -230,10 +242,7 @@ export function registerAuthRoute(app: FastifyInstance): void {
     }
 
     if (!session) {
-      return reply.code(401).send({
-        error: 'NotAuthenticated',
-        message: 'No valid session found',
-      });
+      return reply.send({ authenticated: false });
     }
 
     return reply.send({

--- a/tests/governance-auth-cookie.test.ts
+++ b/tests/governance-auth-cookie.test.ts
@@ -125,6 +125,28 @@ describe('governance auth cookie flow', () => {
     await app.close();
   });
 
+  it('returns an anonymous session state when the cookie token is stale', async () => {
+    getSessionByTokenMock.mockResolvedValueOnce(null);
+
+    const app = Fastify();
+    registerAuthRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/governance/auth/session',
+      headers: {
+        cookie: `${config.GOVERNANCE_SESSION_COOKIE_NAME}=stale-session-token`,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ authenticated: false });
+    expect(getSessionByTokenMock).toHaveBeenCalledTimes(1);
+    expect(getSessionByTokenMock).toHaveBeenCalledWith('stale-session-token');
+
+    await app.close();
+  });
+
   it('clears session cookie on logout and invalidates token', async () => {
     deleteSessionMock.mockResolvedValue(undefined);
 

--- a/tests/governance-auth-cookie.test.ts
+++ b/tests/governance-auth-cookie.test.ts
@@ -109,6 +109,22 @@ describe('governance auth cookie flow', () => {
     await app.close();
   });
 
+  it('returns an anonymous session state without an error status', async () => {
+    const app = Fastify();
+    registerAuthRoute(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/governance/auth/session',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ authenticated: false });
+    expect(getSessionByTokenMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
   it('clears session cookie on logout and invalidates token', async () => {
     deleteSessionMock.mockResolvedValue(undefined);
 

--- a/tests/web-next-auth-client.test.ts
+++ b/tests/web-next-auth-client.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { parseSessionResponse } from '../web-next/lib/api/client';
+
+describe('web-next auth session response contract', () => {
+  it('accepts the anonymous session response', () => {
+    expect(parseSessionResponse({ authenticated: false })).toEqual({
+      authenticated: false,
+    });
+  });
+
+  it('accepts a complete authenticated session response', () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+
+    expect(parseSessionResponse({
+      authenticated: true,
+      did: 'did:plc:alice',
+      handle: 'alice.bsky.social',
+      expiresAt,
+    })).toEqual({
+      authenticated: true,
+      did: 'did:plc:alice',
+      handle: 'alice.bsky.social',
+      expiresAt,
+    });
+  });
+
+  it('rejects an authenticated response without its required identity fields', () => {
+    expect(() => parseSessionResponse({ authenticated: true })).toThrow();
+  });
+});

--- a/tests/web-next-auth-client.test.ts
+++ b/tests/web-next-auth-client.test.ts
@@ -27,4 +27,47 @@ describe('web-next auth session response contract', () => {
   it('rejects an authenticated response without its required identity fields', () => {
     expect(() => parseSessionResponse({ authenticated: true })).toThrow();
   });
+
+  it('rejects an anonymous response with unexpected properties', () => {
+    expect(() => parseSessionResponse({
+      authenticated: false,
+      did: 'did:plc:alice',
+    })).toThrow();
+  });
+
+  it.each([
+    {
+      caseName: 'empty authenticated identity fields',
+      value: {
+        authenticated: true,
+        did: '',
+        handle: '',
+        expiresAt: '2026-07-14T05:00:00.000Z',
+      },
+    },
+    {
+      caseName: 'a malformed expiration timestamp',
+      value: {
+        authenticated: true,
+        did: 'did:plc:alice',
+        handle: 'alice.bsky.social',
+        expiresAt: 'not-a-date',
+      },
+    },
+    {
+      caseName: 'an expiration timestamp without an offset',
+      value: {
+        authenticated: true,
+        did: 'did:plc:alice',
+        handle: 'alice.bsky.social',
+        expiresAt: '2026-07-14T05:00:00.000',
+      },
+    },
+    {
+      caseName: 'a non-boolean authenticated discriminator',
+      value: { authenticated: 'true' },
+    },
+  ])('rejects $caseName', ({ value }) => {
+    expect(() => parseSessionResponse(value)).toThrow();
+  });
 });

--- a/tests/web-next-auth-client.test.ts
+++ b/tests/web-next-auth-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseSessionResponse } from '../web-next/lib/api/client';
+import { parseSessionResponse } from '../web-next/lib/api/session-contract';
 
 describe('web-next auth session response contract', () => {
   it('accepts the anonymous session response', () => {

--- a/web-next/components/auth-provider.tsx
+++ b/web-next/components/auth-provider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, type ReactNode } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { authApi, type SessionResponse } from "@/lib/api/client"
+import { authApi, type AuthenticatedSessionResponse } from "@/lib/api/client"
 import { AuthRequestCoordinator } from "@/lib/auth-request"
 
 /** Query key for the current session — invalidated after login/logout. */
@@ -10,7 +10,7 @@ export const SESSION_QUERY_KEY = ["auth", "session"] as const
 
 interface AuthContextValue {
   /** The live session, or null when unauthenticated / still resolving. */
-  session: SessionResponse | null
+  session: AuthenticatedSessionResponse | null
   /** True only when the backend confirms an authenticated session. */
   isAuthenticated: boolean
   /** True while the very first session probe is in flight. */
@@ -31,9 +31,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => () => loginRequests.current.cancel(), [])
 
-  // Auth state is derived ONLY from the session endpoint. When the user is not
-  // signed in, getSession() rejects (401) and `data` stays undefined — so we
-  // never retry that expected "not authenticated" answer.
+  // Auth state is derived ONLY from the session endpoint. Anonymous callers
+  // receive an explicit authenticated=false response without a failed request.
   const sessionQuery = useQuery({
     queryKey: SESSION_QUERY_KEY,
     queryFn: authApi.getSession,
@@ -70,8 +69,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     queryClient.clear()
   }, [queryClient])
 
-  const session = sessionQuery.data ?? null
-  const isAuthenticated = sessionQuery.data?.authenticated === true
+  const sessionResponse = sessionQuery.data
+  const session: AuthenticatedSessionResponse | null =
+    sessionResponse?.authenticated === true ? sessionResponse : null
+  const isAuthenticated = session !== null
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/web-next/e2e/production-hard-refresh.spec.ts
+++ b/web-next/e2e/production-hard-refresh.spec.ts
@@ -33,7 +33,6 @@ function collectBrowserErrors(page: Page): BrowserErrors {
   page.on("console", (message) => {
     if (message.type() === "error") {
       const location = message.location()
-      if (isExpectedLoggedOutSessionError(message.text(), location.url)) return
       const source = location.url === "" ? "unknown source" : `${location.url}:${location.lineNumber}`
       errors.console.push(`${message.text()} (${source})`)
     }
@@ -43,15 +42,6 @@ function collectBrowserErrors(page: Page): BrowserErrors {
   })
 
   return errors
-}
-
-function isExpectedLoggedOutSessionError(message: string, sourceUrl: string): boolean {
-  if (!message.includes("401 (Unauthorized)")) return false
-  try {
-    return new URL(sourceUrl).pathname === "/api/governance/auth/session"
-  } catch {
-    return false
-  }
 }
 
 async function isRouteVisible(page: Page, route: PublicRoute): Promise<boolean> {

--- a/web-next/lib/api/client.ts
+++ b/web-next/lib/api/client.ts
@@ -1,10 +1,22 @@
 import axios from 'axios';
-import { z } from 'zod';
 import type { GovernanceWeights } from './types';
+import {
+  parseSessionResponse,
+  type AnonymousSessionResponse,
+  type AuthenticatedSessionResponse,
+  type SessionResponse,
+} from './session-contract';
 import {
   waitlistJoinResponseSchema,
   type WaitlistJoinResponse,
 } from './waitlist-contract';
+
+export {
+  parseSessionResponse,
+  type AnonymousSessionResponse,
+  type AuthenticatedSessionResponse,
+  type SessionResponse,
+};
 
 // API base URL — same-origin relative by default (the Fastify backend serves
 // this build), overridable via NEXT_PUBLIC_API_URL for local dev against a
@@ -27,30 +39,6 @@ export interface LoginResponse {
   did: string;
   handle: string;
   expiresAt: string;
-}
-
-export const authenticatedSessionResponseSchema = z.object({
-  authenticated: z.literal(true),
-  did: z.string().min(1),
-  handle: z.string().min(1),
-  expiresAt: z.string().datetime({ offset: true }),
-}).strict();
-
-export const anonymousSessionResponseSchema = z.object({
-  authenticated: z.literal(false),
-}).strict();
-
-export const sessionResponseSchema = z.discriminatedUnion('authenticated', [
-  authenticatedSessionResponseSchema,
-  anonymousSessionResponseSchema,
-]);
-
-export type AuthenticatedSessionResponse = z.infer<typeof authenticatedSessionResponseSchema>;
-export type AnonymousSessionResponse = z.infer<typeof anonymousSessionResponseSchema>;
-export type SessionResponse = z.infer<typeof sessionResponseSchema>;
-
-export function parseSessionResponse(value: unknown): SessionResponse {
-  return sessionResponseSchema.parse(value);
 }
 
 // Auth API

--- a/web-next/lib/api/client.ts
+++ b/web-next/lib/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { z } from 'zod';
 import type { GovernanceWeights } from './types';
 import {
   waitlistJoinResponseSchema,
@@ -28,18 +29,29 @@ export interface LoginResponse {
   expiresAt: string;
 }
 
-export interface AuthenticatedSessionResponse {
-  authenticated: true;
-  did: string;
-  handle: string;
-  expiresAt: string;
-}
+export const authenticatedSessionResponseSchema = z.object({
+  authenticated: z.literal(true),
+  did: z.string().min(1),
+  handle: z.string().min(1),
+  expiresAt: z.string().datetime({ offset: true }),
+}).strict();
 
-export interface AnonymousSessionResponse {
-  authenticated: false;
-}
+export const anonymousSessionResponseSchema = z.object({
+  authenticated: z.literal(false),
+}).strict();
 
-export type SessionResponse = AuthenticatedSessionResponse | AnonymousSessionResponse;
+export const sessionResponseSchema = z.discriminatedUnion('authenticated', [
+  authenticatedSessionResponseSchema,
+  anonymousSessionResponseSchema,
+]);
+
+export type AuthenticatedSessionResponse = z.infer<typeof authenticatedSessionResponseSchema>;
+export type AnonymousSessionResponse = z.infer<typeof anonymousSessionResponseSchema>;
+export type SessionResponse = z.infer<typeof sessionResponseSchema>;
+
+export function parseSessionResponse(value: unknown): SessionResponse {
+  return sessionResponseSchema.parse(value);
+}
 
 // Auth API
 export const authApi = {
@@ -54,8 +66,8 @@ export const authApi = {
   },
 
   getSession: async (): Promise<SessionResponse> => {
-    const response = await api.get<SessionResponse>('/api/governance/auth/session');
-    return response.data;
+    const response = await api.get<unknown>('/api/governance/auth/session');
+    return parseSessionResponse(response.data);
   },
 
   logout: async (): Promise<void> => {

--- a/web-next/lib/api/client.ts
+++ b/web-next/lib/api/client.ts
@@ -28,12 +28,18 @@ export interface LoginResponse {
   expiresAt: string;
 }
 
-export interface SessionResponse {
-  authenticated: boolean;
+export interface AuthenticatedSessionResponse {
+  authenticated: true;
   did: string;
   handle: string;
   expiresAt: string;
 }
+
+export interface AnonymousSessionResponse {
+  authenticated: false;
+}
+
+export type SessionResponse = AuthenticatedSessionResponse | AnonymousSessionResponse;
 
 // Auth API
 export const authApi = {

--- a/web-next/lib/api/session-contract.ts
+++ b/web-next/lib/api/session-contract.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const authenticatedSessionResponseSchema = z.object({
+  authenticated: z.literal(true),
+  did: z.string().min(1),
+  handle: z.string().min(1),
+  expiresAt: z.string().datetime({ offset: true }),
+}).strict();
+
+export const anonymousSessionResponseSchema = z.object({
+  authenticated: z.literal(false),
+}).strict();
+
+export const sessionResponseSchema = z.discriminatedUnion('authenticated', [
+  authenticatedSessionResponseSchema,
+  anonymousSessionResponseSchema,
+]);
+
+export type AuthenticatedSessionResponse = z.infer<typeof authenticatedSessionResponseSchema>;
+export type AnonymousSessionResponse = z.infer<typeof anonymousSessionResponseSchema>;
+export type SessionResponse = z.infer<typeof sessionResponseSchema>;
+
+export function parseSessionResponse(value: unknown): SessionResponse {
+  return sessionResponseSchema.parse(value);
+}


### PR DESCRIPTION
## Summary

- Return a typed anonymous session state with HTTP 200 when the public site probes the governance session while logged out.
- Preserve the frontend's null unauthenticated session state without generating a browser-console 401.
- Remove the production hard-refresh test's suppression for the logged-out session error.
- Regenerate all tracked OpenAPI artifacts for the anonymous and authenticated session response variants.

## Production blocker

The Corgi Commons public story from #357 is live, and #359's signed-out pilot/waitlist copy is deployed. Production currently reports exact SHA `2dc550ea6767ee08fcaeaa26b07518e44e3cefe1`. The affected routes are functionally healthy, but every anonymous rendered route still logs a 401 from `/api/governance/auth/session`. This hotfix closes that PI-review smoke-test blocker without weakening authenticated governance or waitlist gates.

## Exact review scope

- Base: `2dc550ea6767ee08fcaeaa26b07518e44e3cefe1`
- Head: `c4d923a8ab57f70e01374abb64d45bb674c0e3ab`
- Changed files: 8

## Validation

- Full production-shaped `npm run verify`: 154 test files, 1,694 tests, backend/CLI/SDK fixtures, legacy web lint/build, and the 25-page web-next static export — pass.
- GitHub implementation checks, security gates, docs verification, and CodeQL — pass on the exact head.
- Focused governance auth regression suite: 4 files, 19 tests — pass.
- Local CodeRabbit light review of the patch before the conflict-free rebase reported no HIGH or MEDIUM findings.
- Governed current-head CodeRabbit review is still pending because the service returned `rate_limited_will_retry`; no exemption is being applied.

Linear: https://linear.app/andrewnord/issue/PROJ-1821/web-align-corgi-commons-cold-start-story-across-public-and-reviewer
