### PR TITLE
PROJ-1951 Embed reviewer video on Corgi website

### DIFF
--- a/src/feed/server.ts
+++ b/src/feed/server.ts
@@ -80,6 +80,7 @@ export async function createServer(options?: CreateServerOptions) {
         defaultSrc: ["'self'"],
         baseUri: ["'self'"],
         frameAncestors: ["'none'"],
+        frameSrc: ["'self'", 'https://www.youtube-nocookie.com'],
         objectSrc: ["'none'"],
         scriptSrc: ["'self'"],
         styleSrc: ["'self'", "'unsafe-inline'"],

--- a/src/feed/static-export-headers.ts
+++ b/src/feed/static-export-headers.ts
@@ -6,6 +6,7 @@ const STATIC_EXPORT_HTML_CSP = [
   "default-src 'self'",
   "base-uri 'self'",
   "frame-ancestors 'none'",
+  "frame-src 'self' https://www.youtube-nocookie.com",
   "object-src 'none'",
   "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",

--- a/tests/static-export-headers.test.ts
+++ b/tests/static-export-headers.test.ts
@@ -12,6 +12,7 @@ import {
 
 const HTML_ACCEPT = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
 const HTML_SCRIPT_POLICY = "script-src 'self' 'unsafe-inline'";
+const HTML_FRAME_POLICY = "frame-src 'self' https://www.youtube-nocookie.com";
 
 const temporaryDirectories: string[] = [];
 
@@ -77,6 +78,7 @@ describe('static-export response headers', () => {
 
       expect(initial.statusCode).toBe(200);
       expect(initial.headers['content-security-policy']).toContain(HTML_SCRIPT_POLICY);
+      expect(initial.headers['content-security-policy']).toContain(HTML_FRAME_POLICY);
       expect(initial.headers['cache-control']).toBe('no-cache');
       expect(initial.headers.etag).toBeTypeOf('string');
 
@@ -91,6 +93,7 @@ describe('static-export response headers', () => {
 
       expect(conditional.statusCode).toBe(304);
       expect(conditional.headers['content-security-policy']).toContain(HTML_SCRIPT_POLICY);
+      expect(conditional.headers['content-security-policy']).toContain(HTML_FRAME_POLICY);
       expect(conditional.headers['cache-control']).toBe('no-cache');
 
       const staticAsset = await app.inject({

--- a/web-next/app/how-it-works/page.tsx
+++ b/web-next/app/how-it-works/page.tsx
@@ -9,9 +9,12 @@ import { PageHero, HeroGlow, HERO_TOP } from "@/components/ui/page-hero"
 export const metadata: Metadata = {
   title: "How Corgi Works - Community-governed Bluesky ranking",
   description:
-    "Replay how the same posts become a different Bluesky feed when a community changes Corgi's ranking policy.",
+    "Watch Corgi's four-minute product walkthrough, then replay how community policy changes the order of a Bluesky feed.",
   alternates: { canonical: "/how-it-works/" },
 }
+
+const DEMO_VIDEO_URL = "https://www.youtube.com/watch?v=b1TTIcc5ykU"
+const DEMO_VIDEO_EMBED_URL = "https://www.youtube-nocookie.com/embed/b1TTIcc5ykU?rel=0"
 
 const surfaceBoundaries = [
   {
@@ -68,6 +71,49 @@ export default function HowItWorksPage() {
             </div>
           </Container>
         </section>
+
+        <Section
+          id="video-overview"
+          width="stage"
+          bordered="y"
+          spacing="default"
+          className="scroll-mt-24 md:scroll-mt-28"
+        >
+          <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-foreground/55">
+                Product walkthrough · 4:14
+              </p>
+              <h2 className="mt-2 font-display text-2xl font-bold tracking-tight text-foreground md:text-3xl">
+                See the complete governance loop.
+              </h2>
+            </div>
+            <a
+              href={DEMO_VIDEO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-fit text-sm font-semibold text-primary underline-offset-4 transition-colors hover:text-primary-dark hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              Watch on YouTube ↗
+            </a>
+          </div>
+
+          <div className="aspect-video overflow-hidden rounded-2xl border border-border/70 bg-card shadow-[0_2px_12px_rgba(46,38,32,0.07)]">
+            <iframe
+              className="h-full w-full border-0"
+              src={DEMO_VIDEO_EMBED_URL}
+              title="Corgi: Community-Governed Ranking for Bluesky"
+              loading="lazy"
+              referrerPolicy="strict-origin-when-cross-origin"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowFullScreen
+            />
+          </div>
+
+          <p className="mt-3 text-sm leading-relaxed text-foreground/55">
+            A concise system overview followed by the reviewer-safe product demo, shown end to end.
+          </p>
+        </Section>
 
         <Section bordered spacing="tight">
           <ol className="grid gap-0 border-y border-border/60 md:grid-cols-2 xl:grid-cols-6">

--- a/web-next/components/hero-section.tsx
+++ b/web-next/components/hero-section.tsx
@@ -1,9 +1,8 @@
 import React from "react"
-import { ChevronDown } from "lucide-react"
+import Link from "next/link"
+import { ChevronDown, Play } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { DemoCTA } from "@/components/landing-ctas"
-
-const CORGI_COMMONS_URL = "https://bsky.app/profile/corgi-network.bsky.social/feed/community-gov"
 
 export function HeroSection() {
   return (
@@ -143,9 +142,10 @@ export function HeroSection() {
       <div className="relative z-10 flex flex-col sm:flex-row items-center gap-3">
         <DemoCTA />
         <Button asChild variant="ghost" className="text-foreground/70 hover:text-foreground px-5 py-3 rounded-full font-medium text-base">
-          <a href={CORGI_COMMONS_URL} target="_blank" rel="noopener noreferrer">
-            Open Corgi Commons &rarr;
-          </a>
+          <Link href="/how-it-works/#video-overview">
+            <Play aria-hidden="true" />
+            Watch 4-minute overview
+          </Link>
         </Button>
       </div>
       {/* Trust line */}

--- a/web-next/e2e/production-hard-refresh.spec.ts
+++ b/web-next/e2e/production-hard-refresh.spec.ts
@@ -25,6 +25,7 @@ const PUBLIC_ROUTES: readonly PublicRoute[] = [
 
 const HTML_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
 const REQUIRED_HTML_SCRIPT_POLICY = "script-src 'self' 'unsafe-inline'"
+const REQUIRED_HTML_FRAME_POLICY = "frame-src 'self' https://www.youtube-nocookie.com"
 const REQUIRED_RATE_LIMIT_HEADROOM = 120
 
 function collectBrowserErrors(page: Page): BrowserErrors {
@@ -76,6 +77,13 @@ async function verifyConditionalHeaders(
       actual: initial.headers()["content-security-policy"] ?? "missing",
     })
   }
+  if (!initial.headers()["content-security-policy"]?.includes(REQUIRED_HTML_FRAME_POLICY)) {
+    failures.push({
+      path: route.path,
+      check: "200 iframe CSP",
+      actual: initial.headers()["content-security-policy"] ?? "missing",
+    })
+  }
 
   if (etag === undefined) {
     failures.push({ path: route.path, check: "ETag", actual: "missing" })
@@ -96,6 +104,13 @@ async function verifyConditionalHeaders(
     failures.push({
       path: route.path,
       check: "304 CSP",
+      actual: conditional.headers()["content-security-policy"] ?? "missing",
+    })
+  }
+  if (!conditional.headers()["content-security-policy"]?.includes(REQUIRED_HTML_FRAME_POLICY)) {
+    failures.push({
+      path: route.path,
+      check: "304 iframe CSP",
       actual: conditional.headers()["content-security-policy"] ?? "missing",
     })
   }


### PR DESCRIPTION
## What changed

- embeds the approved Corgi reviewer video near the top of `/how-it-works/`
- replaces the homepage secondary hero action with “Watch 4-minute overview”
- uses YouTube privacy-enhanced embedding
- allows only `https://www.youtube-nocookie.com` in the production iframe CSP
- extends existing 200/304 CSP regression checks

## Why

The reviewer video is now on YouTube and needs a credible, discoverable home on the public Corgi site without competing with the primary interactive-demo CTA.

## Validation

- `npm run build`
- `./node_modules/.bin/vitest run tests/static-export-headers.test.ts`
- `cd web-next && npm run build`
- `cd web-next && npm run lint`
- desktop and mobile visual QC
- local CodeRabbit pre-push review: no high or medium findings

Linear: PROJ-1951